### PR TITLE
feat: Added API and unit tests to facilitate fungible and non-fungible token creations for TokenCreateCustom contract

### DIFF
--- a/system-contract-dapp-playground/__tests__/hedera/helper/index.test.ts
+++ b/system-contract-dapp-playground/__tests__/hedera/helper/index.test.ts
@@ -1,0 +1,106 @@
+/*-
+ *
+ * Hedera Smart Contracts
+ *
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { constructIHederaTokenKey } from '@/utils/contract-interactions/HTS/helpers';
+import { DEFAULT_IHTS_KEY_VALUE, KEY_TYPE_MAP } from '@/utils/contract-interactions/HTS/constant';
+import { Wallet, ethers } from 'ethers';
+
+describe('constructIHederaTokenKey test suite', () => {
+  // mock contractId & compressedPubKey
+  const contractId = '0xbdcdf69052c9fc01e38377d05cc83c28ee43f24a';
+  const compressedPubKey = '0x02abd6f73537915169f0172a49b8521f0679482c6538f0cc063c27bd31f32db9c1';
+
+  it('should construct a correct IHederaTokenService.TokenKey for all key types', () => {
+    const keyValueType = 'contractId';
+
+    const keyTypesArray: IHederaTokenServiceKeyType[] = [
+      'ADMIN',
+      'KYC',
+      'FREEZE',
+      'WIPE',
+      'SUPPLY',
+      'FEE',
+      'PAUSE',
+    ];
+
+    keyTypesArray.forEach((keyType) => {
+      const expectedHederaTokenKey = {
+        keyType: KEY_TYPE_MAP[keyType],
+        key: { ...DEFAULT_IHTS_KEY_VALUE, contractId },
+      };
+
+      const hederaTokenKey = constructIHederaTokenKey(keyType, keyValueType, contractId);
+
+      expect(hederaTokenKey).toStrictEqual(expectedHederaTokenKey);
+    });
+  });
+
+  it('should construct a correct IHederaTokenService.TokenKey for all key value types', () => {
+    const keyValueTypsArray: IHederaTokenServiceKeyValueType[] = [
+      'inheritAccountKey',
+      'contractId',
+      'ed25519',
+      'ECDSA_secp256k1',
+      'delegatableContractId',
+    ];
+
+    keyValueTypsArray.forEach((keyValueType) => {
+      let expectedKeyValue, inputKeyValue;
+      if (keyValueType === 'inheritAccountKey') {
+        inputKeyValue = true;
+        expectedKeyValue = true;
+      } else if (keyValueType === 'contractId' || keyValueType === 'delegatableContractId') {
+        inputKeyValue = contractId;
+        expectedKeyValue = contractId;
+      } else {
+        inputKeyValue = compressedPubKey;
+        expectedKeyValue = Buffer.from(compressedPubKey, 'hex');
+      }
+
+      const expectedHederaTokenKey = {
+        keyType: 1, // ADMIN
+        key: { ...DEFAULT_IHTS_KEY_VALUE, [keyValueType]: expectedKeyValue },
+      };
+      const hederaTokenKey = constructIHederaTokenKey('ADMIN', keyValueType, inputKeyValue);
+
+      expect(hederaTokenKey).toStrictEqual(expectedHederaTokenKey);
+    });
+  });
+
+  it('should return NULL when construct a IHederaTokenService.TokenKey with address typed key that does not match standard public address', () => {
+    const keyValueType: IHederaTokenServiceKeyValueType[] = ['contractId', 'delegatableContractId'];
+    const invalidAddress = '0xabc';
+
+    keyValueType.forEach((keyValueType) => {
+      const hederaTokenKey = constructIHederaTokenKey('ADMIN', keyValueType, invalidAddress);
+      expect(hederaTokenKey).toBe(null);
+    });
+  });
+
+  it('should return NULL when construct a IHederaTokenService.TokenKey with compressed public key typed key that does not match standard compressed public key', () => {
+    const keyValueType: IHederaTokenServiceKeyValueType[] = ['ed25519', 'ECDSA_secp256k1'];
+    const invalidPubKey = '0xabc';
+
+    keyValueType.forEach((keyValueType) => {
+      const hederaTokenKey = constructIHederaTokenKey('ADMIN', keyValueType, invalidPubKey);
+      expect(hederaTokenKey).toBe(null);
+    });
+  });
+});

--- a/system-contract-dapp-playground/__tests__/hedera/hts-interactions/index.test.ts
+++ b/system-contract-dapp-playground/__tests__/hedera/hts-interactions/index.test.ts
@@ -1,0 +1,315 @@
+/*-
+ *
+ * Hedera Smart Contracts
+ *
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {
+  createHederaFungibleToken,
+  createHederaNonFungibleToken,
+} from '@/api/hedera/tokenCreateCustom-interactions';
+import { Contract } from 'ethers';
+
+describe('createHederaFungibleToken test suite', () => {
+  // mock states
+  const contractId = '0xbdcdf69052c9fc01e38377d05cc83c28ee43f24a';
+  const tokenAddress = '0x00000000000000000000000000000000000084b7';
+  const feeTokenAddress = '0x00000000000000000000000000000000000006Ab';
+  const txHash = '0x63424020a69bf46a0669f46dd66addba741b9c02d37fab1686428f5209bc759d';
+  const returnedTokenAddress = '0x00000000000000000000000000000000000000000000000000000000000084b7';
+  const tokenName = 'WrappedHbar';
+  const tokenSymbol = 'WHBAR';
+  const tokenMemo = 'Wrapped Hbar';
+  const initialSupply = 900000000; // 9 WHBAR
+  const maxSupply = 30000000000; // 300 WHBAR
+  const decimals = 8;
+  const freezeDefaultStatus = false;
+
+  // mock baseContract object
+  const baseContract = {
+    createFungibleTokenPublic: jest.fn().mockResolvedValue({
+      wait: jest.fn().mockResolvedValue({
+        logs: [
+          {
+            fragment: {
+              name: 'CreatedToken',
+            },
+            data: returnedTokenAddress,
+          },
+        ],
+        hash: txHash,
+      }),
+    }),
+    createFungibleTokenWithCustomFeesPublic: jest.fn().mockResolvedValue({
+      wait: jest.fn().mockResolvedValue({
+        logs: [
+          {
+            fragment: {
+              name: 'CreatedToken',
+            },
+            data: returnedTokenAddress,
+          },
+        ],
+        hash: txHash,
+      }),
+    }),
+    createNonFungibleTokenPublic: jest.fn().mockResolvedValue({
+      wait: jest.fn().mockResolvedValue({
+        logs: [
+          {
+            fragment: {
+              name: 'CreatedToken',
+            },
+            data: returnedTokenAddress,
+          },
+        ],
+        hash: txHash,
+      }),
+    }),
+    createNonFungibleTokenWithCustomFeesPublic: jest.fn().mockResolvedValue({
+      wait: jest.fn().mockResolvedValue({
+        logs: [
+          {
+            fragment: {
+              name: 'CreatedToken',
+            },
+            data: returnedTokenAddress,
+          },
+        ],
+        hash: txHash,
+      }),
+    }),
+  };
+
+  // mock inputKeys with CommonKeyObject[] type
+  const inputKeys: CommonKeyObject[] = [
+    {
+      keyType: 'ADMIN',
+      keyValueType: 'contractId',
+      keyValue: contractId,
+    },
+    {
+      keyType: 'KYC',
+      keyValueType: 'contractId',
+      keyValue: contractId,
+    },
+    {
+      keyType: 'FREEZE',
+      keyValueType: 'contractId',
+      keyValue: contractId,
+    },
+    {
+      keyType: 'WIPE',
+      keyValueType: 'contractId',
+      keyValue: contractId,
+    },
+    {
+      keyType: 'SUPPLY',
+      keyValueType: 'contractId',
+      keyValue: contractId,
+    },
+    {
+      keyType: 'FEE',
+      keyValueType: 'contractId',
+      keyValue: contractId,
+    },
+    {
+      keyType: 'PAUSE',
+      keyValueType: 'contractId',
+      keyValue: contractId,
+    },
+  ];
+
+  describe('createHederaFungibleToken', () => {
+    it('should execute createHederaFungibleToken and return a token address', async () => {
+      const tokenCreateRes = await createHederaFungibleToken(
+        baseContract as unknown as Contract,
+        tokenName,
+        tokenSymbol,
+        tokenMemo,
+        initialSupply,
+        maxSupply,
+        decimals,
+        freezeDefaultStatus,
+        contractId,
+        inputKeys
+      );
+
+      expect(tokenCreateRes.err).toBeNull;
+      expect(tokenCreateRes.transactionHash).toBe(txHash);
+      expect(tokenCreateRes.tokenAddress).toBe(tokenAddress);
+    });
+
+    it('should execute createFungibleTokenWithCustomFeesPublic and return a token address', async () => {
+      const tokenCreateRes = await createHederaFungibleToken(
+        baseContract as unknown as Contract,
+        tokenName,
+        tokenSymbol,
+        tokenMemo,
+        initialSupply,
+        maxSupply,
+        decimals,
+        freezeDefaultStatus,
+        contractId,
+        inputKeys,
+        feeTokenAddress
+      );
+
+      expect(tokenCreateRes.err).toBeNull;
+      expect(tokenCreateRes.transactionHash).toBe(txHash);
+      expect(tokenCreateRes.tokenAddress).toBe(tokenAddress);
+    });
+
+    it('should execute createHederaFungibleToken and return error if initialTotalSupply is invalid', async () => {
+      const tokenCreateRes = await createHederaFungibleToken(
+        baseContract as unknown as Contract,
+        tokenName,
+        tokenSymbol,
+        tokenMemo,
+        -3,
+        maxSupply,
+        decimals,
+        freezeDefaultStatus,
+        contractId,
+        inputKeys
+      );
+
+      expect(tokenCreateRes.err).toBe('initial total supply cannot be negative');
+      expect(tokenCreateRes.tokenAddress).toBeNull;
+    });
+
+    it('should execute createHederaFungibleToken and return error if maxSupply is invalid', async () => {
+      const tokenCreateRes = await createHederaFungibleToken(
+        baseContract as unknown as Contract,
+        tokenName,
+        tokenSymbol,
+        tokenMemo,
+        initialSupply,
+        -3,
+        decimals,
+        freezeDefaultStatus,
+        contractId,
+        inputKeys
+      );
+
+      expect(tokenCreateRes.err).toBe('max supply cannot be negative');
+      expect(tokenCreateRes.tokenAddress).toBeNull;
+    });
+
+    it('should execute createHederaFungibleToken and return error if decimals is invalid', async () => {
+      const tokenCreateRes = await createHederaFungibleToken(
+        baseContract as unknown as Contract,
+        tokenName,
+        tokenSymbol,
+        tokenMemo,
+        initialSupply,
+        maxSupply,
+        -3,
+        freezeDefaultStatus,
+        contractId,
+        inputKeys
+      );
+
+      expect(tokenCreateRes.err).toBe('decimals cannot be negative');
+      expect(tokenCreateRes.tokenAddress).toBeNull;
+    });
+
+    it('should execute createHederaFungibleToken and return error if treasury address does not match public address standard', async () => {
+      const tokenCreateRes = await createHederaFungibleToken(
+        baseContract as unknown as Contract,
+        tokenName,
+        tokenSymbol,
+        tokenMemo,
+        initialSupply,
+        maxSupply,
+        decimals,
+        freezeDefaultStatus,
+        '0xabc',
+        inputKeys
+      );
+
+      expect(tokenCreateRes.err).toBe('invalid treasury address');
+      expect(tokenCreateRes.tokenAddress).toBeNull;
+    });
+
+    it('should execute createHederaFungibleToken and return error if fee token address does not match public address standard', async () => {
+      const tokenCreateRes = await createHederaFungibleToken(
+        baseContract as unknown as Contract,
+        tokenName,
+        tokenSymbol,
+        tokenMemo,
+        initialSupply,
+        maxSupply,
+        decimals,
+        freezeDefaultStatus,
+        contractId,
+        inputKeys,
+        '0xabc'
+      );
+
+      expect(tokenCreateRes.err).toBe('invalid fee token address');
+      expect(tokenCreateRes.tokenAddress).toBeNull;
+    });
+
+    it('should execute createHederaFungibleToken and return error if inputKeys is invalid ', async () => {
+      const failedKeys: CommonKeyObject[] = [
+        {
+          keyType: 'ADMIN',
+          keyValueType: 'contractId',
+          keyValue: '0xabc', // invalid
+        },
+        {
+          keyType: 'KYC',
+          keyValueType: 'contractId',
+          keyValue: contractId,
+        },
+        {
+          keyType: 'FREEZE',
+          keyValueType: 'ECDSA_secp256k1',
+          keyValue: '0x02bc', // invalid
+        },
+      ];
+
+      const tokenCreateRes = await createHederaFungibleToken(
+        baseContract as unknown as Contract,
+        tokenName,
+        tokenSymbol,
+        tokenMemo,
+        initialSupply,
+        maxSupply,
+        decimals,
+        freezeDefaultStatus,
+        contractId,
+        failedKeys
+      );
+
+      expect(tokenCreateRes.err.length).toBe(2);
+
+      expect(tokenCreateRes.err[0].keyType).toBe('ADMIN');
+      expect(tokenCreateRes.err[0].keyValueType).toBe('contractId');
+      expect(tokenCreateRes.err[0].keyValue).toBe('0xabc');
+      expect(tokenCreateRes.err[0].err).toBe('Invalid key value');
+
+      expect(tokenCreateRes.err[1].keyType).toBe('FREEZE');
+      expect(tokenCreateRes.err[1].keyValueType).toBe('ECDSA_secp256k1');
+      expect(tokenCreateRes.err[1].keyValue).toBe('0x02bc');
+      expect(tokenCreateRes.err[1].err).toBe('Invalid key value');
+
+      expect(tokenCreateRes.tokenAddress).toBeNull;
+    });
+  });
+

--- a/system-contract-dapp-playground/__tests__/hedera/hts-interactions/index.test.ts
+++ b/system-contract-dapp-playground/__tests__/hedera/hts-interactions/index.test.ts
@@ -313,3 +313,128 @@ describe('createHederaFungibleToken test suite', () => {
     });
   });
 
+  describe('createHederaNonFungibleToken', () => {
+    it('should execute createHederaNonFungibleToken and return a token address', async () => {
+      const tokenCreateRes = await createHederaNonFungibleToken(
+        baseContract as unknown as Contract,
+        tokenName,
+        tokenSymbol,
+        tokenMemo,
+        maxSupply,
+        contractId,
+        inputKeys
+      );
+
+      expect(tokenCreateRes.err).toBeNull;
+      expect(tokenCreateRes.transactionHash).toBe(txHash);
+      expect(tokenCreateRes.tokenAddress).toBe(tokenAddress);
+    });
+
+    it('should execute createFungibleTokenWithCustomFeesPublic and return a token address', async () => {
+      const tokenCreateRes = await createHederaNonFungibleToken(
+        baseContract as unknown as Contract,
+        tokenName,
+        tokenSymbol,
+        tokenMemo,
+        maxSupply,
+        contractId,
+        inputKeys,
+        feeTokenAddress
+      );
+
+      expect(tokenCreateRes.err).toBeNull;
+      expect(tokenCreateRes.transactionHash).toBe(txHash);
+      expect(tokenCreateRes.tokenAddress).toBe(tokenAddress);
+    });
+
+    it('should execute createHederaNonFungibleToken and return error if maxSupply is invalid', async () => {
+      const tokenCreateRes = await createHederaNonFungibleToken(
+        baseContract as unknown as Contract,
+        tokenName,
+        tokenSymbol,
+        tokenMemo,
+        -3,
+        contractId,
+        inputKeys
+      );
+
+      expect(tokenCreateRes.err).toBe('max supply cannot be negative');
+      expect(tokenCreateRes.tokenAddress).toBeNull;
+    });
+
+    it('should execute createHederaNonFungibleToken and return error if treasury address does not match public address standard', async () => {
+      const tokenCreateRes = await createHederaNonFungibleToken(
+        baseContract as unknown as Contract,
+        tokenName,
+        tokenSymbol,
+        tokenMemo,
+        maxSupply,
+        '0xabc',
+        inputKeys
+      );
+
+      expect(tokenCreateRes.err).toBe('invalid treasury address');
+      expect(tokenCreateRes.tokenAddress).toBeNull;
+    });
+
+    it('should execute createHederaNonFungibleToken and return error if fee token address does not match public address standard', async () => {
+      const tokenCreateRes = await createHederaNonFungibleToken(
+        baseContract as unknown as Contract,
+        tokenName,
+        tokenSymbol,
+        tokenMemo,
+        maxSupply,
+        contractId,
+        inputKeys,
+        '0xabc'
+      );
+
+      expect(tokenCreateRes.err).toBe('invalid fee token address');
+      expect(tokenCreateRes.tokenAddress).toBeNull;
+    });
+
+    it('should execute createHederaNonFungibleToken and return error if inputKeys is invalid ', async () => {
+      const failedKeys: CommonKeyObject[] = [
+        {
+          keyType: 'ADMIN',
+          keyValueType: 'contractId',
+          keyValue: '0xabc', // invalid
+        },
+        {
+          keyType: 'KYC',
+          keyValueType: 'contractId',
+          keyValue: contractId,
+        },
+        {
+          keyType: 'FREEZE',
+          keyValueType: 'ECDSA_secp256k1',
+          keyValue: '0x02bc', // invalid
+        },
+      ];
+
+      const tokenCreateRes = await createHederaNonFungibleToken(
+        baseContract as unknown as Contract,
+        tokenName,
+        tokenSymbol,
+        tokenMemo,
+        maxSupply,
+        contractId,
+        failedKeys
+      );
+
+      expect(tokenCreateRes.err.length).toBe(2);
+
+      expect(tokenCreateRes.err[0].keyType).toBe('ADMIN');
+      expect(tokenCreateRes.err[0].keyValueType).toBe('contractId');
+      expect(tokenCreateRes.err[0].keyValue).toBe('0xabc');
+      expect(tokenCreateRes.err[0].err).toBe('Invalid key value');
+
+      expect(tokenCreateRes.err[1].keyType).toBe('FREEZE');
+      expect(tokenCreateRes.err[1].keyValueType).toBe('ECDSA_secp256k1');
+      expect(tokenCreateRes.err[1].keyValue).toBe('0x02bc');
+      expect(tokenCreateRes.err[1].err).toBe('Invalid key value');
+
+      expect(tokenCreateRes.tokenAddress).toBeNull;
+    });
+  });
+});

--- a/system-contract-dapp-playground/src/api/hedera/tokenCreateCustom-interactions/index.ts
+++ b/system-contract-dapp-playground/src/api/hedera/tokenCreateCustom-interactions/index.ts
@@ -1,0 +1,139 @@
+/*-
+ *
+ * Hedera Smart Contracts
+ *
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { prepareHederaTokenKeyArray } from '@/utils/contract-interactions/HTS/helpers';
+import { Contract, isAddress } from 'ethers';
+
+/**
+ * @dev creates a Hedera fungible token
+ *
+ * @dev integrates tokenCreateCustomContract.createFungibleTokenPublic() and tokenCreateCustomContract.createFungibleTokenWithCustomFeesPublic()
+ *
+ * @param baseContract: ethers.Contract
+ *
+ * @param name: string
+ *
+ * @param symbol: string
+ *
+ * @param memo: string
+ *
+ * @param initialTotalSupply: number
+ *
+ * @param maxSupply: number
+ *
+ * @param decimals: number
+ *
+ * @param freezeDefaultStatus: boolean
+ *
+ * @param treasury: string
+ *
+ * @param inputKeys: CommonKeyObject[],
+ *
+ * @return Promise<TokenCreateCustomSmartContractResult>
+ *
+ * @see https://github.com/hashgraph/hedera-smart-contracts/blob/main/contracts/hts-precompile/IHederaTokenService.sol#L136
+ *      for more information on the purposes of the params
+ */
+export const createHederaFungibleToken = async (
+  baseContract: Contract,
+  name: string,
+  symbol: string,
+  memo: string,
+  initialTotalSupply: number,
+  maxSupply: number,
+  decimals: number,
+  freezeDefaultStatus: boolean,
+  treasury: string,
+  inputKeys: CommonKeyObject[],
+  feeTokenAddress?: string
+): Promise<TokenCreateCustomSmartContractResult> => {
+  // sanitize params
+  if (initialTotalSupply < 0) {
+    return { err: 'initial total supply cannot be negative' };
+  } else if (maxSupply < 0) {
+    return { err: 'max supply cannot be negative' };
+  } else if (decimals < 0) {
+    return { err: 'decimals cannot be negative' };
+  } else if (!isAddress(treasury)) {
+    return { err: 'invalid treasury address' };
+  } else if (feeTokenAddress && !isAddress(feeTokenAddress)) {
+    return { err: 'invalid fee token address' };
+  }
+
+  // prepare keys array
+  const keyRes = prepareHederaTokenKeyArray(inputKeys);
+
+  // handle error
+  if (keyRes.err) {
+    return { err: keyRes.err };
+  }
+
+  try {
+    let tokenCreateTx;
+    if (feeTokenAddress) {
+      tokenCreateTx = await baseContract.createFungibleTokenWithCustomFeesPublic(
+        treasury,
+        feeTokenAddress,
+        name,
+        symbol,
+        memo,
+        initialTotalSupply,
+        maxSupply,
+        decimals,
+        keyRes.hederaTokenKeys,
+        {
+          value: '35000000000000000000',
+          gasLimit: 1_000_000,
+        }
+      );
+    } else {
+      tokenCreateTx = await baseContract.createFungibleTokenPublic(
+        name,
+        symbol,
+        memo,
+        initialTotalSupply,
+        maxSupply,
+        decimals,
+        freezeDefaultStatus,
+        treasury,
+        keyRes.hederaTokenKeys,
+        {
+          value: '35000000000000000000',
+          gasLimit: 1_000_000,
+        }
+      );
+    }
+
+    const txReceipt = await tokenCreateTx.wait();
+
+    const { data } = txReceipt.logs.filter(
+      (event: any) => event.fragment.name === 'CreatedToken'
+    )[0];
+
+    // @notice since the returned `data` is 32 byte, convert it to the public 20-byte address standard
+    const tokenAddress = `0x${data.slice(-40)}`;
+
+    return { tokenAddress, transactionHash: txReceipt.hash };
+  } catch (err) {
+    console.error(err);
+    return { err };
+  }
+};
+

