### PR TITLE
fix: unblocked compile command from requiring env variables be set (#293)

### DIFF
--- a/utils/constants.js
+++ b/utils/constants.js
@@ -1,13 +1,23 @@
 require('dotenv').config()
+const { ethers } = require('ethers')
 
 /**  @type string */
 const OPERATOR_ID_A = process.env.OPERATOR_ID_A
+  ? process.env.OPERATOR_ID_A
+  : '0.0.0'
 /**  @type string */
 const OPERATOR_KEY_A = process.env.OPERATOR_KEY_A
+  ? process.env.OPERATOR_KEY_A
+  : ethers.constants.HashZero
 /**  @type string */
 const HEX_PRIVATE_KEY_A = process.env.HEX_PRIVATE_KEY_A
+  ? process.env.HEX_PRIVATE_KEY_A
+  : ethers.constants.HashZero
 /**  @type string */
 const HEX_PRIVATE_KEY_B = process.env.HEX_PRIVATE_KEY_B
+  ? process.env.HEX_PRIVATE_KEY_B
+  : ethers.constants.HashZero
+
 const NETWORKS = {
   local: {
     name: 'local',


### PR DESCRIPTION
**Description**: This PR fixed the bug where the compile command from Hardhat is blocked by requiring Hedera operator keys be set

Fixes #293 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
