### PR TITLE
Update Solidity files for HIP-358 (token create through the precompile)

### DIFF
--- a/hts-precompile/ExpiryHelper.sol
+++ b/hts-precompile/ExpiryHelper.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.5.0 <0.9.0;
+pragma experimental ABIEncoderV2;
+
+import "./HederaTokenService.sol";
+import "./FeeHelper.sol";
+
+contract ExpiryHelper is FeeHelper {
+
+    function getAutoRenewExpiry(
+        address autoRenewAccount,
+        uint32 autoRenewPeriod
+    ) internal view returns (IHederaTokenService.Expiry memory expiry) {
+        expiry.autoRenewAccount = autoRenewAccount;
+        expiry.autoRenewPeriod = autoRenewPeriod;
+    }
+
+    function getSecondExpiry(uint32 second) internal view returns (IHederaTokenService.Expiry memory expiry) {
+        expiry.second = second;
+    }
+}

--- a/hts-precompile/FeeHelper.sol
+++ b/hts-precompile/FeeHelper.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.5.0 <0.9.0;
+pragma experimental ABIEncoderV2;
+
+import "./HederaTokenService.sol";
+import "./HederaResponseCodes.sol";
+import "./IHederaTokenService.sol";
+import "./KeyHelper.sol";
+
+contract FeeHelper is KeyHelper {
+
+    function createFixedFeeForHbars(
+        uint32 amount,
+        address feeCollector
+    ) internal pure returns (IHederaTokenService.FixedFee memory fixedFee) {
+        fixedFee.amount = amount;
+        fixedFee.useHbarsForPayment = true;
+        fixedFee.feeCollector = feeCollector;
+    }
+
+    function createFixedFeeForToken(
+        uint32 amount,
+        address tokenId,
+        address feeCollector
+    ) internal pure returns (IHederaTokenService.FixedFee memory fixedFee) {
+        fixedFee.amount = amount;
+        fixedFee.tokenId = tokenId;
+        fixedFee.feeCollector = feeCollector;
+    }
+
+    function createFixedFeeForCurrentToken(
+        uint32 amount,
+        address feeCollector
+    ) internal pure returns (IHederaTokenService.FixedFee memory fixedFee) {
+        fixedFee.amount = amount;
+        fixedFee.useCurrentTokenForPayment = true;
+        fixedFee.feeCollector = feeCollector;
+    }
+
+    function createFractionalFeeWithoutLimits(
+        uint32 numerator,
+        uint32 denominator,
+        bool netOfTransfers,
+        address feeCollector
+    ) internal pure returns (IHederaTokenService.FractionalFee memory fractionalFee) {
+        fractionalFee.numerator = numerator;
+        fractionalFee.denominator = denominator;
+        fractionalFee.netOfTransfers = netOfTransfers;
+        fractionalFee.feeCollector = feeCollector;
+    }
+
+    function createFractionalFeeWithLimits(
+        uint32 numerator,
+        uint32 denominator,
+        uint32 minimumAmount,
+        uint32 maximumAmount,
+        bool netOfTransfers,
+        address feeCollector
+    ) internal pure returns (IHederaTokenService.FractionalFee memory fractionalFee) {
+        fractionalFee.numerator = numerator;
+        fractionalFee.denominator = denominator;
+        fractionalFee.minimumAmount = minimumAmount;
+        fractionalFee.maximumAmount = maximumAmount;
+        fractionalFee.netOfTransfers = netOfTransfers;
+        fractionalFee.feeCollector = feeCollector;
+    }
+
+    function createRoyaltyFeeWithoutFallback(
+        uint32 numerator,
+        uint32 denominator,
+        address feeCollector
+    ) internal pure returns (IHederaTokenService.RoyaltyFee memory royaltyFee) {
+        royaltyFee.numerator = numerator;
+        royaltyFee.denominator = denominator;
+        royaltyFee.feeCollector = feeCollector;
+    }
+
+    function createRoyaltyFeeWithHbarFallbackFee(
+        uint32 numerator,
+        uint32 denominator,
+        uint32 amount,
+        address feeCollector
+    ) internal pure returns (IHederaTokenService.RoyaltyFee memory royaltyFee) {
+        royaltyFee.numerator = numerator;
+        royaltyFee.denominator = denominator;
+        royaltyFee.amount = amount;
+        royaltyFee.useHbarsForPayment = true;
+        royaltyFee.feeCollector = feeCollector;
+    }
+
+    function createRoyaltyFeeWithTokenDenominatedFallbackFee(
+        uint32 numerator,
+        uint32 denominator,
+        uint32 amount,
+        address tokenId,
+        address feeCollector
+    ) internal pure returns (IHederaTokenService.RoyaltyFee memory royaltyFee) {
+        royaltyFee.numerator = numerator;
+        royaltyFee.denominator = denominator;
+        royaltyFee.amount = amount;
+        royaltyFee.tokenId = tokenId;
+        royaltyFee.feeCollector = feeCollector;
+    }
+}

