### PR TITLE
Add Allowance/Approval methods to HTS precompile

### DIFF
--- a/hts-precompile/HederaTokenService.sol
+++ b/hts-precompile/HederaTokenService.sol
@@ -209,6 +209,102 @@ abstract contract HederaTokenService is HederaResponseCodes {
         (responseCode, tokenAddress) = success ? abi.decode(result, (int32, address)) : (HederaResponseCodes.UNKNOWN, address(0));
     }
 
+    /// Allows spender to withdraw from your account multiple times, up to the value amount. If this function is called 
+    /// again it overwrites the current allowance with value.
+    /// Only Applicable to Fungible Tokens
+    /// @param token The hedera token address to approve
+    /// @param spender the account authorized to spend
+    /// @param amount the amount of tokens authorized to spend.
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    function approve(address token, address spender, uint256 amount) internal returns (int responseCode)
+    {
+        (bool success, bytes memory result) = precompileAddress.call(
+            abi.encodeWithSelector(IHederaTokenService.approve.selector,
+            token, spender, amount));
+        responseCode = success ? abi.decode(result, (int32)) : HederaResponseCodes.UNKNOWN;
+    }
+
+
+    /// Returns the amount which spender is still allowed to withdraw from owner.
+    /// Only Applicable to Fungible Tokens
+    /// @param token The Hedera token address to check the allowance of
+    /// @param owner the owner of the tokens to be spent
+    /// @param spender the spender of the tokens
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    function allowance(address token, address owner, address spender) internal returns (int responseCode) 
+    {
+        (bool success, bytes memory result) = precompileAddress.call(
+            abi.encodeWithSelector(IHederaTokenService.allowance.selector,
+            token, owner, spender));
+        responseCode = success ? abi.decode(result, (int32)) : HederaResponseCodes.UNKNOWN;
+    }
+
+    /// Allow or reaffirm the approved address to transfer an NFT the approved address does not own.
+    /// Only Applicable to NFT Tokens
+    /// @param token The Hedera NFT token address to approve
+    /// @param approved The new approved NFT controller.  To revoke approvals pass in the zero address.
+    /// @param serialNumber The NFT serial number  to approve
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    function approveNFT(address token, address approved, uint256 serialNumber) internal returns (int responseCode)
+    {
+        (bool success, bytes memory result) = precompileAddress.call(
+            abi.encodeWithSelector(IHederaTokenService.approveNFT.selector,
+            token, approved, serialNumber));
+        responseCode = success ? abi.decode(result, (int32)) : HederaResponseCodes.UNKNOWN;
+    }
+
+    /// Get the approved address for a single NFT
+    /// Only Applicable to NFT Tokens
+    /// @param token The Hedera NFT token address to check approval
+    /// @param serialNumber The NFT to find the approved address for
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return approved The approved address for this NFT, or the zero address if there is none    
+    function getApproved(address token, uint256 serialNumber) internal returns (int responseCode, address approved)
+    {
+        (bool success, bytes memory result) = precompileAddress.call(
+            abi.encodeWithSelector(IHederaTokenService.getApproved.selector,
+            token, serialNumber));
+        (responseCode, approved) =
+            success
+                ? abi.decode(result, (int32, address))
+                : (HederaResponseCodes.UNKNOWN, address(0));
+    }
+    
+    
+    /// Enable or disable approval for a third party ("operator") to manage
+    ///  all of `msg.sender`'s assets
+    /// @param token The Hedera NFT token address to approve
+    /// @param operator Address to add to the set of authorized operators
+    /// @param approved True if the operator is approved, false to revoke approval
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    function setApprovalForAll(address token, address operator, bool approved) internal returns (int responseCode)
+    {
+        (bool success, bytes memory result) = precompileAddress.call(
+            abi.encodeWithSelector(IHederaTokenService.setApprovalForAll.selector,
+            token, operator, approved));
+        responseCode = success ? abi.decode(result, (int32)) : HederaResponseCodes.UNKNOWN;
+    }
+    
+
+    /// Query if an address is an authorized operator for another address
+    /// Only Applicable to NFT Tokens
+    /// @param token The Hedera NFT token address to approve
+    /// @param owner The address that owns the NFTs
+    /// @param operator The address that acts on behalf of the owner
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return approved True if `operator` is an approved operator for `owner`, false otherwise
+    function isApprovedForAll(address token, address owner, address operator) internal returns (int responseCode, bool approved)
+    {
+        (bool success, bytes memory result) = precompileAddress.call(
+            abi.encodeWithSelector(IHederaTokenService.isApprovedForAll.selector,
+            token, owner, operator));
+        (responseCode, approved) =
+            success
+                ? abi.decode(result, (int32, bool))
+                : (HederaResponseCodes.UNKNOWN, false);
+    }
+    
+
     /**********************
      * ABI v1 calls       *
      **********************/
