### PR TITLE
Add `ExchangeRatePrecompile` system precompiles

### DIFF
--- a/exchange-rate-precompile/ExchangeRatePrecompile.sol
+++ b/exchange-rate-precompile/ExchangeRatePrecompile.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import "./SelfFunding.sol";
+
+contract ExchangeRatePrecompile is SelfFunding {
+    // The USD in cents that must be sent as msg.value
+    uint256 toll;
+
+    constructor(uint256 _toll) {
+        toll = _toll;
+    }
+
+    function gatedAccess() external payable costsCents(toll) {
+        // Hope it was worth it!
+    }
+
+    function approxUsdValue() external payable returns (uint256 tinycents) {
+        tinycents = tinybarsToTinycents(msg.value);
+    }
+
+    function invalidCall() external payable {
+        // Should fail, this is not a valid selector 
+        (bool success, bytes memory result) = PRECOMPILE_ADDRESS.call(
+            abi.encodeWithSelector(ExchangeRatePrecompile.approxUsdValue.selector));
+        require(success);
+    }
+}

--- a/exchange-rate-precompile/ExchangeRatePrecompile.sol
+++ b/exchange-rate-precompile/ExchangeRatePrecompile.sol
@@ -2,9 +2,12 @@
 
 import "./SelfFunding.sol";
 
+
 contract ExchangeRatePrecompile is SelfFunding {
     // The USD in cents that must be sent as msg.value
     uint256 toll;
+    // ExchangeRate system contract address
+    address constant PRECOMPILE_ADDRESS = address(0x168);
 
     constructor(uint256 _toll) {
         toll = _toll;

--- a/exchange-rate-precompile/ExchangeRatePrecompile.sol
+++ b/exchange-rate-precompile/ExchangeRatePrecompile.sol
@@ -6,7 +6,7 @@ import "./SelfFunding.sol";
 contract ExchangeRatePrecompile is SelfFunding {
     // The USD in cents that must be sent as msg.value
     uint256 toll;
-    // ExchangeRate system contract address
+    // ExchangeRate system contract address with ContractID 0.0.360
     address constant PRECOMPILE_ADDRESS = address(0x168);
 
     constructor(uint256 _toll) {

--- a/exchange-rate-precompile/IExchangeRate.sol
+++ b/exchange-rate-precompile/IExchangeRate.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.4.9 <0.9.0;
+
+interface IExchangeRate {
+    // Given a value in tinycents (1e-8 US cents or 1e-10 USD), returns the 
+    // equivalent value in tinybars (1e-8 HBAR) at the current exchange rate 
+    // stored in system file 0.0.112. 
+    // 
+    // This rate is a weighted median of the the recent" HBAR-USD exchange 
+    // rate on major exchanges, but should _not_ be treated as a live price 
+    // oracle! It is important primarily because the network will use it to 
+    // compute the tinybar fees for the active transaction. 
+    // 
+    // So a "self-funding" contract can use this rate to compute how much 
+    // tinybar its users must send to cover the Hedera fees for the transaction.
+    function tinycentsToTinybars(uint256 tinycents) external returns (uint256);
+
+    // Given a value in tinybars (1e-8 HBAR), returns the equivalent value in 
+    // tinycents (1e-8 US cents or 1e-10 USD) at the current exchange rate 
+    // stored in system file 0.0.112. 
+    // 
+    // This rate tracks the the HBAR-USD rate on public exchanges, but 
+    // should _not_ be treated as a live price oracle! This conversion is
+    // less likely to be needed than the above conversion from tinycent to
+    // tinybars, but we include it for completeness.
+    function tinybarsToTinycents(uint256 tinybars) external returns (uint256);
+}

--- a/exchange-rate-precompile/SelfFunding.sol
+++ b/exchange-rate-precompile/SelfFunding.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.5.0 <0.9.0;
+
+import "./IExchangeRate.sol";
+
+abstract contract SelfFunding {
+    uint256 constant TINY_PARTS_PER_WHOLE = 100_000_000;
+    address constant PRECOMPILE_ADDRESS = address(0x168);
+
+    function tinycentsToTinybars(uint256 tinycents) internal returns (uint256 tinybars) {
+        (bool success, bytes memory result) = PRECOMPILE_ADDRESS.call(
+            abi.encodeWithSelector(IExchangeRate.tinycentsToTinybars.selector, tinycents));
+        require(success);
+        tinybars = abi.decode(result, (uint256));
+    }
+
+    function tinybarsToTinycents(uint256 tinybars) internal returns (uint256 tinycents) {
+        (bool success, bytes memory result) = PRECOMPILE_ADDRESS.call(
+            abi.encodeWithSelector(IExchangeRate.tinybarsToTinycents.selector, tinybars));
+        require(success);
+        tinycents = abi.decode(result, (uint256));
+    }
+
+    modifier costsCents(uint256 cents) {
+        uint256 tinycents = cents * TINY_PARTS_PER_WHOLE;
+        uint256 requiredTinybars = tinycentsToTinybars(tinycents);
+        require(msg.value >= requiredTinybars);
+        _;
+    } 
+}

--- a/util-precompile/PrngSystemContract.sol
+++ b/util-precompile/PrngSystemContract.sol
@@ -3,6 +3,7 @@
 import "./IPrngSystemContract.sol";
 
 contract PrngSystemContract {
+    // Prng system contract address
     address constant PRECOMPILE_ADDRESS = address(0x169);
 
     function getPseudorandomSeed() external returns (bytes32 seedBytes) {

--- a/util-precompile/PrngSystemContract.sol
+++ b/util-precompile/PrngSystemContract.sol
@@ -3,7 +3,7 @@
 import "./IPrngSystemContract.sol";
 
 contract PrngSystemContract {
-    // Prng system contract address
+    // Prng system contract address with ContractID 0.0.361
     address constant PRECOMPILE_ADDRESS = address(0x169);
 
     function getPseudorandomSeed() external returns (bytes32 seedBytes) {


### PR DESCRIPTION
Signed-off-by: Neeharika-Sompalli <neeharika.sompalli@hedera.com>

Fixes #45 

**Description**:
As per [HIP-475](https://hips.hedera.com/hip/hip-475) Adds `ExchangeRatePrecompile.sol`, `SelfFunding.sol`, and `IExchangeRate.sol` system precompiles