--- a/system-contract-dapp-playground/src/types/contract-interactions/HTS/index.d.ts
+++ b/system-contract-dapp-playground/src/types/contract-interactions/HTS/index.d.ts
@@ -23,3 +23,65 @@ interface TokenCreateCustomSmartContractResult {
   tokenAddress?: string;
   err?: any;
 }
+/**
+ * @dev a type for the IHederaTokenService.TokenKey.keyType
+ *
+ * @see https://github.com/hashgraph/hedera-smart-contracts/blob/main/contracts/hts-precompile/IHederaTokenService.sol#L128
+ */
+type IHederaTokenServiceKeyType = 'ADMIN' | 'KYC' | 'FREEZE' | 'WIPE' | 'SUPPLY' | 'FEE' | 'PAUSE';
+
+/**
+ * @dev a type representing the correct bit value for IHederaTokenService.TokenKey.keyType
+ *
+ * @see https://github.com/hashgraph/hedera-smart-contracts/blob/main/contracts/hts-precompile/IHederaTokenService.sol#L128
+ */
+type IHederaTokenServiceKeyTypeBitValue = 1 | 2 | 4 | 8 | 16 | 32 | 64;
+
+/**
+ * @dev a type for the key value type of the IHederaTokenService.KeyValue
+ *
+ * @see https://github.com/hashgraph/hedera-smart-contracts/blob/main/contracts/hts-precompile/IHederaTokenService.sol#L92
+ */
+type IHederaTokenServiceKeyValueType =
+  | 'inheritAccountKey'
+  | 'contractId'
+  | 'ed25519'
+  | 'ECDSA_secp256k1'
+  | 'delegatableContractId';
+
+/**
+ * @dev an interface that adheres to the `IHederaTokenService.KeyValue` type.
+ *
+ * @param inheritAccountKey: boolean
+ *
+ * @param contractId: string<address>
+ *
+ * @param ed25519: Buffer
+ *
+ * @param ECDSA_secp256k1: Buffer
+ *
+ * @param delegatableContractId: string<address>
+ *
+ * @see https://github.com/hashgraph/hedera-smart-contracts/blob/main/contracts/hts-precompile/IHederaTokenService.sol#L92
+ */
+interface IHederaTokenServiceKeyValue {
+  inheritAccountKey: boolean;
+  contractId: string;
+  ed25519: Buffer;
+  ECDSA_secp256k1: Buffer;
+  delegatableContractId: string;
+}
+
+/**
+ * @dev an interface that adheres to the `IHederaTokenService.TokenKey`
+ *
+ * @param keyType: IHederaTokenServiceKeyTypeBitValue
+ *
+ * @param key: IHederaTokenServiceKeyValue
+ *
+ * @see https://github.com/hashgraph/hedera-smart-contracts/blob/main/contracts/hts-precompile/IHederaTokenService.sol#L116
+ */
+interface IHederaTokenServiceTokenKey {
+  keyType: IHederaTokenServiceKeyTypeBitValue;
+  key: IHederaTokenServiceKeyValue;
+}

