### PR TITLE
Added a warning about using the correct version of the interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Hedera Smart Contracts
 Reference library for Smart Contracts utilized by the Hedera network with supporting files and examples.
 
+Please checkout `v0.2.0` if you want to use the interface currently implemented in the Mainnet.
+
 ## Overview
 The Hedera network utilizes system contracts at a reserved contract address on the EVM to surface HAPI service functionality through EVM processed transactions.
 These system contracts are precompiled smart contracts whose function selectors are mapped to defined network logic.


### PR DESCRIPTION
**Description**:

Added a warning about using the correct version of the interface.

**Related issue(s)**:

N/A

**Notes for reviewer**:

The current implementation in the `main` branch is very different from that in production. It is crucial developers use the correct interface; this is why I set the note at the beginning of the page.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