--- a/hts-precompile/HederaTokenService.sol
+++ b/hts-precompile/HederaTokenService.sol
@@ -9,6 +9,14 @@ abstract contract HederaTokenService is HederaResponseCodes {
 
     address constant precompileAddress = address(0x167);
 
+    uint constant ADMIN_KEY_TYPE = 1;
+    uint constant KYC_KEY_TYPE = 2;
+    uint constant FREEZE_KEY_TYPE = 4;
+    uint constant WIPE_KEY_TYPE = 8;
+    uint constant SUPPLY_KEY_TYPE = 16;
+    uint constant FEE_SCHEDULE_KEY_TYPE = 32;
+    uint constant PAUSE_KEY_TYPE = 64;
+
     /// Initiates a Token Transfer
     /// @param tokenTransfers the list of transfers to do
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
@@ -127,6 +135,79 @@ abstract contract HederaTokenService is HederaResponseCodes {
         responseCode = success ? abi.decode(result, (int32)) : HederaResponseCodes.UNKNOWN;
     }
 
+    /// Creates a Fungible Token with the specified properties
+    /// @param token the basic properties of the token being created
+    /// @param initialTotalSupply Specifies the initial supply of tokens to be put in circulation. The
+    /// initial supply is sent to the Treasury Account. The supply is in the lowest denomination possible.
+    /// @param decimals the number of decimal places a token is divisible by
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return tokenAddress the created token's address
+    function createFungibleToken(
+        IHederaTokenService.HederaToken memory token,
+        uint initialTotalSupply,
+        uint decimals)
+    internal returns (int responseCode, address tokenAddress) {
+
+        (bool success, bytes memory result) = precompileAddress.call{value: msg.value}(
+            abi.encodeWithSelector(IHederaTokenService.createFungibleToken.selector,
+            token, initialTotalSupply, decimals));
+
+
+        (responseCode, tokenAddress) = success ? abi.decode(result, (int32, address)) : (HederaResponseCodes.UNKNOWN, address(0));
+    }
+
+    /// Creates a Fungible Token with the specified properties
+    /// @param token the basic properties of the token being created
+    /// @param initialTotalSupply Specifies the initial supply of tokens to be put in circulation. The
+    /// initial supply is sent to the Treasury Account. The supply is in the lowest denomination possible.
+    /// @param decimals the number of decimal places a token is divisible by
+    /// @param fixedFees list of fixed fees to apply to the token
+    /// @param fractionalFees list of fractional fees to apply to the token
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return tokenAddress the created token's address
+    function createFungibleTokenWithCustomFees(
+        IHederaTokenService.HederaToken memory token,
+        uint initialTotalSupply,
+        uint decimals,
+        IHederaTokenService.FixedFee[] memory fixedFees,
+        IHederaTokenService.FractionalFee[] memory fractionalFees)
+    internal returns (int responseCode, address tokenAddress) {
+
+        (bool success, bytes memory result) = precompileAddress.call{value: msg.value}(
+            abi.encodeWithSelector(IHederaTokenService.createFungibleTokenWithCustomFees.selector,
+            token, initialTotalSupply, decimals, fixedFees, fractionalFees));
+        (responseCode, tokenAddress) = success ? abi.decode(result, (int32, address)) : (HederaResponseCodes.UNKNOWN, address(0));
+    }
+
+    /// Creates an Non Fungible Unique Token with the specified properties
+    /// @param token the basic properties of the token being created
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return tokenAddress the created token's address
+    function createNonFungibleToken(IHederaTokenService.HederaToken memory token)
+    internal returns (int responseCode, address tokenAddress) {
+
+        (bool success, bytes memory result) = precompileAddress.call{value: msg.value}(
+            abi.encodeWithSelector(IHederaTokenService.createNonFungibleToken.selector, token));
+        (responseCode, tokenAddress) = success ? abi.decode(result, (int32, address)) : (HederaResponseCodes.UNKNOWN, address(0));
+    }
+
+    /// Creates an Non Fungible Unique Token with the specified properties
+    /// @param token the basic properties of the token being created
+    /// @param fixedFees list of fixed fees to apply to the token
+    /// @param royaltyFees list of royalty fees to apply to the token
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return tokenAddress the created token's address
+    function createNonFungibleTokenWithCustomFees(
+        IHederaTokenService.HederaToken memory token,
+        IHederaTokenService.FixedFee[] memory fixedFees,
+        IHederaTokenService.RoyaltyFee[] memory royaltyFees)
+    internal returns (int responseCode, address tokenAddress) {
+
+        (bool success, bytes memory result) = precompileAddress.call{value: msg.value}(
+            abi.encodeWithSelector(IHederaTokenService.createNonFungibleTokenWithCustomFees.selector,
+            token, fixedFees, royaltyFees));
+        (responseCode, tokenAddress) = success ? abi.decode(result, (int32, address)) : (HederaResponseCodes.UNKNOWN, address(0));
+    }
 
     /**********************
      * ABI v1 calls       *
@@ -190,4 +271,5 @@ abstract contract HederaTokenService is HederaResponseCodes {
             token, sender, receiver, serialNumber));
         responseCode = success ? abi.decode(result, (int32)) : HederaResponseCodes.UNKNOWN;
     }
+
 }

--- a/hts-precompile/IHederaTokenService.sol
+++ b/hts-precompile/IHederaTokenService.sol
@@ -49,6 +49,177 @@ interface IHederaTokenService {
         NftTransfer[] nftTransfers;
     }
 
+    /// Expiry properties of a Hedera token - second, autoRenewAccount, autoRenewPeriod
+    struct Expiry {
+        // The epoch second at which the token should expire; if an auto-renew account and period are
+        // specified, this is coerced to the current epoch second plus the autoRenewPeriod
+        uint32 second;
+
+        // ID of an account which will be automatically charged to renew the token's expiration, at
+        // autoRenewPeriod interval, expressed as a solidity address
+        address autoRenewAccount;
+
+        // The interval at which the auto-renew account will be charged to extend the token's expiry
+        uint32 autoRenewPeriod;
+    }
+
+    /// A Key can be a public key from either the Ed25519 or ECDSA(secp256k1) signature schemes, where
+    /// in the ECDSA(secp256k1) case we require the 33-byte compressed form of the public key. We call
+    /// these public keys <b>primitive keys</b>.
+    /// A Key can also be the ID of a smart contract instance, which is then authorized to perform any
+    /// precompiled contract action that requires this key to sign.
+    /// Note that when a Key is a smart contract ID, it <i>doesn't</i> mean the contract with that ID
+    /// will actually create a cryptographic signature. It only means that when the contract calls a
+    /// precompiled contract, the resulting "child transaction" will be authorized to perform any action
+    /// controlled by the Key.
+    /// Exactly one of the possible values should be populated in order for the Key to be valid.
+    struct KeyValue {
+
+        // if set to true, the key of the calling Hedera account will be inherited as the token key
+        bool inheritAccountKey;
+
+        // smart contract instance that is authorized as if it had signed with a key
+        address contractId;
+
+        // Ed25519 public key bytes
+        bytes ed25519;
+
+        // Compressed ECDSA(secp256k1) public key bytes
+        bytes ECDSA_secp256k1;
+
+        // A smart contract that, if the recipient of the active message frame, should be treated
+        // as having signed. (Note this does not mean the <i>code being executed in the frame</i>
+        // will belong to the given contract, since it could be running another contract's code via
+        // <tt>delegatecall</tt>. So setting this key is a more permissive version of setting the
+        // contractID key, which also requires the code in the active message frame belong to the
+        // the contract with the given id.)
+        address delegatableContractId;
+    }
+
+    /// A list of token key types the key should be applied to and the value of the key
+    struct TokenKey {
+
+        // bit field representing the key type. Keys of all types that have corresponding bits set to 1
+        // will be created for the token.
+        // 0th bit: adminKey
+        // 1st bit: kycKey
+        // 2nd bit: freezeKey
+        // 3rd bit: wipeKey
+        // 4th bit: supplyKey
+        // 5th bit: feeScheduleKey
+        // 6th bit: pauseKey
+        // 7th bit: ignored
+        uint keyType;
+
+        // the value that will be set to the key type
+        KeyValue key;
+    }
+
+    /// Basic properties of a Hedera Token - name, symbol, memo, tokenSupplyType, maxSupply,
+    /// treasury, freezeDefault. These properties are related both to Fungible and NFT token types.
+    struct HederaToken {
+        // The publicly visible name of the token. The token name is specified as a Unicode string.
+        // Its UTF-8 encoding cannot exceed 100 bytes, and cannot contain the 0 byte (NUL).
+        string name;
+
+        // The publicly visible token symbol. The token symbol is specified as a Unicode string.
+        // Its UTF-8 encoding cannot exceed 100 bytes, and cannot contain the 0 byte (NUL).
+        string symbol;
+
+        // The ID of the account which will act as a treasury for the token as a solidity address.
+        // This account will receive the specified initial supply or the newly minted NFTs in
+        // the case for NON_FUNGIBLE_UNIQUE Type
+        address treasury;
+
+        // The memo associated with the token (UTF-8 encoding max 100 bytes)
+        string memo;
+
+        // IWA compatibility. Specified the token supply type. Defaults to INFINITE
+        bool tokenSupplyType;
+
+        // IWA Compatibility. Depends on TokenSupplyType. For tokens of type FUNGIBLE_COMMON - the
+        // maximum number of tokens that can be in circulation. For tokens of type NON_FUNGIBLE_UNIQUE -
+        // the maximum number of NFTs (serial numbers) that can be minted. This field can never be changed!
+        uint32 maxSupply;
+
+        // The default Freeze status (frozen or unfrozen) of Hedera accounts relative to this token. If
+        // true, an account must be unfrozen before it can receive the token
+        bool freezeDefault;
+
+        // list of keys to set to the token
+        TokenKey[] tokenKeys;
+
+        // expiry properties of a Hedera token - second, autoRenewAccount, autoRenewPeriod
+        Expiry expiry;
+    }
+
+    /// A fixed number of units (hbar or token) to assess as a fee during a transfer of
+    /// units of the token to which this fixed fee is attached. The denomination of
+    /// the fee depends on the values of tokenId, useHbarsForPayment and
+    /// useCurrentTokenForPayment. Exactly one of the values should be set.
+    struct FixedFee {
+
+        uint32 amount;
+
+        // Specifies ID of token that should be used for fixed fee denomination
+        address tokenId;
+
+        // Specifies this fixed fee should be denominated in Hbar
+        bool useHbarsForPayment;
+
+        // Specifies this fixed fee should be denominated in the Token currently being created
+        bool useCurrentTokenForPayment;
+
+        // The ID of the account to receive the custom fee, expressed as a solidity address
+        address feeCollector;
+    }
+
+    /// A fraction of the transferred units of a token to assess as a fee. The amount assessed will never
+    /// be less than the given minimumAmount, and never greater than the given maximumAmount.  The
+    /// denomination is always units of the token to which this fractional fee is attached.
+    struct FractionalFee {
+        // A rational number's numerator, used to set the amount of a value transfer to collect as a custom fee
+        uint32 numerator;
+
+        // A rational number's denominator, used to set the amount of a value transfer to collect as a custom fee
+        uint32 denominator;
+
+        // The minimum amount to assess
+        uint32 minimumAmount;
+
+        // The maximum amount to assess (zero implies no maximum)
+        uint32 maximumAmount;
+        bool netOfTransfers;
+
+        // The ID of the account to receive the custom fee, expressed as a solidity address
+        address feeCollector;
+    }
+
+    /// A fee to assess during a transfer that changes ownership of an NFT. Defines the fraction of
+    /// the fungible value exchanged for an NFT that the ledger should collect as a royalty. ("Fungible
+    /// value" includes both ℏ and units of fungible HTS tokens.) When the NFT sender does not receive
+    /// any fungible value, the ledger will assess the fallback fee, if present, to the new NFT owner.
+    /// Royalty fees can only be added to tokens of type type NON_FUNGIBLE_UNIQUE.
+    struct RoyaltyFee {
+        // A fraction's numerator of fungible value exchanged for an NFT to collect as royalty
+        uint32 numerator;
+
+        // A fraction's denominator of fungible value exchanged for an NFT to collect as royalty
+        uint32 denominator;
+
+        // If present, the fee to assess to the NFT receiver when no fungible value
+        // is exchanged with the sender. Consists of:
+        // amount: the amount to charge for the fee
+        // tokenId: Specifies ID of token that should be used for fixed fee denomination
+        // useHbarsForPayment: Specifies this fee should be denominated in Hbar
+        uint32 amount;
+        address tokenId;
+        bool useHbarsForPayment;
+
+        // The ID of the account to receive the custom fee, expressed as a solidity address
+        address feeCollector;
+    }
+
     /**********************
      * Direct HTS Calls   *
      **********************/
@@ -132,6 +303,56 @@ interface IHederaTokenService {
     /// @param account The account to be associated with the provided token
     /// @param token The token to be associated with the provided account
     function dissociateToken(address account, address token) external returns (int responseCode);
+
+    /// Creates a Fungible Token with the specified properties
+    /// @param token the basic properties of the token being created
+    /// @param initialTotalSupply Specifies the initial supply of tokens to be put in circulation. The
+    /// initial supply is sent to the Treasury Account. The supply is in the lowest denomination possible.
+    /// @param decimals the number of decimal places a token is divisible by
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return tokenAddress the created token's address
+    function createFungibleToken(
+        HederaToken memory token,
+        uint initialTotalSupply,
+        uint decimals)
+    external payable returns (int responseCode, address tokenAddress);
+
+    /// Creates a Fungible Token with the specified properties
+    /// @param token the basic properties of the token being created
+    /// @param initialTotalSupply Specifies the initial supply of tokens to be put in circulation. The
+    /// initial supply is sent to the Treasury Account. The supply is in the lowest denomination possible.
+    /// @param decimals the number of decimal places a token is divisible by.
+    /// @param fixedFees list of fixed fees to apply to the token
+    /// @param fractionalFees list of fractional fees to apply to the token
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return tokenAddress the created token's address
+    function createFungibleTokenWithCustomFees(
+        HederaToken memory token,
+        uint initialTotalSupply,
+        uint decimals,
+        FixedFee[] memory fixedFees,
+        FractionalFee[] memory fractionalFees)
+    external payable returns (int responseCode, address tokenAddress);
+
+    /// Creates an Non Fungible Unique Token with the specified properties
+    /// @param token the basic properties of the token being created
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return tokenAddress the created token's address
+    function createNonFungibleToken(HederaToken memory token)
+    external payable returns (int responseCode, address tokenAddress);
+
+    /// Creates an Non Fungible Unique Token with the specified properties
+    /// @param token the basic properties of the token being created
+    /// @param fixedFees list of fixed fees to apply to the token
+    /// @param royaltyFees list of royalty fees to apply to the token
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return tokenAddress the created token's address
+    function createNonFungibleTokenWithCustomFees(
+        HederaToken memory token,
+        FixedFee[] memory fixedFees,
+        RoyaltyFee[] memory royaltyFees)
+    external payable returns (int responseCode, address tokenAddress);
+
 
     /**********************
      * ABIV1 calls        *

--- a/hts-precompile/KeyHelper.sol
+++ b/hts-precompile/KeyHelper.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.5.0 <0.9.0;
+pragma experimental ABIEncoderV2;
+
+import "./HederaTokenService.sol";
+
+contract KeyHelper is HederaTokenService {
+
+    uint constant INHERIT_ACCOUNT_KEY = 1;
+    uint constant CONTRACT_ID_KEY = 2;
+    uint constant ED25519_KEY = 3;
+    uint constant ECDSA_SECPK2561K1_KEY = 4;
+    uint constant DELEGATABLE_CONTRACT_ID_KEY = 5;
+
+    function getSingleKey(
+        uint keyType,
+        uint keyValueType,
+        bytes memory key
+    ) internal view returns (IHederaTokenService.TokenKey memory tokenKey) {
+        tokenKey = IHederaTokenService.TokenKey(keyType, getKeyValueType(keyValueType, key, address(0)));
+    }
+
+    function getSingleKey(
+        uint keyType,
+        uint keyValueType,
+        address key
+    ) internal view returns (IHederaTokenService.TokenKey memory tokenKey) {
+        tokenKey = IHederaTokenService.TokenKey(keyType, getKeyValueType(keyValueType, "", key));
+    }
+
+    function getKeyValueType(
+        uint keyValueType,
+        bytes memory key,
+        address keyAddress
+    ) internal view returns (IHederaTokenService.KeyValue memory keyValue) {
+        if (keyValueType == INHERIT_ACCOUNT_KEY) {
+            keyValue.inheritAccountKey = true;
+        } else if (keyValueType == CONTRACT_ID_KEY) {
+            keyValue.contractId = keyAddress;
+        } else if (keyValueType == ED25519_KEY) {
+            keyValue.ed25519 = key;
+        } else if (keyValueType == ECDSA_SECPK2561K1_KEY) {
+            keyValue.ECDSA_secp256k1 = key;
+        } else if (keyValueType == DELEGATABLE_CONTRACT_ID_KEY) {
+            keyValue.delegatableContractId = keyAddress;
+        }
+    }
+}

--- a/hts-precompile/TokenCreateContract.sol
+++ b/hts-precompile/TokenCreateContract.sol
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.6.0 <0.9.0;
+pragma experimental ABIEncoderV2;
+
+import "./HederaTokenService.sol";
+import "./IHederaTokenService.sol";
+import "./HederaResponseCodes.sol";
+import "./ExpiryHelper.sol";
+
+/// This is a notional example of how the functions in HIP-358 could be used.
+/// It is non-normative.
+contract TokenCreateContract is ExpiryHelper {
+
+    using Bits for uint;
+
+    // create a fungible Token with no custom fees, with calling contract as
+    // admin key, passed ED25519 key as supply and pause key.
+    function createFungible(
+        bytes memory ed25519Key,
+        address autoRenewAccount,
+        uint32 autoRenewPeriod
+    ) external payable returns (address createdTokenAddress) {
+
+        // instantiate the list of keys we'll use for token create
+        IHederaTokenService.TokenKey[] memory keys = new IHederaTokenService.TokenKey[](2);
+
+        // use the helper methods in KeyHelper to create basic keys
+        keys[0] = getSingleKey(HederaTokenService.ADMIN_KEY_TYPE, KeyHelper.INHERIT_ACCOUNT_KEY, "");
+
+        // create TokenKey of types supplyKey and pauseKey with value a contract address passed as function arg
+        uint supplyPauseKeyType;
+        IHederaTokenService.KeyValue memory supplyPauseKeyValue;
+        // turn on bits corresponding to supply and pause key types
+        supplyPauseKeyType = supplyPauseKeyType.setBit(4);
+        supplyPauseKeyType = supplyPauseKeyType.setBit(6);
+        // set the value of the key to the ed25519Key passed as function arg
+        supplyPauseKeyValue.ed25519 = ed25519Key;
+        keys[1] = IHederaTokenService.TokenKey (supplyPauseKeyType, supplyPauseKeyValue);
+
+        IHederaTokenService.HederaToken memory myToken;
+        myToken.name = "MyToken";
+        myToken.symbol = "MTK";
+        myToken.treasury = address(this);
+        myToken.tokenKeys = keys;
+        // create the expiry schedule for the token using ExpiryHelper
+        myToken.expiry = getAutoRenewExpiry(autoRenewAccount, autoRenewPeriod);
+
+        // call HTS precompiled contract, passing 200 as initial supply and 8 as decimals
+        (int responseCode, address token) =
+                HederaTokenService.createFungibleToken(myToken, 200, 8);
+
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert ();
+        }
+
+        createdTokenAddress = token;
+    }
+
+    // create fungible token with custom fees, with an ECDSA key as admin key
+    function createFungibleWithFees(
+        bytes memory ecdsaAdminKey,
+        address treasury,
+        address feeCollector,
+        address existingTokenAddress,
+        address autoRenewAccount,
+        uint32 autoRenewPeriod
+    ) external payable returns (address createdTokenAddress) {
+
+        // create the admin key using KeyHelper method
+        IHederaTokenService.TokenKey[] memory keys = new IHederaTokenService.TokenKey[](1);
+        keys[0] = getSingleKey(HederaTokenService.ADMIN_KEY_TYPE, KeyHelper.ECDSA_SECPK2561K1_KEY, ecdsaAdminKey);
+
+        // declare custom fees
+        IHederaTokenService.FixedFee[] memory fixedFees = new IHederaTokenService.FixedFee[](2);
+        // create a fixed fee with hbar as payment using FeeHelper 
+        fixedFees[0] = createFixedFeeForHbars(5, feeCollector);
+        // create a fixed fee with existing token as payment using FeeHelper 
+        fixedFees[1] = createFixedFeeForToken(5, existingTokenAddress, feeCollector);
+
+        IHederaTokenService.FractionalFee[] memory fractionalFees = new IHederaTokenService.FractionalFee[](1);
+        // create a fractional fee without limits using FeeHelper
+        fractionalFees[0] = createFractionalFeeWithoutLimits(4, 5, true, feeCollector);
+
+        IHederaTokenService.HederaToken memory myToken;
+        myToken.name = "MyToken";
+        myToken.symbol = "MTK";
+        myToken.treasury = treasury;
+        myToken.tokenKeys = keys;
+        // create the expiry schedule for the token using ExpiryHelper
+        myToken.expiry = getAutoRenewExpiry(autoRenewAccount, autoRenewPeriod);
+
+        (int responseCode, address token) =
+                HederaTokenService.createFungibleTokenWithCustomFees(myToken, 200, 8, fixedFees, fractionalFees);
+
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert ();
+        }
+
+        createdTokenAddress = token;
+    }
+
+    // create an NFT without fees with contract as freeze key
+    function createNonFungibleToken(
+        address contractFreezeKey,
+        address autoRenewAccount,
+        uint32 autoRenewPeriod
+    ) external payable returns (address createdTokenAddress) {
+
+        // instantiate the list of keys we'll use for token create
+        IHederaTokenService.TokenKey[] memory keys = new IHederaTokenService.TokenKey[](1);
+        // use the helper methods in KeyHelper to create basic key
+        keys[0] = getSingleKey(HederaTokenService.FREEZE_KEY_TYPE, KeyHelper.CONTRACT_ID_KEY, contractFreezeKey);
+
+        IHederaTokenService.HederaToken memory myToken;
+        myToken.name = "MyNFT";
+        myToken.symbol = "MNFT";
+        myToken.memo = "memo";
+        myToken.treasury = address(this);
+        myToken.tokenSupplyType = true; // make the total supply FINITE
+        myToken.maxSupply = 10;
+        myToken.tokenKeys = keys;
+        myToken.freezeDefault = true;
+        myToken.expiry = getAutoRenewExpiry(autoRenewAccount, autoRenewPeriod);
+
+        (int responseCode, address token) =
+                HederaTokenService.createNonFungibleToken(myToken);
+
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert ();
+        }
+
+        createdTokenAddress = token;
+    }
+
+    // create NFT with royalty fees, contract has the mint and admin key
+    function createNonFungibleTokenWithCustomFees(
+        address contractIdKey,
+        address feeCollectorAndTreasury,
+        address existingTokenAddress,
+        address autoRenewAccount,
+        uint32 autoRenewPeriod
+    ) external payable returns (address createdTokenAddress) {
+
+        // TokenKey of type adminKey and supplyKey with value this contract id
+        uint adminSupplyKeyType;
+        adminSupplyKeyType = adminSupplyKeyType.setBit(0); // turn on bit corresponding to admin key type
+        adminSupplyKeyType = adminSupplyKeyType.setBit(4); // turn on bit corresponding to supply key type
+        IHederaTokenService.KeyValue memory adminSupplyKeyValue;
+        adminSupplyKeyValue.contractId = contractIdKey;
+
+        // instantiate the list of keys we'll use for token create
+        IHederaTokenService.TokenKey[] memory keys = new IHederaTokenService.TokenKey[](1);
+        keys[0] = IHederaTokenService.TokenKey (adminSupplyKeyType, adminSupplyKeyValue);
+
+        // declare fees
+        IHederaTokenService.RoyaltyFee[] memory royaltyFees = new IHederaTokenService.RoyaltyFee[](3);
+        royaltyFees[0] = createRoyaltyFeeWithoutFallback(4, 5, feeCollectorAndTreasury);
+        royaltyFees[1] = createRoyaltyFeeWithHbarFallbackFee(4, 5, 50, feeCollectorAndTreasury);
+        royaltyFees[2] =
+                createRoyaltyFeeWithTokenDenominatedFallbackFee(4, 5, 30, existingTokenAddress, feeCollectorAndTreasury);
+
+        IHederaTokenService.HederaToken memory myToken;
+        myToken.name = "MyNFT";
+        myToken.symbol = "MNFT";
+        myToken.treasury = feeCollectorAndTreasury;
+        myToken.tokenKeys = keys;
+        myToken.expiry = getAutoRenewExpiry(autoRenewAccount, autoRenewPeriod);
+
+        // create the token through HTS with default expiry and royalty fees;
+        (int responseCode, address token) =
+                HederaTokenService.createNonFungibleTokenWithCustomFees(
+                    myToken,
+                    new IHederaTokenService.FixedFee[](0),
+                    royaltyFees
+                );
+
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert ();
+        }
+
+        createdTokenAddress = token;
+    }
+}
+
+library Bits {
+
+    uint constant internal ONE = uint(1);
+
+    // Sets the bit at the given 'index' in 'self' to '1'.
+    // Returns the modified value.
+    function setBit(uint self, uint8 index) internal pure returns (uint) {
+        return self | ONE << index;
+    }
+}


### PR DESCRIPTION
**Description**:
This PR updates the Solidity files `IHederaTokenService.sol` and `HederaTokenService.sol` with the most recent changes from HIP-358. It also adds new Solidity files that may serve as examples for token creation through the precompile contract:
* `KeyHelper.sol`, `FeeHelper.sol` and `ExpiryHelper.sol` contain helper methods 
*  `TokenCreateContract.sol` contains example methods for creating fungible and non-fungible tokens (both without and with fees) using the above mentioned helper contracts