--- a/system-contract-dapp-playground/src/types/contract-interactions/HTS/index.d.ts
+++ b/system-contract-dapp-playground/src/types/contract-interactions/HTS/index.d.ts
@@ -21,6 +21,7 @@
 /** @dev an interface for the results returned back from interacting with Hedera TokenCreateCustom smart contract */
 interface TokenCreateCustomSmartContractResult {
   tokenAddress?: string;
+  transactionHash?: string;
   err?: any;
 }
 /**

--- a/system-contract-dapp-playground/src/types/contract-interactions/HTS/index.d.ts
+++ b/system-contract-dapp-playground/src/types/contract-interactions/HTS/index.d.ts
@@ -21,6 +21,7 @@
 /** @dev an interface for the results returned back from interacting with Hedera TokenCreateCustom smart contract */
 interface TokenCreateCustomSmartContractResult {
   tokenAddress?: string;
+  mintTokenRes?: boolean;
   transactionHash?: string;
   err?: any;
 }

--- a/system-contract-dapp-playground/src/types/contract-interactions/HTS/index.d.ts
+++ b/system-contract-dapp-playground/src/types/contract-interactions/HTS/index.d.ts
@@ -50,6 +50,24 @@ type IHederaTokenServiceKeyValueType =
   | 'delegatableContractId';
 
 /**
+ * @dev an interface for keyInput
+ *
+ * @param keyType: IHederaTokenServiceKeyType;
+ *
+ * @param keyValueType: IHederaTokenServiceKeyValueType;
+ *
+ * @param keyValue: string | boolean;
+ *
+ * @param err?: any
+ */
+interface CommonKeyObject {
+  keyType: IHederaTokenServiceKeyType;
+  keyValueType: IHederaTokenServiceKeyValueType;
+  keyValue: string | boolean;
+  err?: any;
+}
+
+/**
  * @dev an interface that adheres to the `IHederaTokenService.KeyValue` type.
  *
  * @param inheritAccountKey: boolean

--- a/system-contract-dapp-playground/src/utils/contract-interactions/HTS/constant.ts
+++ b/system-contract-dapp-playground/src/utils/contract-interactions/HTS/constant.ts
@@ -1,0 +1,48 @@
+/*-
+ *
+ * Hedera Smart Contracts
+ *
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { ethers } from 'ethers';
+
+/**
+ * @notice an object to map key type to the specific bit value
+ *
+ * @see https://github.com/hashgraph/hedera-smart-contracts/blob/main/contracts/hts-precompile/IHederaTokenService.sol#L128C22-L128C22
+ */
+export const KEY_TYPE_MAP: Record<IHederaTokenServiceKeyType, IHederaTokenServiceKeyTypeBitValue> =
+  {
+    ADMIN: 1,
+    KYC: 2,
+    FREEZE: 4,
+    WIPE: 8,
+    SUPPLY: 16,
+    FEE: 32,
+    PAUSE: 64,
+  };
+
+/**
+ * @notice an object of the keyValue's default values which conform to IHederaTokenService.KeyValue
+ */
+export const DEFAULT_IHTS_KEY_VALUE: IHederaTokenServiceKeyValue = {
+  inheritAccountKey: false,
+  contractId: ethers.ZeroAddress,
+  ed25519: Buffer.from('', 'hex'),
+  ECDSA_secp256k1: Buffer.from('', 'hex'),
+  delegatableContractId: ethers.ZeroAddress,
+};

