### PR TITLE
Add `Prng`Util Precompiles

### DIFF
--- a/util-precompile/IPrngSystemContract.sol
+++ b/util-precompile/IPrngSystemContract.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.4.9 <0.9.0;
+
+interface IPrngSystemContract {
+    // Generates a 256-bit pseudorandom seed using the first 256-bits of running hash of n-3 transaction record.
+    // Users can generate a pseudorandom number in a specified range using the seed by (integer value of seed % range)
+    function getPseudorandomSeed() external returns (bytes32);
+}

--- a/util-precompile/PrngSystemContract.sol
+++ b/util-precompile/PrngSystemContract.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import "./IPrngSystemContract.sol";
+
+contract PrngSystemContract {
+    address constant PRECOMPILE_ADDRESS = address(0x169);
+
+    function getPseudorandomSeed() external returns (bytes32 randomBytes) {
+        (bool success, bytes memory result) = PRECOMPILE_ADDRESS.call(
+            abi.encodeWithSelector(IPrngSystemContract.getPseudorandomSeed.selector));
+        require(success);
+        randomBytes = abi.decode(result, (bytes32));
+    }
+}

--- a/util-precompile/PrngSystemContract.sol
+++ b/util-precompile/PrngSystemContract.sol
@@ -5,10 +5,10 @@ import "./IPrngSystemContract.sol";
 contract PrngSystemContract {
     address constant PRECOMPILE_ADDRESS = address(0x169);
 
-    function getPseudorandomSeed() external returns (bytes32 randomBytes) {
+    function getPseudorandomSeed() external returns (bytes32 seedBytes) {
         (bool success, bytes memory result) = PRECOMPILE_ADDRESS.call(
             abi.encodeWithSelector(IPrngSystemContract.getPseudorandomSeed.selector));
-        require(success);
+        require(success, "PRNG system call failed");
         randomBytes = abi.decode(result, (bytes32));
     }
 }

--- a/util-precompile/PrngSystemContract.sol
+++ b/util-precompile/PrngSystemContract.sol
@@ -9,6 +9,6 @@ contract PrngSystemContract {
         (bool success, bytes memory result) = PRECOMPILE_ADDRESS.call(
             abi.encodeWithSelector(IPrngSystemContract.getPseudorandomSeed.selector));
         require(success, "PRNG system call failed");
-        randomBytes = abi.decode(result, (bytes32));
+        seedBytes = abi.decode(result, (bytes32));
     }
 }


### PR DESCRIPTION
Signed-off-by: Neeharika-Sompalli <neeharika.sompalli@hedera.com>

**Description**:
As per the [HIP-351](https://hips.hedera.com/hip/hip-351) , added `Prng` Precompiles in the name `IPrngSystemContract.sol` and `PrngSystemContract.sol`

**Related issue(s)**:

Fixes #31 