### PR TITLE
fixed: fixed contract types for contract interaction logic (#330)

### DIFF
--- a/system-contract-dapp-playground/__tests__/ethers/index.test.ts
+++ b/system-contract-dapp-playground/__tests__/ethers/index.test.ts
@@ -1,0 +1,71 @@
+/*-
+ *
+ * Hedera Smart Contracts
+ *
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { Contract, ethers } from 'ethers';
+import { HEDERA_SMART_CONTRACTS_ASSETS } from '@/utils/constants';
+
+// Mock the provider and signer
+const mockProvider = {
+  getSigner: jest.fn(),
+};
+
+const mockSigner = {
+  getAddress: jest.fn(),
+};
+
+// Mock the ethers.Contract constructor
+jest.mock('ethers', () => {
+  const actualEthers = jest.requireActual('ethers');
+  return {
+    ...actualEthers,
+    Contract: jest.fn().mockImplementation(() => ({
+      name: jest.fn().mockResolvedValue('Hedera'),
+    })),
+  };
+});
+
+describe('Contract tests', () => {
+  beforeEach(() => {
+    (Contract as jest.Mock).mockClear();
+  });
+
+  it('should create an instance of ethers.Contract and interact with deployed contract', async () => {
+    const contractAddress = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
+    const contractABI = HEDERA_SMART_CONTRACTS_ASSETS.ERC_20.contractABI;
+
+    const contract = new Contract(contractAddress, contractABI);
+    const name = await contract.name();
+
+    expect(name).toBe('Hedera');
+  });
+
+  it('should not create an instance of ethers.ContractFactory to interact with deployed contract', async () => {
+    const contractABI = HEDERA_SMART_CONTRACTS_ASSETS.ERC_20.contractABI;
+    const contractBytecode = HEDERA_SMART_CONTRACTS_ASSETS.ERC_20.contractBytecode;
+
+    const factory = new ethers.ContractFactory(contractABI, contractBytecode);
+
+    try {
+      await (factory as any).name();
+    } catch (error: any) {
+      expect(error.toString()).toBe('TypeError: factory.name is not a function');
+    }
+  });
+});

--- a/system-contract-dapp-playground/__tests__/ethers/index.test.ts
+++ b/system-contract-dapp-playground/__tests__/ethers/index.test.ts
@@ -21,15 +21,6 @@
 import { Contract, ethers } from 'ethers';
 import { HEDERA_SMART_CONTRACTS_ASSETS } from '@/utils/constants';
 
-// Mock the provider and signer
-const mockProvider = {
-  getSigner: jest.fn(),
-};
-
-const mockSigner = {
-  getAddress: jest.fn(),
-};
-
 // Mock the ethers.Contract constructor
 jest.mock('ethers', () => {
   const actualEthers = jest.requireActual('ethers');

--- a/system-contract-dapp-playground/src/api/ethers/index.ts
+++ b/system-contract-dapp-playground/src/api/ethers/index.ts
@@ -21,10 +21,9 @@
 import { ethers } from 'ethers';
 import { getWalletProvider } from '../wallet';
 import { ContractABI, EthersResult } from '@/types/interfaces';
-import { ERC20MockMethod } from '@/components/contract-interaction/erc/utils/methodInterfaces';
 
 /**
- * @dev generate a new BaseContract instance at contractAddress
+ * @dev generate a new ethers.Contract instance at contractAddress
  *
  * @param contractAddress: string
  *
@@ -46,8 +45,8 @@ export const generateBaseContractInstance = async (
     // get signer
     const walletSigner = await walletProvider.walletProvider.getSigner();
 
-    // generate a new BaseContract instance
-    const baseContract = new ethers.BaseContract(
+    // generate a new ethers.Contract instance
+    const baseContract = new ethers.Contract(
       contractAddress,
       JSON.stringify(contractABI),
       walletSigner

--- a/system-contract-dapp-playground/src/api/ethers/index.ts
+++ b/system-contract-dapp-playground/src/api/ethers/index.ts
@@ -18,22 +18,23 @@
  *
  */
 
-import { ContractFactory } from 'ethers';
+import { ethers } from 'ethers';
 import { getWalletProvider } from '../wallet';
 import { ContractABI, EthersResult } from '@/types/interfaces';
+import { ERC20MockMethod } from '@/components/contract-interaction/erc/utils/methodInterfaces';
 
 /**
- * @dev get contractFactory
+ * @dev generate a new BaseContract instance at contractAddress
  *
- * @param contractABI: ContractABI
+ * @param contractAddress: string
  *
- * @param contractBytecode: string
+ * @param contractABI: ContractABI[]
  *
  * @return Promise<EthersResult>
  */
-export const getContractFactory = async (
-  contractABI: ContractABI[],
-  contractBytecode: string
+export const generateBaseContractInstance = async (
+  contractAddress: string,
+  contractABI: ContractABI[]
 ): Promise<EthersResult> => {
   // get wallet provider
   const walletProvider = getWalletProvider();
@@ -45,14 +46,14 @@ export const getContractFactory = async (
     // get signer
     const walletSigner = await walletProvider.walletProvider.getSigner();
 
-    // get contract from contract factory
-    const contractFactory = new ContractFactory(
+    // generate a new BaseContract instance
+    const baseContract = new ethers.BaseContract(
+      contractAddress,
       JSON.stringify(contractABI),
-      contractBytecode,
       walletSigner
     );
 
-    return { contractFactory };
+    return { baseContract };
   } catch (err) {
     console.error(err);
     return { err };

--- a/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/BalanceOf.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/BalanceOf.tsx
@@ -21,14 +21,14 @@
 import { useState } from 'react';
 import { Tooltip } from '@chakra-ui/react';
 import { AiOutlineMinus } from 'react-icons/ai';
-import { ContractFactory, BaseContract } from 'ethers';
+import { ERC20MockMethod } from '../../utils/methodInterfaces';
 import HederaCommonTextField from '@/components/common/HederaCommonTextField';
 
 interface PageProps {
-  contractFactory: ContractFactory<any[], BaseContract>;
+  baseContract: ERC20MockMethod;
 }
 
-const BalanceOf = ({ contractFactory }: PageProps) => {
+const BalanceOf = ({ baseContract }: PageProps) => {
   const [value, setValue] = useState('');
   const [balances, setBalances] = useState([
     {

--- a/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/BalanceOf.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/BalanceOf.tsx
@@ -19,13 +19,13 @@
  */
 
 import { useState } from 'react';
+import { Contract } from 'ethers';
 import { Tooltip } from '@chakra-ui/react';
 import { AiOutlineMinus } from 'react-icons/ai';
-import { ERC20MockMethod } from '../../utils/methodInterfaces';
 import HederaCommonTextField from '@/components/common/HederaCommonTextField';
 
 interface PageProps {
-  baseContract: ERC20MockMethod;
+  baseContract: Contract;
 }
 
 const BalanceOf = ({ baseContract }: PageProps) => {

--- a/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/Mint.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/Mint.tsx
@@ -19,12 +19,12 @@
  */
 
 import { useState } from 'react';
+import { Contract } from 'ethers';
 import { mintParamFields } from '../../utils/constant';
 import MultiLineMethod from '../common/MultiLineMethod';
-import { ERC20MockMethod } from '../../utils/methodInterfaces';
 
 interface PageProps {
-  baseContract: ERC20MockMethod;
+  baseContract: Contract;
 }
 
 const Mint = ({ baseContract }: PageProps) => {

--- a/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/Mint.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/Mint.tsx
@@ -19,15 +19,15 @@
  */
 
 import { useState } from 'react';
-import { ContractFactory, BaseContract } from 'ethers';
-import MultiLineMethod from '../common/MultiLineMethod';
 import { mintParamFields } from '../../utils/constant';
+import MultiLineMethod from '../common/MultiLineMethod';
+import { ERC20MockMethod } from '../../utils/methodInterfaces';
 
 interface PageProps {
-  contractFactory: ContractFactory<any[], BaseContract>;
+  baseContract: ERC20MockMethod;
 }
 
-const Mint = ({ contractFactory }: PageProps) => {
+const Mint = ({ baseContract }: PageProps) => {
   const [mintParams, setMintParams] = useState({
     recipient: '',
     amount: '',

--- a/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/TokenInformation.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/TokenInformation.tsx
@@ -18,11 +18,11 @@
  *
  */
 
+import { Contract } from 'ethers';
 import OneLineMethod from '../common/OneLineMethod';
-import { ERC20MockMethod } from '../../utils/methodInterfaces';
 
 interface PageProps {
-  baseContract: ERC20MockMethod;
+  baseContract: Contract;
 }
 
 const TokenInformation = ({ baseContract }: PageProps) => {

--- a/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/TokenInformation.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/TokenInformation.tsx
@@ -19,13 +19,13 @@
  */
 
 import OneLineMethod from '../common/OneLineMethod';
-import { ContractFactory, BaseContract } from 'ethers';
+import { ERC20MockMethod } from '../../utils/methodInterfaces';
 
 interface PageProps {
-  contractFactory: ContractFactory<any[], BaseContract>;
+  baseContract: ERC20MockMethod;
 }
 
-const TokenInformation = ({ contractFactory }: PageProps) => {
+const TokenInformation = ({ baseContract }: PageProps) => {
   return (
     <div className="w-full">
       {/* wrapper */}

--- a/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/TokenPermissions.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/TokenPermissions.tsx
@@ -19,8 +19,8 @@
  */
 
 import { useState } from 'react';
+import { Contract } from 'ethers';
 import MultiLineMethod from '../common/MultiLineMethod';
-import { ERC20MockMethod } from '../../utils/methodInterfaces';
 import {
   allowanceParamFields,
   approveParamFields,
@@ -29,7 +29,7 @@ import {
 } from '../../utils/constant';
 
 interface PageProps {
-  baseContract: ERC20MockMethod;
+  baseContract: Contract;
 }
 
 const TokenPermission = ({ baseContract }: PageProps) => {

--- a/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/TokenPermissions.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/TokenPermissions.tsx
@@ -19,8 +19,8 @@
  */
 
 import { useState } from 'react';
-import { ContractFactory, BaseContract } from 'ethers';
 import MultiLineMethod from '../common/MultiLineMethod';
+import { ERC20MockMethod } from '../../utils/methodInterfaces';
 import {
   allowanceParamFields,
   approveParamFields,
@@ -29,10 +29,10 @@ import {
 } from '../../utils/constant';
 
 interface PageProps {
-  contractFactory: ContractFactory<any[], BaseContract>;
+  baseContract: ERC20MockMethod;
 }
 
-const TokenPermission = ({ contractFactory }: PageProps) => {
+const TokenPermission = ({ baseContract }: PageProps) => {
   const [approveParams, setApproveParams] = useState({
     spender: '',
     amount: '',

--- a/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/Transfer.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/Transfer.tsx
@@ -19,12 +19,12 @@
  */
 
 import { useState } from 'react';
+import { Contract } from 'ethers';
 import MultiLineMethod from '../common/MultiLineMethod';
 import { transferParamFields, transferFromParamFields } from '../../utils/constant';
-import { ERC20MockMethod } from '../../utils/methodInterfaces';
 
 interface PageProps {
-  baseContract: ERC20MockMethod;
+  baseContract: Contract;
 }
 
 const Transfer = ({ baseContract }: PageProps) => {

--- a/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/Transfer.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/Transfer.tsx
@@ -19,15 +19,15 @@
  */
 
 import { useState } from 'react';
-import { ContractFactory, BaseContract } from 'ethers';
 import MultiLineMethod from '../common/MultiLineMethod';
 import { transferParamFields, transferFromParamFields } from '../../utils/constant';
+import { ERC20MockMethod } from '../../utils/methodInterfaces';
 
 interface PageProps {
-  contractFactory: ContractFactory<any[], BaseContract>;
+  baseContract: ERC20MockMethod;
 }
 
-const Transfer = ({ contractFactory }: PageProps) => {
+const Transfer = ({ baseContract }: PageProps) => {
   const [transferParams, setTransferParams] = useState({
     recipient: '',
     amount: '',

--- a/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/index.tsx
@@ -23,21 +23,21 @@ import Transfer from './Transfer';
 import BalanceOf from './BalanceOf';
 import TokenPermission from './TokenPermissions';
 import TokenInformation from './TokenInformation';
-import { ContractFactory, BaseContract } from 'ethers';
+import { ERC20MockMethod } from '../../utils/methodInterfaces';
 
 interface PageProps {
-  contractFactory: ContractFactory<any[], BaseContract>;
   method: string;
+  baseContract: ERC20MockMethod;
 }
 
-const ERC20Methods = ({ contractFactory, method }: PageProps) => {
+const ERC20Methods = ({ baseContract, method }: PageProps) => {
   return (
     <>
-      {method === 'tokenInformation' && <TokenInformation contractFactory={contractFactory} />}
-      {method === 'mint' && <Mint contractFactory={contractFactory} />}
-      {method === 'balanceOf' && <BalanceOf contractFactory={contractFactory} />}
-      {method === 'tokenPermissions' && <TokenPermission contractFactory={contractFactory} />}
-      {method === 'transfer' && <Transfer contractFactory={contractFactory} />}
+      {method === 'tokenInformation' && <TokenInformation baseContract={baseContract} />}
+      {method === 'mint' && <Mint baseContract={baseContract} />}
+      {method === 'balanceOf' && <BalanceOf baseContract={baseContract} />}
+      {method === 'tokenPermissions' && <TokenPermission baseContract={baseContract} />}
+      {method === 'transfer' && <Transfer baseContract={baseContract} />}
     </>
   );
 };

--- a/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/index.tsx
@@ -19,15 +19,15 @@
  */
 
 import Mint from './Mint';
+import { Contract } from 'ethers';
 import Transfer from './Transfer';
 import BalanceOf from './BalanceOf';
 import TokenPermission from './TokenPermissions';
 import TokenInformation from './TokenInformation';
-import { ERC20MockMethod } from '../../utils/methodInterfaces';
 
 interface PageProps {
   method: string;
-  baseContract: ERC20MockMethod;
+  baseContract: Contract;
 }
 
 const ERC20Methods = ({ baseContract, method }: PageProps) => {

--- a/system-contract-dapp-playground/src/components/contract-interaction/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/index.tsx
@@ -20,14 +20,13 @@
 
 import Link from 'next/link';
 import Image from 'next/image';
-import { BaseContract } from 'ethers';
+import { Contract } from 'ethers';
 import ERC20Methods from './erc/erc-20/methods';
 import { deploySmartContract } from '@/api/hedera';
 import { HASHSCAN_BASE_URL } from '@/utils/constants';
 import HederaAlertDialog from '../common/AlertDialog';
 import { useCallback, useEffect, useState } from 'react';
 import { generateBaseContractInstance } from '@/api/ethers';
-import { ERC20MockMethod } from './erc/utils/methodInterfaces';
 import ERC20DeployField from './erc/deployment/ERCDeployField';
 import { convertCalmelCaseFunctionName } from '@/utils/helpers';
 import { getHederaNativeIDFromEvmAddress } from '@/api/mirror-node';
@@ -49,9 +48,9 @@ const ContractInteraction = ({ contract }: PageProps) => {
   const [network, setNetwork] = useState<NetworkName>();
   const [contractAddress, setContractAddress] = useState('');
   const [didDeployStart, setDidDeployStart] = useState(false);
+  const [baseContract, setBaseContract] = useState<Contract>();
   const [deployedParams, setDeployedParams] = useState<any>([]);
   const [displayConfirmDialog, setDisplayConfirmDialog] = useState(false);
-  const [baseContract, setBaseContract] = useState<BaseContract>();
 
   // handle set up baseContract
   useEffect(() => {
@@ -77,7 +76,7 @@ const ContractInteraction = ({ contract }: PageProps) => {
           return;
         }
 
-        // update contractFactory state
+        // update baseContract state
         setBaseContract(baseContract);
       }
     })();
@@ -254,10 +253,7 @@ const ContractInteraction = ({ contract }: PageProps) => {
                   <div className="flex py-9 text-xl w-full h-full justify-center items-center">
                     {/* ERC-20 */}
                     {contract.name === 'ERC20Mock' && (
-                      <ERC20Methods
-                        method={method}
-                        baseContract={baseContract! as ERC20MockMethod}
-                      />
+                      <ERC20Methods method={method} baseContract={baseContract! as Contract} />
                     )}
                     {contract.name !== 'ERC20Mock' && <>{convertCalmelCaseFunctionName(method)}</>}
                   </div>

--- a/system-contract-dapp-playground/src/components/contract-interaction/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/index.tsx
@@ -20,13 +20,14 @@
 
 import Link from 'next/link';
 import Image from 'next/image';
+import { BaseContract } from 'ethers';
 import ERC20Methods from './erc/erc-20/methods';
-import { getContractFactory } from '@/api/ethers';
 import { deploySmartContract } from '@/api/hedera';
 import { HASHSCAN_BASE_URL } from '@/utils/constants';
 import HederaAlertDialog from '../common/AlertDialog';
-import { BaseContract, ContractFactory } from 'ethers';
 import { useCallback, useEffect, useState } from 'react';
+import { generateBaseContractInstance } from '@/api/ethers';
+import { ERC20MockMethod } from './erc/utils/methodInterfaces';
 import ERC20DeployField from './erc/deployment/ERCDeployField';
 import { convertCalmelCaseFunctionName } from '@/utils/helpers';
 import { getHederaNativeIDFromEvmAddress } from '@/api/mirror-node';
@@ -50,35 +51,37 @@ const ContractInteraction = ({ contract }: PageProps) => {
   const [didDeployStart, setDidDeployStart] = useState(false);
   const [deployedParams, setDeployedParams] = useState<any>([]);
   const [displayConfirmDialog, setDisplayConfirmDialog] = useState(false);
-  const [contractFactory, setContractFactory] = useState<ContractFactory<any[], BaseContract>>();
+  const [baseContract, setBaseContract] = useState<BaseContract>();
 
-  // handle set up contractFactory
+  // handle set up baseContract
   useEffect(() => {
     (async () => {
-      const { contractFactory, err: contractFactoryErr } = await getContractFactory(
-        contract.contractABI,
-        contract.contractBytecode
-      );
+      if (contractAddress) {
+        const { baseContract, err: baseContractErr } = await generateBaseContractInstance(
+          contractAddress,
+          contract.contractABI
+        );
 
-      // handle error
-      if (contractFactoryErr || !contractFactory) {
-        if (contractFactoryErr === '!HEDERA') {
-          NoWalletToast({ toaster });
+        // handle error
+        if (baseContractErr || !baseContract) {
+          if (baseContractErr === '!HEDERA') {
+            NoWalletToast({ toaster });
+            return;
+          }
+
+          CommonErrorToast({
+            toaster,
+            title: 'Cannot deploy contract',
+            description: "See client's console for more information",
+          });
           return;
         }
 
-        CommonErrorToast({
-          toaster,
-          title: 'Cannot deploy contract',
-          description: "See client's console for more information",
-        });
-        return;
+        // update contractFactory state
+        setBaseContract(baseContract);
       }
-
-      // update contractFactory state
-      setContractFactory(contractFactory);
     })();
-  }, [contract.contractABI, contract.contractBytecode, toaster]);
+  }, [contract.contractABI, contractAddress, toaster]);
 
   /** @dev handle deploying contract */
   const handleDeployContract = useCallback(async () => {
@@ -251,7 +254,10 @@ const ContractInteraction = ({ contract }: PageProps) => {
                   <div className="flex py-9 text-xl w-full h-full justify-center items-center">
                     {/* ERC-20 */}
                     {contract.name === 'ERC20Mock' && (
-                      <ERC20Methods contractFactory={contractFactory!} method={method} />
+                      <ERC20Methods
+                        method={method}
+                        baseContract={baseContract! as ERC20MockMethod}
+                      />
                     )}
                     {contract.name !== 'ERC20Mock' && <>{convertCalmelCaseFunctionName(method)}</>}
                   </div>

--- a/system-contract-dapp-playground/src/types/interfaces.d.ts
+++ b/system-contract-dapp-playground/src/types/interfaces.d.ts
@@ -61,12 +61,12 @@ interface WalletResult {
 /**
  * @dev an interface for the results related to ethers module
  *
- * @params contractFactory?: ContractFactory<any[], BaseContract>
+ * @params baseContract?: BaseContract
  *
  * @params err: any
  */
 interface EthersResult {
-  contractFactory?: ContractFactory<any[], BaseContract>;
+  baseContract?: BaseContract;
   err?: any;
 }
 

--- a/system-contract-dapp-playground/src/types/interfaces.d.ts
+++ b/system-contract-dapp-playground/src/types/interfaces.d.ts
@@ -18,7 +18,7 @@
  *
  */
 
-import { BaseContract, BrowserProvider, ContractFactory } from 'ethers';
+import { BrowserProvider, Contract, ContractFactory } from 'ethers';
 
 /**
  * @dev a type for network name
@@ -61,12 +61,12 @@ interface WalletResult {
 /**
  * @dev an interface for the results related to ethers module
  *
- * @params baseContract?: BaseContract
+ * @params baseContract?: ethers.Contract
  *
  * @params err: any
  */
 interface EthersResult {
-  baseContract?: BaseContract;
+  baseContract?: Contract;
   err?: any;
 }
 


### PR DESCRIPTION
To interact with on-chain contracts, baseContract is needed not contractFactory

**Description**: This PR reworked the logic for the getContractFactory function to generate a new BaseContract type instance and redistribute it to the child components of the contract-interaction

Fixes #330 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