--- a/system-contract-dapp-playground/src/utils/contract-interactions/HTS/helpers.ts
+++ b/system-contract-dapp-playground/src/utils/contract-interactions/HTS/helpers.ts
@@ -72,3 +72,43 @@ export const constructIHederaTokenKey = (
     key: { ...DEFAULT_IHTS_KEY_VALUE, [inputKeyValueType]: keyValue },
   };
 };
+
+/**
+ * @dev prepares a list of IHederaTokenService.TokenKey typed keys with a CommonKeyObject[] input
+ *
+ * @param inputKeys: CommonKeyObject[]
+ *
+ * @return IHederaTokenServiceTokenKey[]
+ *
+ * @return err: CommonKeyObject[]
+ */
+export const prepareHederaTokenKeyArray = (inputKeys: CommonKeyObject[]) => {
+  let constructingKeyError: CommonKeyObject[] = [];
+  const hederaTokenKeys = inputKeys.map((inputKey) => {
+    // construct IHederaTokenKey
+    const hederaTokenKey = constructIHederaTokenKey(
+      inputKey.keyType,
+      inputKey.keyValueType,
+      inputKey.keyValue
+    );
+
+    // push the invalid keys to the error list
+    if (!hederaTokenKey) {
+      constructingKeyError.push({
+        keyType: inputKey.keyType,
+        keyValueType: inputKey.keyValueType,
+        keyValue: inputKey.keyValue,
+        err: 'Invalid key value',
+      });
+    }
+
+    // return the new token key
+    return hederaTokenKey;
+  });
+
+  if (constructingKeyError.length > 0) {
+    return { err: constructingKeyError };
+  } else {
+    return { hederaTokenKeys: hederaTokenKeys as IHederaTokenServiceTokenKey[] };
+  }
+};

