### PR TITLE
Critical HTS functions marked external

### DIFF
--- a/contracts/hts-precompile/HederaTokenService.sol
+++ b/contracts/hts-precompile/HederaTokenService.sol
@@ -436,7 +436,7 @@ abstract contract HederaTokenService {
     /// @param account The account address associated with the token
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return kycGranted True if `account` has kyc granted for `token`
-    function isKyc(address token, address account) external returns (int64 responseCode, bool kycGranted){
+    function isKyc(address token, address account) internal returns (int64 responseCode, bool kycGranted){
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.isKyc.selector, token, account));
         (responseCode, kycGranted) = success ? abi.decode(result, (int32, bool)) : (HederaResponseCodes.UNKNOWN, false);
@@ -466,7 +466,7 @@ abstract contract HederaTokenService {
     /// @param token The token address
     /// @param account The account address to grant kyc
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
-    function grantTokenKyc(address token, address account) external returns (int64 responseCode){
+    function grantTokenKyc(address token, address account) internal returns (int64 responseCode){
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.grantTokenKyc.selector, token, account));
         (responseCode) = success ? abi.decode(result, (int32)) : HederaResponseCodes.UNKNOWN;
@@ -476,7 +476,7 @@ abstract contract HederaTokenService {
     /// @param token The token address
     /// @param account The account address to revoke kyc
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
-    function revokeTokenKyc(address token, address account) external returns (int64 responseCode){
+    function revokeTokenKyc(address token, address account) internal returns (int64 responseCode){
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.revokeTokenKyc.selector, token, account));
         (responseCode) = success ? abi.decode(result, (int32)) : HederaResponseCodes.UNKNOWN;
@@ -614,7 +614,7 @@ abstract contract HederaTokenService {
     /// Operation to pause token
     /// @param token The token address to be paused
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
-    function pauseToken(address token) external returns (int responseCode)
+    function pauseToken(address token) internal returns (int responseCode)
     {
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.pauseToken.selector, token));
@@ -624,7 +624,7 @@ abstract contract HederaTokenService {
     /// Operation to unpause token
     /// @param token The token address to be unpaused
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
-    function unpauseToken(address token) external returns (int responseCode)
+    function unpauseToken(address token) internal returns (int responseCode)
     {
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.unpauseToken.selector, token));
@@ -715,7 +715,7 @@ abstract contract HederaTokenService {
     /// @param token The token address
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return expiryInfo The expiry info of the token
-    function getTokenExpiryInfo(address token) external returns (int responseCode, IHederaTokenService.Expiry memory expiryInfo){
+    function getTokenExpiryInfo(address token) internal returns (int responseCode, IHederaTokenService.Expiry memory expiryInfo){
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.getTokenExpiryInfo.selector, token));
         IHederaTokenService.Expiry memory defaultExpiryInfo;
@@ -725,7 +725,7 @@ abstract contract HederaTokenService {
     /// Operation to update token expiry info
     /// @param token The token address
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
-    function updateTokenExpiryInfo(address token, IHederaTokenService.Expiry memory expiryInfo) external returns (int responseCode){
+    function updateTokenExpiryInfo(address token, IHederaTokenService.Expiry memory expiryInfo) internal returns (int responseCode){
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.updateTokenExpiryInfo.selector, token, expiryInfo));
         (responseCode) = success ? abi.decode(result, (int32)) : HederaResponseCodes.UNKNOWN;
@@ -735,7 +735,7 @@ abstract contract HederaTokenService {
     /// @param token The token address
     /// @param tokenInfo The hedera token info to update token with
     /// @return responseCode The response code for the status of the request. SUCCESS is 22.
-    function updateTokenInfo(address token, IHederaTokenService.HederaToken memory tokenInfo) external returns (int responseCode) {
+    function updateTokenInfo(address token, IHederaTokenService.HederaToken memory tokenInfo) internal returns (int responseCode) {
         (bool success, bytes memory result) = precompileAddress.call(
             abi.encodeWithSelector(IHederaTokenService.updateTokenInfo.selector, token, tokenInfo));
         (responseCode) = success ? abi.decode(result, (int32)) : HederaResponseCodes.UNKNOWN;

--- a/contracts/hts-precompile/examples/token-create/TokenCreateContract.sol
+++ b/contracts/hts-precompile/examples/token-create/TokenCreateContract.sol
@@ -175,7 +175,7 @@ contract TokenCreateContract is HederaTokenService, ExpiryHelper, KeyHelper {
     }
 
     function grantTokenKycPublic(address token, address account) external returns (int64 responseCode) {
-        (responseCode) = this.grantTokenKyc(token, account);
+        (responseCode) = HederaTokenService.grantTokenKyc(token, account);
         emit ResponseCode(responseCode);
 
         if (responseCode != HederaResponseCodes.SUCCESS) {

--- a/contracts/hts-precompile/examples/token-manage/TokenManagementContract.sol
+++ b/contracts/hts-precompile/examples/token-manage/TokenManagementContract.sol
@@ -40,7 +40,7 @@ contract TokenManagementContract is HederaTokenService, ExpiryHelper, KeyHelper 
     }
 
     function revokeTokenKycPublic(address token, address account) external returns (int64 responseCode) {
-        (responseCode) = this.revokeTokenKyc(token, account);
+        (responseCode) = HederaTokenService.revokeTokenKyc(token, account);
         emit ResponseCode(responseCode);
 
         if (responseCode != HederaResponseCodes.SUCCESS) {
@@ -49,7 +49,7 @@ contract TokenManagementContract is HederaTokenService, ExpiryHelper, KeyHelper 
     }
 
     function pauseTokenPublic(address token) public returns (int responseCode) {
-        responseCode = this.pauseToken(token);
+        responseCode = HederaTokenService.pauseToken(token);
         emit ResponseCode(responseCode);
 
         if (responseCode != HederaResponseCodes.SUCCESS) {
@@ -60,7 +60,7 @@ contract TokenManagementContract is HederaTokenService, ExpiryHelper, KeyHelper 
     }
 
     function unpauseTokenPublic(address token) public returns (int responseCode) {
-        responseCode = this.unpauseToken(token);
+        responseCode = HederaTokenService.unpauseToken(token);
         emit ResponseCode(responseCode);
 
         if (responseCode != HederaResponseCodes.SUCCESS) {
@@ -89,7 +89,7 @@ contract TokenManagementContract is HederaTokenService, ExpiryHelper, KeyHelper 
     }
 
     function updateTokenInfoPublic(address token, IHederaTokenService.HederaToken memory tokenInfo)external returns (int responseCode) {
-        (responseCode) = this.updateTokenInfo(token, tokenInfo);
+        (responseCode) = HederaTokenService.updateTokenInfo(token, tokenInfo);
         emit ResponseCode(responseCode);
 
         if(responseCode != HederaResponseCodes.SUCCESS) {
@@ -98,7 +98,7 @@ contract TokenManagementContract is HederaTokenService, ExpiryHelper, KeyHelper 
     }
 
     function updateTokenExpiryInfoPublic(address token, IHederaTokenService.Expiry memory expiryInfo)external returns (int responseCode) {
-        (responseCode) = this.updateTokenExpiryInfo(token, expiryInfo);
+        (responseCode) = HederaTokenService.updateTokenExpiryInfo(token, expiryInfo);
         emit ResponseCode(responseCode);
 
         if(responseCode != HederaResponseCodes.SUCCESS) {

--- a/contracts/hts-precompile/examples/token-query/TokenQueryContract.sol
+++ b/contracts/hts-precompile/examples/token-query/TokenQueryContract.sol
@@ -69,7 +69,7 @@ contract TokenQueryContract is HederaTokenService, ExpiryHelper, KeyHelper {
     }
 
     function isKycPublic(address token, address account) external returns (int64 responseCode, bool kycGranted) {
-        (responseCode, kycGranted) = this.isKyc(token, account);
+        (responseCode, kycGranted) = HederaTokenService.isKyc(token, account);
         emit ResponseCode(responseCode);
 
         if (responseCode != HederaResponseCodes.SUCCESS) {
@@ -118,7 +118,7 @@ contract TokenQueryContract is HederaTokenService, ExpiryHelper, KeyHelper {
     }
 
     function getTokenExpiryInfoPublic(address token)external returns (int responseCode, IHederaTokenService.Expiry memory expiryInfo) {
-        (responseCode, expiryInfo) = this.getTokenExpiryInfo(token);
+        (responseCode, expiryInfo) = HederaTokenService.getTokenExpiryInfo(token);
         emit ResponseCode(responseCode);
 
         if(responseCode != HederaResponseCodes.SUCCESS) {

--- a/test/hts-precompile/erc-721/ERC721Contract.js
+++ b/test/hts-precompile/erc-721/ERC721Contract.js
@@ -25,7 +25,7 @@ describe("ERC721Contract tests", function () {
     secondWallet = signers[1];
 
     await tokenCreateContract.associateTokenPublic(erc721Contract.address, tokenAddress, {gasLimit: 1_000_000});
-    await tokenCreateContract.grantTokenKyc(tokenAddress, erc721Contract.address);
+    await tokenCreateContract.grantTokenKycPublic(tokenAddress, erc721Contract.address);
     await tokenTransferContract.transferNFTPublic(tokenAddress, tokenCreateContract.address, signers[0].address, mintedTokenSerialNumber, {gasLimit: 1_000_000});
     nftInitialOwnerAddress = signers[0].address;
   });

--- a/test/hts-precompile/utils.js
+++ b/test/hts-precompile/utils.js
@@ -1,117 +1,191 @@
-const {ethers} = require("hardhat");
-const {expect} = require("chai");
+const { ethers } = require("hardhat");
+const { expect } = require("chai");
 
 class Utils {
   //createTokenCost is cost for creating the token, which is passed to the precompile. This is equivalent of 10 and 20hbars, any excess hbars are refunded.
-  static createTokenCost = '10000000000000000000';
-  static createTokenCustomFeesCost = '20000000000000000000';
+  static createTokenCost = "10000000000000000000";
+  static createTokenCustomFeesCost = "20000000000000000000";
 
   static async deployTokenCreateContract() {
-    const tokenCreateFactory = await ethers.getContractFactory("TokenCreateContract");
-    const tokenCreate = await tokenCreateFactory.deploy({gasLimit: 1_000_000});
+    const tokenCreateFactory = await ethers.getContractFactory(
+      "TokenCreateContract"
+    );
+    const tokenCreate = await tokenCreateFactory.deploy({
+      gasLimit: 1_000_000,
+    });
     const tokenCreateReceipt = await tokenCreate.deployTransaction.wait();
 
-    return await ethers.getContractAt('TokenCreateContract', tokenCreateReceipt.contractAddress);
+    return await ethers.getContractAt(
+      "TokenCreateContract",
+      tokenCreateReceipt.contractAddress
+    );
   }
 
   static async deployTokenManagementContract() {
-    const tokenManagementFactory = await ethers.getContractFactory("TokenManagementContract");
-    const tokenManagement = await tokenManagementFactory.deploy({gasLimit: 1_000_000});
-    const tokenManagementReceipt = await tokenManagement.deployTransaction.wait();
+    const tokenManagementFactory = await ethers.getContractFactory(
+      "TokenManagementContract"
+    );
+    const tokenManagement = await tokenManagementFactory.deploy({
+      gasLimit: 1_000_000,
+    });
+    const tokenManagementReceipt =
+      await tokenManagement.deployTransaction.wait();
 
-    return await ethers.getContractAt('TokenManagementContract', tokenManagementReceipt.contractAddress);
+    return await ethers.getContractAt(
+      "TokenManagementContract",
+      tokenManagementReceipt.contractAddress
+    );
   }
 
   static async deployTokenQueryContract() {
-    const tokenQueryFactory = await ethers.getContractFactory("TokenQueryContract");
-    const tokenQuery = await tokenQueryFactory.deploy({gasLimit: 1_000_000});
+    const tokenQueryFactory = await ethers.getContractFactory(
+      "TokenQueryContract"
+    );
+    const tokenQuery = await tokenQueryFactory.deploy({ gasLimit: 1_000_000 });
     const tokenQueryReceipt = await tokenQuery.deployTransaction.wait();
 
-    return await ethers.getContractAt('TokenQueryContract', tokenQueryReceipt.contractAddress);
+    return await ethers.getContractAt(
+      "TokenQueryContract",
+      tokenQueryReceipt.contractAddress
+    );
   }
 
   static async deployTokenTransferContract() {
-    const tokenTransferFactory = await ethers.getContractFactory("TokenTransferContract");
-    const tokenTransfer = await tokenTransferFactory.deploy({gasLimit: 1_000_000});
+    const tokenTransferFactory = await ethers.getContractFactory(
+      "TokenTransferContract"
+    );
+    const tokenTransfer = await tokenTransferFactory.deploy({
+      gasLimit: 1_000_000,
+    });
     const tokenTransferReceipt = await tokenTransfer.deployTransaction.wait();
 
-    return await ethers.getContractAt('TokenTransferContract', tokenTransferReceipt.contractAddress);
+    return await ethers.getContractAt(
+      "TokenTransferContract",
+      tokenTransferReceipt.contractAddress
+    );
   }
-  
+
   static async deployERC20Contract() {
-    const erc20ContractFactory = await ethers.getContractFactory("ERC20Contract");
-    const erc20Contract = await erc20ContractFactory.deploy({gasLimit: 1_000_000});
+    const erc20ContractFactory = await ethers.getContractFactory(
+      "ERC20Contract"
+    );
+    const erc20Contract = await erc20ContractFactory.deploy({
+      gasLimit: 1_000_000,
+    });
     const erc20ContractReceipt = await erc20Contract.deployTransaction.wait();
 
-    return await ethers.getContractAt('ERC20Contract', erc20ContractReceipt.contractAddress);
+    return await ethers.getContractAt(
+      "ERC20Contract",
+      erc20ContractReceipt.contractAddress
+    );
   }
 
   static async deployERC721Contract() {
-    const erc721ContractFactory = await ethers.getContractFactory("ERC721Contract");
-    const erc721Contract = await erc721ContractFactory.deploy({gasLimit: 1_000_000});
+    const erc721ContractFactory = await ethers.getContractFactory(
+      "ERC721Contract"
+    );
+    const erc721Contract = await erc721ContractFactory.deploy({
+      gasLimit: 1_000_000,
+    });
     const erc721ContractReceipt = await erc721Contract.deployTransaction.wait();
 
-    return await ethers.getContractAt('ERC721Contract', erc721ContractReceipt.contractAddress);
+    return await ethers.getContractAt(
+      "ERC721Contract",
+      erc721ContractReceipt.contractAddress
+    );
   }
 
   static async createFungibleToken(contract) {
-    const tokenAddressTx = await contract.createFungibleTokenPublic(contract.address, {
-      value: ethers.BigNumber.from(this.createTokenCost),
-      gasLimit: 1_000_000
-    });
+    const tokenAddressTx = await contract.createFungibleTokenPublic(
+      contract.address,
+      {
+        value: ethers.BigNumber.from(this.createTokenCost),
+        gasLimit: 1_000_000,
+      }
+    );
     const tokenAddressReceipt = await tokenAddressTx.wait();
-    const {tokenAddress} = tokenAddressReceipt.events.filter(e => e.event === 'CreatedToken')[0].args;
+    const { tokenAddress } = tokenAddressReceipt.events.filter(
+      (e) => e.event === "CreatedToken"
+    )[0].args;
 
     return tokenAddress;
   }
 
   static async createFungibleTokenWithCustomFees(contract, feeTokenAddress) {
-    const tokenAddressTx = await contract.createFungibleTokenWithCustomFeesPublic(contract.address, feeTokenAddress, {
-      value: ethers.BigNumber.from(this.createTokenCustomFeesCost),
-      gasLimit: 10_000_000
-    });
+    const tokenAddressTx =
+      await contract.createFungibleTokenWithCustomFeesPublic(
+        contract.address,
+        feeTokenAddress,
+        {
+          value: ethers.BigNumber.from(this.createTokenCustomFeesCost),
+          gasLimit: 10_000_000,
+        }
+      );
     const tokenAddressReceipt = await tokenAddressTx.wait();
-    const {tokenAddress} = tokenAddressReceipt.events.filter(e => e.event === 'CreatedToken')[0].args;
+    const { tokenAddress } = tokenAddressReceipt.events.filter(
+      (e) => e.event === "CreatedToken"
+    )[0].args;
 
     return tokenAddress;
   }
 
   static async createNonFungibleToken(contract) {
-    const tokenAddressTx = await contract.createNonFungibleTokenPublic(contract.address, {
-      value: ethers.BigNumber.from(this.createTokenCost),
-      gasLimit: 1_000_000
-    });
+    const tokenAddressTx = await contract.createNonFungibleTokenPublic(
+      contract.address,
+      {
+        value: ethers.BigNumber.from(this.createTokenCost),
+        gasLimit: 1_000_000,
+      }
+    );
     const tokenAddressReceipt = await tokenAddressTx.wait();
-    const {tokenAddress} = tokenAddressReceipt.events.filter(e => e.event === 'CreatedToken')[0].args;
+    const { tokenAddress } = tokenAddressReceipt.events.filter(
+      (e) => e.event === "CreatedToken"
+    )[0].args;
 
     return tokenAddress;
   }
 
   static async mintNFT(contract, nftTokenAddress, data = ["0x01"]) {
     const mintNftTx = await contract.mintTokenPublic(nftTokenAddress, 0, data, {
-      gasLimit: 1_000_000
+      gasLimit: 1_000_000,
     });
     const tokenAddressReceipt = await mintNftTx.wait();
-    const {serialNumbers} = tokenAddressReceipt.events.filter(e => e.event === 'MintedToken')[0].args;
+    const { serialNumbers } = tokenAddressReceipt.events.filter(
+      (e) => e.event === "MintedToken"
+    )[0].args;
 
     return parseInt(serialNumbers);
   }
 
   static async associateToken(contract, tokenAddress, contractName) {
     const signers = await ethers.getSigners();
-    const associateTx1 = await ethers.getContractAt(contractName, contract.address, signers[0]);
-    const associateTx2 = await ethers.getContractAt(contractName, contract.address, signers[1]);
+    const associateTx1 = await ethers.getContractAt(
+      contractName,
+      contract.address,
+      signers[0]
+    );
+    const associateTx2 = await ethers.getContractAt(
+      contractName,
+      contract.address,
+      signers[1]
+    );
 
-    await contract.associateTokenPublic(contract.address, tokenAddress, {gasLimit: 1_000_000});
-    await associateTx1.associateTokenPublic(signers[0].address, tokenAddress, {gasLimit: 1_000_000});
-    await associateTx2.associateTokenPublic(signers[1].address, tokenAddress, {gasLimit: 1_000_000});
+    await contract.associateTokenPublic(contract.address, tokenAddress, {
+      gasLimit: 1_000_000,
+    });
+    await associateTx1.associateTokenPublic(signers[0].address, tokenAddress, {
+      gasLimit: 1_000_000,
+    });
+    await associateTx2.associateTokenPublic(signers[1].address, tokenAddress, {
+      gasLimit: 1_000_000,
+    });
   }
 
   static async grantTokenKyc(contract, tokenAddress) {
     const signers = await ethers.getSigners();
-    await contract.grantTokenKyc(tokenAddress, contract.address);
-    await contract.grantTokenKyc(tokenAddress, signers[0].address);
-    await contract.grantTokenKyc(tokenAddress, signers[1].address);
+    await contract.grantTokenKycPublic(tokenAddress, contract.address);
+    await contract.grantTokenKycPublic(tokenAddress, signers[0].address);
+    await contract.grantTokenKycPublic(tokenAddress, signers[1].address);
   }
 
   static async expectToFail(transaction, code) {
@@ -119,8 +193,7 @@ class Utils {
       const result = await transaction;
       const receipt = await result.wait();
       expect(true).to.eq(false);
-    }
-    catch(e) {
+    } catch (e) {
       expect(e).to.exist;
       expect(e.code).to.eq(code);
     }


### PR DESCRIPTION
Signed-off-by: georgi-l95 <glazarov95@gmail.com>

**Description**:
Changed functions perform critical operations that change token state. If they are left external, it would allow anyone to cause very serious issues if the inheriting contract has the ADMIN, KYC, or PAUSE keys for Hedera token[s].

In your tutorials, devs are suggested to inherit these HTS contracts. If they decide to make the inheriting contract have the admin key to allow it to change the token's certain properties behind restricted functions, anyone can bypass the restrictions via the inherited HTS contract, and hijack the token. Or if they make the inheriting contract have the pause key and make it algorithmically manage the pause state of the token, anyone can bypass such algorithm and DOS the token. Given the expected usage of these contracts, and the severity of the impact, this is a high risk issue.

**Related issue(s)**:

Fixes #93 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