@@ -272,4 +368,6 @@ abstract contract HederaTokenService is HederaResponseCodes {
         responseCode = success ? abi.decode(result, (int32)) : HederaResponseCodes.UNKNOWN;
     }
 
+    
+    
 }

--- a/hts-precompile/HederaTokenService.sol
+++ b/hts-precompile/HederaTokenService.sol
@@ -224,7 +224,6 @@ abstract contract HederaTokenService is HederaResponseCodes {
         responseCode = success ? abi.decode(result, (int32)) : HederaResponseCodes.UNKNOWN;
     }
 
-
     /// Returns the amount which spender is still allowed to withdraw from owner.
     /// Only Applicable to Fungible Tokens
     /// @param token The Hedera token address to check the allowance of
@@ -303,7 +302,6 @@ abstract contract HederaTokenService is HederaResponseCodes {
                 ? abi.decode(result, (int32, bool))
                 : (HederaResponseCodes.UNKNOWN, false);
     }
-    
 
     /**********************
      * ABI v1 calls       *
@@ -368,6 +366,4 @@ abstract contract HederaTokenService is HederaResponseCodes {
         responseCode = success ? abi.decode(result, (int32)) : HederaResponseCodes.UNKNOWN;
     }
 
-    
-    
 }

--- a/hts-precompile/IHederaTokenService.sol
+++ b/hts-precompile/IHederaTokenService.sol
@@ -397,7 +397,7 @@ interface IHederaTokenService {
     /// again it overwrites the current allowance with value.
     /// Only Applicable to Fungible Tokens
     /// @param token The hedera token address to approve
-    /// @param spender the account authorized to spend
+    /// @param spender the account address authorized to spend
     /// @param amount the amount of tokens authorized to spend.
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     function approve(address token, address spender, uint256 amount) external returns (int responseCode);

--- a/hts-precompile/IHederaTokenService.sol
+++ b/hts-precompile/IHederaTokenService.sol
@@ -392,4 +392,55 @@ interface IHederaTokenService {
     /// @param serialNumber The serial number of the NFT to transfer.
     function transferNFT(address token,  address sender, address recipient, int64 serialNumber) external
         returns (int responseCode);
+
+    /// Allows spender to withdraw from your account multiple times, up to the value amount. If this function is called 
+    /// again it overwrites the current allowance with value.
+    /// Only Applicable to Fungible Tokens
+    /// @param token The hedera token address to approve
+    /// @param spender the account authorized to spend
+    /// @param amount the amount of tokens authorized to spend.
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    function approve(address token, address spender, uint256 amount) external returns (int responseCode);
+
+    /// Returns the amount which spender is still allowed to withdraw from owner.
+    /// Only Applicable to Fungible Tokens
+    /// @param token The Hedera token address to check the allowance of
+    /// @param owner the owner of the tokens to be spent
+    /// @param spender the spender of the tokens
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    function allowance(address token, address owner, address spender) external returns (int responseCode);
+
+    /// Allow or reaffirm the approved address to transfer an NFT the approved address does not own.
+    /// Only Applicable to NFT Tokens
+    /// @param token The Hedera NFT token address to approve
+    /// @param approved The new approved NFT controller.  To revoke approvals pass in the zero address.
+    /// @param serialNumber The NFT serial number  to approve
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    function approveNFT(address token, address approved, uint256 serialNumber) external returns (int responseCode);
+
+    /// Get the approved address for a single NFT
+    /// Only Applicable to NFT Tokens
+    /// @param token The Hedera NFT token address to check approval
+    /// @param serialNumber The NFT to find the approved address for
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return approved The approved address for this NFT, or the zero address if there is none    
+    function getApproved(address token, uint256 serialNumber) external returns (int responseCode, address approved);
+
+    /// Enable or disable approval for a third party ("operator") to manage
+    ///  all of `msg.sender`'s assets
+    /// @param token The Hedera NFT token address to approve
+    /// @param operator Address to add to the set of authorized operators
+    /// @param approved True if the operator is approved, false to revoke approval
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    function setApprovalForAll(address token, address operator, bool approved) external returns (int responseCode);
+
+    /// Query if an address is an authorized operator for another address
+    /// Only Applicable to NFT Tokens
+    /// @param token The Hedera NFT token address to approve
+    /// @param owner The address that owns the NFTs
+    /// @param operator The address that acts on behalf of the owner
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return approved True if `operator` is an approved operator for `owner`, false otherwise
+    function isApprovedForAll(address token, address owner, address operator)  external returns (int responseCode, bool approved);
+    
 }


### PR DESCRIPTION
**Description**:
Add the missing Allowance/Approval methods that can be accessed via
the ERC-20 proxy that is not available in the HTS precompile.


**Related issue(s)**:

Fixes #6

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
