### PR TITLE
feat: Added new deploySmartContract() API, reworked getHederaNativeIDFromEVMaddress API logic, reworked HEDERA_SMART_CONTRACTS_ASSETS constant logic(#303)

### DIFF
--- a/system-contract-dapp-playground/__tests__/hedera/index.test.ts
+++ b/system-contract-dapp-playground/__tests__/hedera/index.test.ts
@@ -1,0 +1,87 @@
+/*-
+ *
+ * Hedera Smart Contracts
+ *
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { ContractFactory } from 'ethers';
+import { deploySmartContract } from '@/api/hedera';
+import { HederaSmartContractResult } from '@/types/interfaces';
+import { HEDERA_SMART_CONTRACTS_ASSETS } from '@/utils/constants';
+
+// Mock ethers
+jest.mock('ethers', () => {
+  const actualEthers = jest.requireActual('ethers');
+  return {
+    ...actualEthers,
+    ContractFactory: jest.fn(),
+  };
+});
+
+// Mock the getWalletProvider function
+jest.mock('../../src/api/wallet', () => {
+  const actualModule = jest.requireActual('../../src/api/wallet');
+
+  return {
+    ...actualModule,
+    getWalletProvider: jest.fn().mockImplementation(() => ({
+      err: null,
+      walletProvider: { getSigner: jest.fn() },
+    })),
+  };
+});
+
+describe('deploySmartContract', () => {
+  beforeEach(() => {
+    (ContractFactory as unknown as jest.Mock).mockClear();
+  });
+
+  it('should deploy the smart contract', async () => {
+    // prepare states
+    const deployParams = [100];
+    const contractAddr = '0x8f18eCFeC4dB88ACe84dD1c8d11eBFeDd9274324';
+    const contractABI = HEDERA_SMART_CONTRACTS_ASSETS.EXCHANGE_RATE.contractABI;
+    const contractBytecode = HEDERA_SMART_CONTRACTS_ASSETS.EXCHANGE_RATE.contractBytecode;
+
+    // mock contractDeployTx
+    const mockContractDeployTx = {
+      getAddress: jest.fn().mockResolvedValue(contractAddr),
+    };
+
+    // mock contract
+    const mockContract = {
+      deploy: jest.fn().mockResolvedValue(mockContractDeployTx),
+    };
+
+    // mock contract factory
+    (ContractFactory as unknown as jest.Mock).mockImplementation(() => mockContract);
+
+    // execute deploySmartContract API
+    const result: HederaSmartContractResult = await deploySmartContract(
+      contractABI,
+      contractBytecode,
+      deployParams
+    );
+
+    // validation
+    expect(result.err).toBeNull;
+    expect(deploySmartContract).toBeCalled;
+    expect(result.contractAddress).toEqual(contractAddr);
+    expect(mockContractDeployTx.getAddress).toHaveBeenCalled();
+    expect(mockContract.deploy).toHaveBeenCalledWith(...deployParams, { gasLimit: 4_000_000 });
+  });
+});

--- a/system-contract-dapp-playground/src/api/hedera/index.ts
+++ b/system-contract-dapp-playground/src/api/hedera/index.ts
@@ -1,0 +1,74 @@
+/*-
+ *
+ * Hedera Smart Contracts
+ *
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { ContractFactory } from 'ethers';
+import { getWalletProvider } from '../wallet';
+import { ContractABI, HederaSmartContractResult } from '@/types/interfaces';
+
+/**
+ * @dev deploys smart contract to Hedera network
+ *
+ * @params contractABI: ContractABI
+ *
+ * @params contractBytecode: string
+ *
+ * @return Promise<HederaSmartContractResult>
+ *
+ * @resource https://github.com/ed-marquez/hedera-example-metamask-counter-dapp/blob/master/src/components/hedera/contractDeploy.js
+ */
+export const deploySmartContract = async (
+  contractABI: ContractABI[],
+  contractBytecode: string,
+  params: any[]
+): Promise<HederaSmartContractResult> => {
+  // get wallet provider
+  const walletProvider = getWalletProvider();
+  if (walletProvider.err || !walletProvider.walletProvider) {
+    return { err: walletProvider.err };
+  }
+
+  // get signer
+  const walletSigner = await walletProvider.walletProvider.getSigner();
+
+  // Deploy smart contract
+  try {
+    // prepare gaslimit
+    const gasLimit = 4_000_000;
+
+    // get contract from contract factory
+    const contract = new ContractFactory(
+      JSON.stringify(contractABI),
+      contractBytecode,
+      walletSigner
+    );
+
+    // execute deploy transaction
+    const contractDeployTx = await contract.deploy(...params, {
+      gasLimit,
+    });
+
+    // get contractAddress
+    const contractAddress = await contractDeployTx.getAddress();
+    return { contractAddress };
+  } catch (err) {
+    console.error(err);
+    return { err };
+  }
+};

--- a/system-contract-dapp-playground/src/api/mirror-node/index.ts
+++ b/system-contract-dapp-playground/src/api/mirror-node/index.ts
@@ -31,16 +31,21 @@ import { MirrorNodeResult, NetworkName } from '@/types/interfaces';
  *
  * @returns string
  */
-export const getAcocuntIdFromEvmAddress = async (
+export const getHederaNativeIDFromEvmAddress = async (
   evmAddress: string,
-  network: NetworkName
+  network: NetworkName,
+  params: 'accounts' | 'contracts'
 ): Promise<MirrorNodeResult> => {
   try {
     const accountInfo = await axios.get(
-      `${HEDERA_NETWORKS[network].mirrorNodeUrl}/accounts/${evmAddress}`
+      `${HEDERA_NETWORKS[network].mirrorNodeUrl}/${params}/${evmAddress}`
     );
 
-    return { accountId: accountInfo.data.account };
+    if (params === 'accounts') {
+      return { accountId: accountInfo.data.account };
+    } else {
+      return { contractId: accountInfo.data.contract_id };
+    }
   } catch (err) {
     console.error(err);
     return { err };

--- a/system-contract-dapp-playground/src/components/wallet-popup/index.tsx
+++ b/system-contract-dapp-playground/src/components/wallet-popup/index.tsx
@@ -27,7 +27,7 @@ import { HASHSCAN_BASE_URL } from '@/utils/constants';
 import { BiCopy, BiCheckDouble } from 'react-icons/bi';
 import { SkeletonText, useToast } from '@chakra-ui/react';
 import { getBalance, getWalletProvider } from '@/api/wallet';
-import { getAcocuntIdFromEvmAddress } from '@/api/mirror-node';
+import { getHederaNativeIDFromEvmAddress } from '@/api/mirror-node';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { CommonErrorToast, NoWalletToast } from '../toast/CommonToast';
 import { BsChevronDown, BsFillQuestionOctagonFill } from 'react-icons/bs';
@@ -78,9 +78,10 @@ const WalletPopup = ({ isOpen, setIsOpen, userAddress, network }: PageProps) => 
       setAccountBalance(`${Number(ethers.formatEther(balance)).toFixed(4)} ℏ`);
 
       // handle getting Hedera native accountId from EvmAddress
-      const { accountId, err: getAccountIdErr } = await getAcocuntIdFromEvmAddress(
+      const { accountId, err: getAccountIdErr } = await getHederaNativeIDFromEvmAddress(
         userAddress,
-        network
+        network,
+        'accounts'
       );
       // handle error
       if (getAccountIdErr || !accountId) {

--- a/system-contract-dapp-playground/src/sections/hts-hip-206/index.tsx
+++ b/system-contract-dapp-playground/src/sections/hts-hip-206/index.tsx
@@ -93,7 +93,7 @@ const HTS206Section = () => {
 
         {/* Contracts */}
         <ol className="px-6 flex flex-col gap-9">
-          {HEDERA_SMART_CONTRACTS_ASSETS.slice(0, 4).map((contract, index) => (
+          {HEDERA_SMART_CONTRACTS_ASSETS.HTS_PRECOMPILED.map((contract, index) => (
             <li key={contract.name} className="flex flex-col gap-3 w-full">
               {/* title */}
               <div className="flex gap-1 items-center text-[20px]">
@@ -109,7 +109,6 @@ const HTS206Section = () => {
                   </Link>
                 </Tooltip>
               </div>
-
             </li>
           ))}
         </ol>

--- a/system-contract-dapp-playground/src/types/interfaces.d.ts
+++ b/system-contract-dapp-playground/src/types/interfaces.d.ts
@@ -55,6 +55,19 @@ interface MirrorNodeResult {
   accountId?: string;
   err?: any;
 }
+
+/**
+ * @dev an interface for the results returned back from interacting with Hedera smart contracts
+ *
+ * @params contractAddress?: string
+ *
+ * @params err: any
+ */
+interface HederaSmartContractResult {
+  contractAddress?: string;
+  err?: any;
+}
+
 /**
  * @dev a type for solidity contract ABI
  */

--- a/system-contract-dapp-playground/src/types/interfaces.d.ts
+++ b/system-contract-dapp-playground/src/types/interfaces.d.ts
@@ -53,6 +53,7 @@ type NetworkName = 'mainnet' | 'testnet' | 'previewnet' | 'localnet';
  */
 interface MirrorNodeResult {
   accountId?: string;
+  contractId?: string;
   err?: any;
 }
 

--- a/system-contract-dapp-playground/src/utils/constants.ts
+++ b/system-contract-dapp-playground/src/utils/constants.ts
@@ -18,13 +18,12 @@
  *
  */
 
-import { HederaContractAsset } from '@/types/interfaces';
 import ERC20Mock from '@hashgraph-smartcontract/artifacts/contracts/erc-20/ERC20Mock.sol/ERC20Mock.json';
 import ERC721Mock from '@hashgraph-smartcontract/artifacts/contracts/erc-721/ERC721Mock.sol/ERC721Mock.json';
-import SelfFunding from '@hashgraph-smartcontract/artifacts/contracts/exchange-rate-precompile/SelfFunding.sol/SelfFunding.json';
 import HRCContract from '@hashgraph-smartcontract/artifacts/contracts/hts-precompile/examples/hrc/HRCContract.sol/HRCContract.json';
 import PrngSystemContract from '@hashgraph-smartcontract/artifacts/contracts/util-precompile/PrngSystemContract.sol/PrngSystemContract.json';
 import TokenQueryContract from '@hashgraph-smartcontract/artifacts/contracts/hts-precompile/examples/token-query/TokenQueryContract.sol/TokenQueryContract.json';
+import ExchangeRatePrecompile from '@hashgraph-smartcontract/artifacts/contracts/exchange-rate-precompile/ExchangeRatePrecompile.sol/ExchangeRatePrecompile.json';
 import TokenTransferContract from '@hashgraph-smartcontract/artifacts/contracts/hts-precompile/examples/token-transfer/TokenTransferContract.sol/TokenTransferContract.json';
 import TokenManagementContract from '@hashgraph-smartcontract/artifacts/contracts/hts-precompile/examples/token-manage/TokenManagementContract.sol/TokenManagementContract.json';
 import TokenCreateCustomContract from '@hashgraph-smartcontract/artifacts/contracts/hts-precompile/examples/token-create/TokenCreateCustom.sol/TokenCreateCustomContract.json';
@@ -176,68 +175,70 @@ export const LEFT_SIDE_BAR_ITEMS = [
 /**
  * @notice information about Hedera Smart Contract assets
  */
-export const HEDERA_SMART_CONTRACTS_ASSETS: HederaContractAsset[] = [
-  {
-    name: 'TokenCreateCustomContract',
-    title: 'Token Create Contract',
-    contractABI: TokenCreateCustomContract.abi,
-    contractBytecode: TokenCreateCustomContract.bytecode,
-    githubUrl: `${HEDERA_SMART_CONTRACT_OFFICIAL_GITHUB_URL}/blob/main/contracts/hts-precompile/examples/token-create/TokenCreateCustom.sol`,
-  },
-  {
-    name: 'TokenManagementContract',
-    title: 'Token Management Contract',
-    contractABI: TokenManagementContract.abi,
-    contractBytecode: TokenManagementContract.bytecode,
-    githubUrl: `${HEDERA_SMART_CONTRACT_OFFICIAL_GITHUB_URL}/blob/main/contracts/hts-precompile/examples/token-manage/TokenManagementContract.sol`,
-  },
-  {
-    name: 'TokenQueryContract',
-    title: 'Token Query Contract',
-    contractABI: TokenQueryContract.abi,
-    contractBytecode: TokenQueryContract.bytecode,
-    githubUrl: `${HEDERA_SMART_CONTRACT_OFFICIAL_GITHUB_URL}/blob/main/contracts/hts-precompile/examples/token-query/TokenQueryContract.sol`,
-  },
-  {
-    name: 'TokenTransferContract',
-    title: 'Token Transfer Contract',
-    contractABI: TokenTransferContract.abi,
-    contractBytecode: TokenTransferContract.bytecode,
-    githubUrl: `${HEDERA_SMART_CONTRACT_OFFICIAL_GITHUB_URL}/blob/main/contracts/hts-precompile/examples/token-transfer/TokenTransferContract.sol`,
-  },
-  {
+export const HEDERA_SMART_CONTRACTS_ASSETS = {
+  HTS_PRECOMPILED: [
+    {
+      name: 'TokenCreateCustomContract',
+      title: 'Token Create Contract',
+      contractABI: TokenCreateCustomContract.abi,
+      contractBytecode: TokenCreateCustomContract.bytecode,
+      githubUrl: `${HEDERA_SMART_CONTRACT_OFFICIAL_GITHUB_URL}/blob/main/contracts/hts-precompile/examples/token-create/TokenCreateCustom.sol`,
+    },
+    {
+      name: 'TokenManagementContract',
+      title: 'Token Management Contract',
+      contractABI: TokenManagementContract.abi,
+      contractBytecode: TokenManagementContract.bytecode,
+      githubUrl: `${HEDERA_SMART_CONTRACT_OFFICIAL_GITHUB_URL}/blob/main/contracts/hts-precompile/examples/token-manage/TokenManagementContract.sol`,
+    },
+    {
+      name: 'TokenQueryContract',
+      title: 'Token Query Contract',
+      contractABI: TokenQueryContract.abi,
+      contractBytecode: TokenQueryContract.bytecode,
+      githubUrl: `${HEDERA_SMART_CONTRACT_OFFICIAL_GITHUB_URL}/blob/main/contracts/hts-precompile/examples/token-query/TokenQueryContract.sol`,
+    },
+    {
+      name: 'TokenTransferContract',
+      title: 'Token Transfer Contract',
+      contractABI: TokenTransferContract.abi,
+      contractBytecode: TokenTransferContract.bytecode,
+      githubUrl: `${HEDERA_SMART_CONTRACT_OFFICIAL_GITHUB_URL}/blob/main/contracts/hts-precompile/examples/token-transfer/TokenTransferContract.sol`,
+    },
+  ],
+  TOKEN_ASSOCIATION: {
     name: 'HRCContract',
     title: 'Token Associate Example Contract',
     contractABI: HRCContract.abi,
     contractBytecode: HRCContract.bytecode,
     githubUrl: `${HEDERA_SMART_CONTRACT_OFFICIAL_GITHUB_URL}/blob/main/contracts/hts-precompile/examples/hrc/HRCContract.sol`,
   },
-  {
-    name: 'SelfFunding',
+  EXCHANGE_RATE: {
+    name: 'ExchangeRatePrecompile',
     title: 'Exchange Rate Example Contract',
-    contractABI: SelfFunding.abi,
-    contractBytecode: SelfFunding.bytecode,
-    githubUrl: `${HEDERA_SMART_CONTRACT_OFFICIAL_GITHUB_URL}/blob/main/contracts/exchange-rate-precompile/SelfFunding.sol`,
+    contractABI: ExchangeRatePrecompile.abi,
+    contractBytecode: ExchangeRatePrecompile.bytecode,
+    githubUrl: `${HEDERA_SMART_CONTRACT_OFFICIAL_GITHUB_URL}/blob/main/contracts/exchange-rate-precompile/ExchangeRatePrecompile.sol`,
   },
-  {
+  PRNG_PRECOMPILED: {
     name: 'PrngSystemContract',
     title: 'Pseudo Random Number Example Contract',
     contractABI: PrngSystemContract.abi,
     contractBytecode: PrngSystemContract.bytecode,
     githubUrl: `${HEDERA_SMART_CONTRACT_OFFICIAL_GITHUB_URL}/blob/main/contracts/util-precompile/PrngSystemContract.sol`,
   },
-  {
+  ERC_20: {
     name: 'ERC20Mock',
     title: 'ERC-20 Example Contract',
     contractABI: ERC20Mock.abi,
     contractBytecode: ERC20Mock.bytecode,
     githubUrl: `${HEDERA_SMART_CONTRACT_OFFICIAL_GITHUB_URL}/blob/main/contracts/hts-precompile/examples/erc-20/ERC20Contract.sol`,
   },
-  {
+  ERC_721: {
     name: 'ERC721Mock',
     title: 'ERC=721 Example Contract',
     contractABI: ERC721Mock.abi,
     contractBytecode: ERC721Mock.bytecode,
     githubUrl: `${HEDERA_SMART_CONTRACT_OFFICIAL_GITHUB_URL}/blob/main/contracts/hts-precompile/examples/erc-721/ERC721Contract.sol`,
   },
-];
+};


### PR DESCRIPTION
**Description**: This PR adds new PR and reworked API logics

- New deploySmartContract() API
- getHederaNativeIDFromEVMaddress() can now dynamically querying both accountId and contractId
- HEDERA_SMART_CONTRACTS_ASSETS constant is now an object instead of array


**Related issue(s)**: #279

Fixes #303 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
