### PR TITLE
test: added unit tests to fix #342

### DIFF
--- a/test/hts-precompile/token-create/tokenCreateCustomContract.js
+++ b/test/hts-precompile/token-create/tokenCreateCustomContract.js
@@ -391,7 +391,7 @@ describe('TokenCreateCustomContract Test Suite', () => {
   })
 
   describe('Key params', () => {
-    it.only("should fail when the key param is different than the caller's public key", async () => {
+    it("should fail when the key param is different than the caller's public key", async () => {
       const wallet0 = new ethers.Wallet(
         hre.config.networks[network.name].accounts[0]
       )
@@ -438,7 +438,7 @@ describe('TokenCreateCustomContract Test Suite', () => {
       }
     })
 
-    it.only("should pass when the key caller's public key is set as key param", async () => {
+    it("should pass when the key caller's public key is set as key param", async () => {
       const wallet0 = new ethers.Wallet(
         hre.config.networks[network.name].accounts[0]
       )

--- a/test/hts-precompile/token-create/tokenCreateCustomContract.js
+++ b/test/hts-precompile/token-create/tokenCreateCustomContract.js
@@ -391,7 +391,7 @@ describe('TokenCreateCustomContract Test Suite', () => {
   })
 
   describe('Key params', () => {
-    it("should fail when the key param is different than the caller's public key", async () => {
+    it('should fail when token create has missing signatures in transaction', async () => {
       const wallet0 = new ethers.Wallet(
         hre.config.networks[network.name].accounts[0]
       )

--- a/test/hts-precompile/token-create/tokenCreateCustomContract.js
+++ b/test/hts-precompile/token-create/tokenCreateCustomContract.js
@@ -397,11 +397,6 @@ describe('TokenCreateCustomContract Test Suite', () => {
       )
       const callerAddress = await wallet0.getAddress()
 
-      const callerPubKey = Buffer.from(
-        wallet0._signingKey().compressedPublicKey.replace('0x', ''),
-        'hex'
-      )
-
       const wallet1 = new ethers.Wallet(
         hre.config.networks[network.name].accounts[1]
       )
@@ -426,7 +421,6 @@ describe('TokenCreateCustomContract Test Suite', () => {
           gasLimit: 1_000_000,
         }
       )
-      expect(callerPubKey).to.not.eq(failedKey)
       expect(tx.from).to.eq(callerAddress)
       expect(tx.to).to.be.null
 


### PR DESCRIPTION
**Description**: This PR contains two unit tests to make sure that the caller's public key needs to be set as the `key` param for the create token functions
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->



Fixes #342

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
