### PR TITLE
Cleanup hts-precompile

### DIFF
--- a/contracts/hts-precompile/ExpiryHelper.sol
+++ b/contracts/hts-precompile/ExpiryHelper.sol
@@ -2,20 +2,19 @@
 pragma solidity >=0.5.0 <0.9.0;
 pragma experimental ABIEncoderV2;
 
-import "./HederaTokenService.sol";
-import "./FeeHelper.sol";
+import "./IHederaTokenService.sol";
 
-contract ExpiryHelper is FeeHelper {
+abstract contract ExpiryHelper {
 
     function createAutoRenewExpiry(
         address autoRenewAccount,
         uint32 autoRenewPeriod
-    ) internal view returns (IHederaTokenService.Expiry memory expiry) {
+    ) internal pure returns (IHederaTokenService.Expiry memory expiry) {
         expiry.autoRenewAccount = autoRenewAccount;
         expiry.autoRenewPeriod = autoRenewPeriod;
     }
 
-    function createSecondExpiry(uint32 second) internal view returns (IHederaTokenService.Expiry memory expiry) {
+    function createSecondExpiry(uint32 second) internal pure returns (IHederaTokenService.Expiry memory expiry) {
         expiry.second = second;
     }
 }

--- a/contracts/hts-precompile/FeeHelper.sol
+++ b/contracts/hts-precompile/FeeHelper.sol
@@ -2,12 +2,9 @@
 pragma solidity >=0.5.0 <0.9.0;
 pragma experimental ABIEncoderV2;
 
-import "./HederaTokenService.sol";
-import "./HederaResponseCodes.sol";
 import "./IHederaTokenService.sol";
-import "./KeyHelper.sol";
 
-abstract contract FeeHelper is KeyHelper {
+abstract contract FeeHelper {
     function createFixedHbarFee(uint32 amount, address feeCollector)
         internal
         pure

--- a/contracts/hts-precompile/HederaResponseCodes.sol
+++ b/contracts/hts-precompile/HederaResponseCodes.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.4.9 <0.9.0;
 
-abstract contract HederaResponseCodes {
+library HederaResponseCodes {
 
     // response codes
     int32 internal constant OK = 0; // The transaction passed the precheck validations.

--- a/contracts/hts-precompile/HederaTokenService.sol
+++ b/contracts/hts-precompile/HederaTokenService.sol
@@ -2,10 +2,10 @@
 pragma solidity >=0.5.0 <0.9.0;
 pragma experimental ABIEncoderV2;
 
-import "./HederaResponseCodes.sol";
 import "./IHederaTokenService.sol";
+import "./HederaResponseCodes.sol";
 
-abstract contract HederaTokenService is HederaResponseCodes {
+abstract contract HederaTokenService {
     address constant precompileAddress = address(0x167);
     // 90 days in seconds
     uint32 constant defaultAutoRenewPeriod = 7776000;

--- a/contracts/hts-precompile/KeyHelper.sol
+++ b/contracts/hts-precompile/KeyHelper.sol
@@ -2,9 +2,9 @@
 pragma solidity >=0.5.0 <0.9.0;
 pragma experimental ABIEncoderV2;
 
-import './HederaTokenService.sol';
+import "./IHederaTokenService.sol";
 
-abstract contract KeyHelper is HederaTokenService {
+abstract contract KeyHelper {
     using Bits for uint256;
     address supplyContract;
 

--- a/contracts/hts-precompile/TokenCreate.sol
+++ b/contracts/hts-precompile/TokenCreate.sol
@@ -2,9 +2,11 @@
 pragma solidity >=0.5.0 <0.9.0;
 pragma experimental ABIEncoderV2;
 
-import "./FeeHelper.sol";
+import "./HederaTokenService.sol";
+import "./ExpiryHelper.sol";
+import "./KeyHelper.sol";
 
-abstract contract TokenCreate is FeeHelper {
+abstract contract TokenCreate is HederaTokenService, ExpiryHelper, KeyHelper {
 
     string name = "tokenName";
     string symbol = "tokenSymbol";


### PR DESCRIPTION
Clean up dependencies of hts-precompile modules to reduce unnecessary coupling and fix some warnings about visibility modifiers.

**Description**:
The PR modifies the ht-precompile contracts to:
* Reduce coupling between helpers
* Changes HederaResponseCodes to a library
* Makes all hts-precompile contracts abstract
* Changes the visibility of FeeHelper to pure to silence compiler warnings.

**Related issue(s)**:
None

**Notes for reviewer**:
There are some broken unit tests in the IERC20 directory that are broken, so this change probably won't pass CI.

**Checklist**

- [n/a] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