--- a/system-contract-dapp-playground/src/utils/contract-interactions/HTS/helpers.ts
+++ b/system-contract-dapp-playground/src/utils/contract-interactions/HTS/helpers.ts
@@ -1,0 +1,74 @@
+/*-
+ *
+ * Hedera Smart Contracts
+ *
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { isAddress } from 'ethers';
+import { KEY_TYPE_MAP, DEFAULT_IHTS_KEY_VALUE } from './constant';
+
+/**
+ * @dev tests if the input conforms to the common compressed public key standard
+ *
+ * @param compressedPublicKey: string
+ *
+ * @return boolean
+ */
+export const isCompressedPublicKey = (compressedPublicKey: string): boolean => {
+  const compressedPublicKeyPattern = /^0x(02|03)[0-9a-fA-F]{64}$/;
+  return compressedPublicKeyPattern.test(compressedPublicKey);
+};
+
+/**
+ * @dev Constructs a key conforming to the IHederaTokenService.TokenKey type
+ *
+ * @param keyType: IHederaTokenServiceKeyType
+ *
+ * @param keyValueType: IHederaTokenServiceKeyValueType
+ *
+ * @param keyValue: string | boolean
+ *
+ * @return IHederaTokenServiceTokenKey
+ */
+export const constructIHederaTokenKey = (
+  inputKeyType: IHederaTokenServiceKeyType,
+  inputKeyValueType: IHederaTokenServiceKeyValueType,
+  inputKeyValue: string | boolean
+): IHederaTokenServiceTokenKey | null => {
+  // sanitize params and prepare keyValue
+  let keyValue;
+  if (inputKeyValueType === 'inheritAccountKey') {
+    keyValue = inputKeyValue as boolean;
+  } else if (inputKeyValueType === 'contractId' || inputKeyValueType === 'delegatableContractId') {
+    if (!isAddress(inputKeyValue as string)) {
+      return null;
+    } else {
+      keyValue = inputKeyValue as string;
+    }
+  } else {
+    if (!isCompressedPublicKey(inputKeyValue as string)) {
+      return null;
+    } else {
+      keyValue = Buffer.from(inputKeyValue as string, 'hex');
+    }
+  }
+
+  return {
+    keyType: KEY_TYPE_MAP[inputKeyType],
+    key: { ...DEFAULT_IHTS_KEY_VALUE, [inputKeyValueType]: keyValue },
+  };
+};


### PR DESCRIPTION
**Description**:
This PR adds a set of APIs and unit tests to support facilitating interacting with TokenCreateCustom contract. The methods exposed in this PR are 
- createFungibleTokenPublic()
- createFungibleTokenWithCustomFeesPublic()
- createNonFungibleTokenPublic()
- createNonFungibleTokenWithCustomFeesPublic()

In addition, this PR also adds a couple of quick helper functions constructIHederaTokenKey() and prepareHederaTokenKeyArray() to help constructing an array of keys to assign to the token during creation

**Related issue(s)**: #316 

Fixes partial #316

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
