### PR TITLE
Tests to show system HTS contract transferFrom does not work without approval

### DIFF
--- a/test/hts-precompile/token-transfer/tokenTransferContract.js
+++ b/test/hts-precompile/token-transfer/tokenTransferContract.js
@@ -35,6 +35,28 @@ describe("TokenTransferContract tests", function () {
     signers = await ethers.getSigners();
   });
 
+  it("should NOT be able to use transferFrom on fungible tokens without approval", async function () {
+    const amount = 1;
+    try {
+      const txApprove = await tokenTransferContract.transferFromPublic(tokenAddress, signers[0].address, signers[1].address, amount, {gasLimit: 1_000_000});
+      await txApprove.wait();
+    } catch(e) {
+      expect(e).to.exist;
+      expect(e.reason).to.eq('transaction failed');
+    }
+  });
+
+  it("should NOT be able to use transferFrom on NFT tokens without approval", async function () {
+    const amount = 1;
+    try {
+      const txApprove = await tokenTransferContract.transferFromNFTPublic(nftTokenAddress, signers[0].address, signers[1].address, amount, {gasLimit: 1_000_000});
+      await txApprove.wait();
+    } catch(e) {
+      expect(e).to.exist;
+      expect(e.reason).to.eq('transaction failed');
+    }
+  });
+
   it('should be able to execute transferTokens', async function () {
     const amount = 33;
     const signers = await ethers.getSigners();
@@ -342,4 +364,5 @@ describe("TokenTransferContract tests", function () {
     expect(nftOwnerBefore).to.equal(signers[0].address);
     expect(nftOwnerAfter).to.equal(signers[1].address);
   });
+
 });

--- a/test/hts-precompile/token-transfer/tokenTransferContract.js
+++ b/test/hts-precompile/token-transfer/tokenTransferContract.js
@@ -46,10 +46,9 @@ describe("TokenTransferContract tests", function () {
     }
   });
 
-  it("should NOT be able to use transferFrom on NFT tokens without approval", async function () {
-    const amount = 1;
+  it("should NOT be able to use transferFrom on NFT tokens without approval", async function () {    const amount = 1;
     try {
-      const txApprove = await tokenTransferContract.transferFromNFTPublic(nftTokenAddress, signers[0].address, signers[1].address, amount, {gasLimit: 1_000_000});
+      const txApprove = await tokenTransferContract.transferFromNFTPublic(nftTokenAddress, signers[0].address, signers[1].address, mintedTokenSerialNumber, {gasLimit: 1_000_000});
       await txApprove.wait();
     } catch(e) {
       expect(e).to.exist;

--- a/test/hts-precompile/token-transfer/tokenTransferContract.js
+++ b/test/hts-precompile/token-transfer/tokenTransferContract.js
@@ -1,5 +1,6 @@
 const {expect} = require("chai");
 const {ethers} = require("hardhat");
+const { expectToFail } = require("../utils");
 const utils = require('../utils');
 
 describe("TokenTransferContract tests", function () {
@@ -38,8 +39,9 @@ describe("TokenTransferContract tests", function () {
   it("should NOT be able to use transferFrom on fungible tokens without approval", async function () {
     const amount = 1;
     try {
-      const txApprove = await tokenTransferContract.transferFromPublic(tokenAddress, signers[0].address, signers[1].address, amount, {gasLimit: 1_000_000});
-      await txApprove.wait();
+      const txTransfer = await tokenTransferContract.transferFromPublic(tokenAddress, signers[0].address, signers[1].address, amount, {gasLimit: 1_000_000});
+      await txTransfer.wait();
+      expect.fail();
     } catch(e) {
       expect(e).to.exist;
       expect(e.reason).to.eq('transaction failed');
@@ -48,8 +50,9 @@ describe("TokenTransferContract tests", function () {
 
   it("should NOT be able to use transferFrom on NFT tokens without approval", async function () {    const amount = 1;
     try {
-      const txApprove = await tokenTransferContract.transferFromNFTPublic(nftTokenAddress, signers[0].address, signers[1].address, mintedTokenSerialNumber, {gasLimit: 1_000_000});
-      await txApprove.wait();
+      const txTransfer = await tokenTransferContract.transferFromNFTPublic(nftTokenAddress, signers[0].address, signers[1].address, mintedTokenSerialNumber, {gasLimit: 1_000_000});
+      await txTransfer.wait();
+      expect.fail();
     } catch(e) {
       expect(e).to.exist;
       expect(e.reason).to.eq('transaction failed');


### PR DESCRIPTION
Signed-off-by: lukelee-sl <luke.lee@swirldslabs.com>

**Description**:
Write tests to show that the transferFrom function does not allow the caller to transfer fungible or non-fungible tokens without approval.

**Related issue(s)**:

Fixes #133 

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
