### PR TITLE
feat: Added API and unit tests to facilitate token mint, token associating, and granting kyc for TokenCreateCustom contract

### DIFF
--- a/system-contract-dapp-playground/__tests__/hedera/hts-interactions/index.test.ts
+++ b/system-contract-dapp-playground/__tests__/hedera/hts-interactions/index.test.ts
@@ -38,6 +38,10 @@ describe('createHederaFungibleToken test suite', () => {
   const grantingKYCAccount = '0x34810E139b451e0a4c67d5743E956Ac8990842A8';
   const txHash = '0x63424020a69bf46a0669f46dd66addba741b9c02d37fab1686428f5209bc759d';
   const returnedTokenAddress = '0x00000000000000000000000000000000000000000000000000000000000084b7';
+  const returnedMintedTokenEvent =
+    '000000000000000000000000000000000000000000000000000000000000000900000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000';
+  const returnedTransferTokenEvent =
+    '0x000000000000000000000000000000000000000000000000000000000000abc700000000000000000000000034810e139b451e0a4c67d5743e956ac8990842a80000000000000000000000000000000000000000000000000000000000000001';
   const tokenName = 'WrappedHbar';
   const tokenSymbol = 'WHBAR';
   const tokenMemo = 'Wrapped Hbar';
@@ -103,16 +107,52 @@ describe('createHederaFungibleToken test suite', () => {
     }),
     mintTokenPublic: jest.fn().mockResolvedValue({
       wait: jest.fn().mockResolvedValue({
+        logs: [
+          {
+            fragment: {
+              name: 'MintedToken',
+            },
+            data: returnedMintedTokenEvent,
+          },
+        ],
         hash: txHash,
       }),
     }),
     mintTokenToAddressPublic: jest.fn().mockResolvedValue({
       wait: jest.fn().mockResolvedValue({
+        logs: [
+          {
+            fragment: {
+              name: 'MintedToken',
+            },
+            data: returnedMintedTokenEvent,
+          },
+          {
+            fragment: {
+              name: 'TransferToken',
+            },
+            data: returnedTransferTokenEvent,
+          },
+        ],
         hash: txHash,
       }),
     }),
     mintNonFungibleTokenToAddressPublic: jest.fn().mockResolvedValue({
       wait: jest.fn().mockResolvedValue({
+        logs: [
+          {
+            fragment: {
+              name: 'MintedToken',
+            },
+            data: returnedMintedTokenEvent,
+          },
+          {
+            fragment: {
+              name: 'TransferToken',
+            },
+            data: returnedTransferTokenEvent,
+          },
+        ],
         hash: txHash,
       }),
     }),
@@ -502,6 +542,7 @@ describe('createHederaFungibleToken test suite', () => {
 
       expect(txRes.err).toBeNull;
       expect(txRes.transactionHash).toBe(txHash);
+      expect(txRes.mintedTokenEventData).toBe(returnedMintedTokenEvent);
     });
 
     it('should execute mintTokenPublic to mint a NON-FUNGIBLE token then return a transaction hash', async () => {
@@ -515,6 +556,7 @@ describe('createHederaFungibleToken test suite', () => {
 
       expect(txRes.err).toBeNull;
       expect(txRes.transactionHash).toBe(txHash);
+      expect(txRes.mintedTokenEventData).toBe(returnedMintedTokenEvent);
     });
 
     it('should execute mintTokenPublic to mint a Hedera token and return error when the hederaTokenAddress is invalid', async () => {
@@ -528,6 +570,7 @@ describe('createHederaFungibleToken test suite', () => {
 
       expect(txRes.err).toBe('invalid Hedera token address');
       expect(txRes.transactionHash).toBeNull;
+      expect(txRes.mintedTokenEventData).toBeNul;
     });
 
     it('should execute mintTokenPublic to mint a FUNGIBLE token and return error when the amount to mint is a negative number', async () => {
@@ -554,6 +597,7 @@ describe('createHederaFungibleToken test suite', () => {
 
       expect(txRes.err).toBe('amount to mint must be 0 when minting a non-fungible token');
       expect(txRes.transactionHash).toBeNull;
+      expect(txRes.mintedTokenEventData).toBeNull;
     });
   });
 
@@ -570,6 +614,8 @@ describe('createHederaFungibleToken test suite', () => {
 
       expect(txRes.err).toBeNull;
       expect(txRes.transactionHash).toBe(txHash);
+      expect(txRes.mintedTokenEventData).toBe(returnedMintedTokenEvent);
+      expect(txRes.transferTokenEventData).toBe(returnedTransferTokenEvent);
     });
 
     it('should execute mintHederaTokenToAddress to mint a NON-FUNGIBLE token and transfer it to the recipient then return a transaction hash', async () => {
@@ -584,6 +630,8 @@ describe('createHederaFungibleToken test suite', () => {
 
       expect(txRes.err).toBeNull;
       expect(txRes.transactionHash).toBe(txHash);
+      expect(txRes.mintedTokenEventData).toBe(returnedMintedTokenEvent);
+      expect(txRes.transferTokenEventData).toBe(returnedTransferTokenEvent);
     });
 
     it('should execute mintHederaTokenToAddress to mint a Hedera token and transfer it to the recipient then return error when the hederaTokenAddress is invalid', async () => {
@@ -598,6 +646,8 @@ describe('createHederaFungibleToken test suite', () => {
 
       expect(txRes.err).toBe('invalid Hedera token address');
       expect(txRes.transactionHash).toBeNull;
+      expect(txRes.mintedTokenEventData).toBeNull;
+      expect(txRes.transferTokenEventData).toBeNull;
     });
 
     it('should execute mintHederaTokenToAddress to mint a Hedera token and transfer it to the recipient then return error when the recipientAddress is invalid', async () => {
@@ -612,6 +662,8 @@ describe('createHederaFungibleToken test suite', () => {
 
       expect(txRes.err).toBe('invalid recipient address');
       expect(txRes.transactionHash).toBeNull;
+      expect(txRes.mintedTokenEventData).toBeNull;
+      expect(txRes.transferTokenEventData).toBeNull;
     });
 
     it('should execute mintHederaTokenToAddress to mint a FUNGIBLE token and transfer it to the recipient then return error when the amount to mint is a negative number', async () => {
@@ -626,6 +678,8 @@ describe('createHederaFungibleToken test suite', () => {
 
       expect(txRes.err).toBe('amount to mint cannot be negative when minting a fungible token');
       expect(txRes.transactionHash).toBeNull;
+      expect(txRes.mintedTokenEventData).toBeNull;
+      expect(txRes.transferTokenEventData).toBeNull;
     });
 
     it('should execute mintHederaTokenToAddress to mint a NON-FUNGIBLE token and transfer it to the recipient then return error when the amount to mint is a non-zero number', async () => {
@@ -640,6 +694,8 @@ describe('createHederaFungibleToken test suite', () => {
 
       expect(txRes.err).toBe('amount to mint must be 0 when minting a non-fungible token');
       expect(txRes.transactionHash).toBeNull;
+      expect(txRes.mintedTokenEventData).toBeNull;
+      expect(txRes.transferTokenEventData).toBeNull;
     });
   });
 

--- a/system-contract-dapp-playground/__tests__/hedera/hts-interactions/index.test.ts
+++ b/system-contract-dapp-playground/__tests__/hedera/hts-interactions/index.test.ts
@@ -19,6 +19,7 @@
  */
 
 import {
+  associateHederaTokensToAccounts,
   createHederaFungibleToken,
   createHederaNonFungibleToken,
   mintHederaToken,
@@ -32,6 +33,7 @@ describe('createHederaFungibleToken test suite', () => {
   const recipient = '0x34810E139b451e0a4c67d5743E956Ac8990842A8';
   const tokenAddress = '0x00000000000000000000000000000000000084b7';
   const feeTokenAddress = '0x00000000000000000000000000000000000006Ab';
+  const associtingAccount = '0x34810E139b451e0a4c67d5743E956Ac8990842A8';
   const txHash = '0x63424020a69bf46a0669f46dd66addba741b9c02d37fab1686428f5209bc759d';
   const returnedTokenAddress = '0x00000000000000000000000000000000000000000000000000000000000084b7';
   const tokenName = 'WrappedHbar';
@@ -108,6 +110,16 @@ describe('createHederaFungibleToken test suite', () => {
       }),
     }),
     mintNonFungibleTokenToAddressPublic: jest.fn().mockResolvedValue({
+      wait: jest.fn().mockResolvedValue({
+        hash: txHash,
+      }),
+    }),
+    associateTokenPublic: jest.fn().mockResolvedValue({
+      wait: jest.fn().mockResolvedValue({
+        hash: txHash,
+      }),
+    }),
+    associateTokensPublic: jest.fn().mockResolvedValue({
       wait: jest.fn().mockResolvedValue({
         hash: txHash,
       }),
@@ -620,6 +632,60 @@ describe('createHederaFungibleToken test suite', () => {
       );
 
       expect(txRes.err).toBe('amount to mint must be 0 when minting a non-fungible token');
+      expect(txRes.transactionHash).toBeNull;
+    });
+  });
+
+  describe('associateHederaTokensToAccounts', () => {
+    it('should execute associateHederaTokensToAccounts to associate a token to an account then return a transaction hash', async () => {
+      const txRes = await associateHederaTokensToAccounts(
+        baseContract as unknown as Contract,
+        [tokenAddress],
+        associtingAccount
+      );
+      expect(txRes.err).toBeNull;
+      expect(txRes.transactionHash).toBe(txHash);
+    });
+
+    it('should execute associateHederaTokensToAccounts to associate a list of tokens to an account then return a transaction hash', async () => {
+      const txRes = await associateHederaTokensToAccounts(
+        baseContract as unknown as Contract,
+        [tokenAddress, feeTokenAddress],
+        associtingAccount
+      );
+      expect(txRes.err).toBeNull;
+      expect(txRes.transactionHash).toBe(txHash);
+    });
+
+    it('should execute associateHederaTokensToAccounts and return an error when the hederaTokenAddresses array is empty', async () => {
+      const txRes = await associateHederaTokensToAccounts(
+        baseContract as unknown as Contract,
+        [],
+        associtingAccount
+      );
+      expect(txRes.err).toBe('must have at least one token address to associate');
+      expect(txRes.transactionHash).toBeNull;
+    });
+
+    it('should execute associateHederaTokensToAccounts and return an error when the associtingAccountAddress is invalid', async () => {
+      const txRes = await associateHederaTokensToAccounts(
+        baseContract as unknown as Contract,
+        [tokenAddress, feeTokenAddress],
+        '0xabc'
+      );
+      expect(txRes.err).toBe('associating account address is invalid');
+      expect(txRes.transactionHash).toBeNull;
+    });
+
+    it('should execute associateHederaTokensToAccounts and return an error when the hederaTokenAddresses array contains invalid token addresses', async () => {
+      const invalidTokenAddress = '0xaac';
+      const txRes = await associateHederaTokensToAccounts(
+        baseContract as unknown as Contract,
+        [tokenAddress, invalidTokenAddress],
+        associtingAccount
+      );
+
+      expect((txRes.err as any).invalidTokens).toStrictEqual([invalidTokenAddress]);
       expect(txRes.transactionHash).toBeNull;
     });
   });

--- a/system-contract-dapp-playground/__tests__/hedera/hts-interactions/index.test.ts
+++ b/system-contract-dapp-playground/__tests__/hedera/hts-interactions/index.test.ts
@@ -21,12 +21,15 @@
 import {
   createHederaFungibleToken,
   createHederaNonFungibleToken,
+  mintHederaToken,
+  mintHederaTokenToAddress,
 } from '@/api/hedera/tokenCreateCustom-interactions';
 import { Contract } from 'ethers';
 
 describe('createHederaFungibleToken test suite', () => {
   // mock states
   const contractId = '0xbdcdf69052c9fc01e38377d05cc83c28ee43f24a';
+  const recipient = '0x34810E139b451e0a4c67d5743E956Ac8990842A8';
   const tokenAddress = '0x00000000000000000000000000000000000084b7';
   const feeTokenAddress = '0x00000000000000000000000000000000000006Ab';
   const txHash = '0x63424020a69bf46a0669f46dd66addba741b9c02d37fab1686428f5209bc759d';
@@ -94,6 +97,21 @@ describe('createHederaFungibleToken test suite', () => {
         hash: txHash,
       }),
     }),
+    mintTokenPublic: jest.fn().mockResolvedValue({
+      wait: jest.fn().mockResolvedValue({
+        hash: txHash,
+      }),
+    }),
+    mintTokenToAddressPublic: jest.fn().mockResolvedValue({
+      wait: jest.fn().mockResolvedValue({
+        hash: txHash,
+      }),
+    }),
+    mintNonFungibleTokenToAddressPublic: jest.fn().mockResolvedValue({
+      wait: jest.fn().mockResolvedValue({
+        hash: txHash,
+      }),
+    }),
   };
 
   // mock inputKeys with CommonKeyObject[] type
@@ -136,8 +154,8 @@ describe('createHederaFungibleToken test suite', () => {
   ];
 
   describe('createHederaFungibleToken', () => {
-    it('should execute createHederaFungibleToken and return a token address', async () => {
-      const tokenCreateRes = await createHederaFungibleToken(
+    it('should execute createHederaFungibleToken then a token address and transaction hash', async () => {
+      const txRes = await createHederaFungibleToken(
         baseContract as unknown as Contract,
         tokenName,
         tokenSymbol,
@@ -151,13 +169,13 @@ describe('createHederaFungibleToken test suite', () => {
         msgValue
       );
 
-      expect(tokenCreateRes.err).toBeNull;
-      expect(tokenCreateRes.transactionHash).toBe(txHash);
-      expect(tokenCreateRes.tokenAddress).toBe(tokenAddress);
+      expect(txRes.err).toBeNull;
+      expect(txRes.transactionHash).toBe(txHash);
+      expect(txRes.tokenAddress).toBe(tokenAddress);
     });
 
-    it('should execute createFungibleTokenWithCustomFeesPublic and return a token address', async () => {
-      const tokenCreateRes = await createHederaFungibleToken(
+    it('should execute createFungibleTokenWithCustomFeesPublic then a token address and transaction hash', async () => {
+      const txRes = await createHederaFungibleToken(
         baseContract as unknown as Contract,
         tokenName,
         tokenSymbol,
@@ -172,13 +190,13 @@ describe('createHederaFungibleToken test suite', () => {
         feeTokenAddress
       );
 
-      expect(tokenCreateRes.err).toBeNull;
-      expect(tokenCreateRes.transactionHash).toBe(txHash);
-      expect(tokenCreateRes.tokenAddress).toBe(tokenAddress);
+      expect(txRes.err).toBeNull;
+      expect(txRes.transactionHash).toBe(txHash);
+      expect(txRes.tokenAddress).toBe(tokenAddress);
     });
 
     it('should execute createHederaFungibleToken and return error if initialTotalSupply is invalid', async () => {
-      const tokenCreateRes = await createHederaFungibleToken(
+      const txRes = await createHederaFungibleToken(
         baseContract as unknown as Contract,
         tokenName,
         tokenSymbol,
@@ -192,12 +210,12 @@ describe('createHederaFungibleToken test suite', () => {
         msgValue
       );
 
-      expect(tokenCreateRes.err).toBe('initial total supply cannot be negative');
-      expect(tokenCreateRes.tokenAddress).toBeNull;
+      expect(txRes.err).toBe('initial total supply cannot be negative');
+      expect(txRes.tokenAddress).toBeNull;
     });
 
     it('should execute createHederaFungibleToken and return error if maxSupply is invalid', async () => {
-      const tokenCreateRes = await createHederaFungibleToken(
+      const txRes = await createHederaFungibleToken(
         baseContract as unknown as Contract,
         tokenName,
         tokenSymbol,
@@ -211,12 +229,12 @@ describe('createHederaFungibleToken test suite', () => {
         msgValue
       );
 
-      expect(tokenCreateRes.err).toBe('max supply cannot be negative');
-      expect(tokenCreateRes.tokenAddress).toBeNull;
+      expect(txRes.err).toBe('max supply cannot be negative');
+      expect(txRes.tokenAddress).toBeNull;
     });
 
     it('should execute createHederaFungibleToken and return error if decimals is invalid', async () => {
-      const tokenCreateRes = await createHederaFungibleToken(
+      const txRes = await createHederaFungibleToken(
         baseContract as unknown as Contract,
         tokenName,
         tokenSymbol,
@@ -230,12 +248,12 @@ describe('createHederaFungibleToken test suite', () => {
         msgValue
       );
 
-      expect(tokenCreateRes.err).toBe('decimals cannot be negative');
-      expect(tokenCreateRes.tokenAddress).toBeNull;
+      expect(txRes.err).toBe('decimals cannot be negative');
+      expect(txRes.tokenAddress).toBeNull;
     });
 
     it('should execute createHederaFungibleToken and return error if treasury address does not match public address standard', async () => {
-      const tokenCreateRes = await createHederaFungibleToken(
+      const txRes = await createHederaFungibleToken(
         baseContract as unknown as Contract,
         tokenName,
         tokenSymbol,
@@ -249,12 +267,12 @@ describe('createHederaFungibleToken test suite', () => {
         msgValue
       );
 
-      expect(tokenCreateRes.err).toBe('invalid treasury address');
-      expect(tokenCreateRes.tokenAddress).toBeNull;
+      expect(txRes.err).toBe('invalid treasury address');
+      expect(txRes.tokenAddress).toBeNull;
     });
 
     it('should execute createHederaFungibleToken and return error if fee token address does not match public address standard', async () => {
-      const tokenCreateRes = await createHederaFungibleToken(
+      const txRes = await createHederaFungibleToken(
         baseContract as unknown as Contract,
         tokenName,
         tokenSymbol,
@@ -269,8 +287,8 @@ describe('createHederaFungibleToken test suite', () => {
         '0xabc'
       );
 
-      expect(tokenCreateRes.err).toBe('invalid fee token address');
-      expect(tokenCreateRes.tokenAddress).toBeNull;
+      expect(txRes.err).toBe('invalid fee token address');
+      expect(txRes.tokenAddress).toBeNull;
     });
 
     it('should execute createHederaFungibleToken and return error if inputKeys is invalid ', async () => {
@@ -292,7 +310,7 @@ describe('createHederaFungibleToken test suite', () => {
         },
       ];
 
-      const tokenCreateRes = await createHederaFungibleToken(
+      const txRes = await createHederaFungibleToken(
         baseContract as unknown as Contract,
         tokenName,
         tokenSymbol,
@@ -306,25 +324,25 @@ describe('createHederaFungibleToken test suite', () => {
         msgValue
       );
 
-      expect(tokenCreateRes.err.length).toBe(2);
+      expect(txRes.err.length).toBe(2);
 
-      expect(tokenCreateRes.err[0].keyType).toBe('ADMIN');
-      expect(tokenCreateRes.err[0].keyValueType).toBe('contractId');
-      expect(tokenCreateRes.err[0].keyValue).toBe('0xabc');
-      expect(tokenCreateRes.err[0].err).toBe('Invalid key value');
+      expect(txRes.err[0].keyType).toBe('ADMIN');
+      expect(txRes.err[0].keyValueType).toBe('contractId');
+      expect(txRes.err[0].keyValue).toBe('0xabc');
+      expect(txRes.err[0].err).toBe('Invalid key value');
 
-      expect(tokenCreateRes.err[1].keyType).toBe('FREEZE');
-      expect(tokenCreateRes.err[1].keyValueType).toBe('ECDSA_secp256k1');
-      expect(tokenCreateRes.err[1].keyValue).toBe('0x02bc');
-      expect(tokenCreateRes.err[1].err).toBe('Invalid key value');
+      expect(txRes.err[1].keyType).toBe('FREEZE');
+      expect(txRes.err[1].keyValueType).toBe('ECDSA_secp256k1');
+      expect(txRes.err[1].keyValue).toBe('0x02bc');
+      expect(txRes.err[1].err).toBe('Invalid key value');
 
-      expect(tokenCreateRes.tokenAddress).toBeNull;
+      expect(txRes.tokenAddress).toBeNull;
     });
   });
 
   describe('createHederaNonFungibleToken', () => {
-    it('should execute createHederaNonFungibleToken and return a token address', async () => {
-      const tokenCreateRes = await createHederaNonFungibleToken(
+    it('should execute createHederaNonFungibleToken then a token address and transaction hash', async () => {
+      const txRes = await createHederaNonFungibleToken(
         baseContract as unknown as Contract,
         tokenName,
         tokenSymbol,
@@ -335,13 +353,13 @@ describe('createHederaFungibleToken test suite', () => {
         msgValue
       );
 
-      expect(tokenCreateRes.err).toBeNull;
-      expect(tokenCreateRes.transactionHash).toBe(txHash);
-      expect(tokenCreateRes.tokenAddress).toBe(tokenAddress);
+      expect(txRes.err).toBeNull;
+      expect(txRes.transactionHash).toBe(txHash);
+      expect(txRes.tokenAddress).toBe(tokenAddress);
     });
 
-    it('should execute createFungibleTokenWithCustomFeesPublic and return a token address', async () => {
-      const tokenCreateRes = await createHederaNonFungibleToken(
+    it('should execute createFungibleTokenWithCustomFeesPublic then a token address and transaction hash', async () => {
+      const txRes = await createHederaNonFungibleToken(
         baseContract as unknown as Contract,
         tokenName,
         tokenSymbol,
@@ -353,13 +371,13 @@ describe('createHederaFungibleToken test suite', () => {
         feeTokenAddress
       );
 
-      expect(tokenCreateRes.err).toBeNull;
-      expect(tokenCreateRes.transactionHash).toBe(txHash);
-      expect(tokenCreateRes.tokenAddress).toBe(tokenAddress);
+      expect(txRes.err).toBeNull;
+      expect(txRes.transactionHash).toBe(txHash);
+      expect(txRes.tokenAddress).toBe(tokenAddress);
     });
 
     it('should execute createHederaNonFungibleToken and return error if maxSupply is invalid', async () => {
-      const tokenCreateRes = await createHederaNonFungibleToken(
+      const txRes = await createHederaNonFungibleToken(
         baseContract as unknown as Contract,
         tokenName,
         tokenSymbol,
@@ -370,12 +388,12 @@ describe('createHederaFungibleToken test suite', () => {
         msgValue
       );
 
-      expect(tokenCreateRes.err).toBe('max supply cannot be negative');
-      expect(tokenCreateRes.tokenAddress).toBeNull;
+      expect(txRes.err).toBe('max supply cannot be negative');
+      expect(txRes.tokenAddress).toBeNull;
     });
 
     it('should execute createHederaNonFungibleToken and return error if treasury address does not match public address standard', async () => {
-      const tokenCreateRes = await createHederaNonFungibleToken(
+      const txRes = await createHederaNonFungibleToken(
         baseContract as unknown as Contract,
         tokenName,
         tokenSymbol,
@@ -386,12 +404,12 @@ describe('createHederaFungibleToken test suite', () => {
         msgValue
       );
 
-      expect(tokenCreateRes.err).toBe('invalid treasury address');
-      expect(tokenCreateRes.tokenAddress).toBeNull;
+      expect(txRes.err).toBe('invalid treasury address');
+      expect(txRes.tokenAddress).toBeNull;
     });
 
     it('should execute createHederaNonFungibleToken and return error if fee token address does not match public address standard', async () => {
-      const tokenCreateRes = await createHederaNonFungibleToken(
+      const txRes = await createHederaNonFungibleToken(
         baseContract as unknown as Contract,
         tokenName,
         tokenSymbol,
@@ -403,8 +421,8 @@ describe('createHederaFungibleToken test suite', () => {
         '0xabc'
       );
 
-      expect(tokenCreateRes.err).toBe('invalid fee token address');
-      expect(tokenCreateRes.tokenAddress).toBeNull;
+      expect(txRes.err).toBe('invalid fee token address');
+      expect(txRes.tokenAddress).toBeNull;
     });
 
     it('should execute createHederaNonFungibleToken and return error if inputKeys is invalid ', async () => {
@@ -426,7 +444,7 @@ describe('createHederaFungibleToken test suite', () => {
         },
       ];
 
-      const tokenCreateRes = await createHederaNonFungibleToken(
+      const txRes = await createHederaNonFungibleToken(
         baseContract as unknown as Contract,
         tokenName,
         tokenSymbol,
@@ -437,19 +455,116 @@ describe('createHederaFungibleToken test suite', () => {
         msgValue
       );
 
-      expect(tokenCreateRes.err.length).toBe(2);
+      expect(txRes.err.length).toBe(2);
 
-      expect(tokenCreateRes.err[0].keyType).toBe('ADMIN');
-      expect(tokenCreateRes.err[0].keyValueType).toBe('contractId');
-      expect(tokenCreateRes.err[0].keyValue).toBe('0xabc');
-      expect(tokenCreateRes.err[0].err).toBe('Invalid key value');
+      expect(txRes.err[0].keyType).toBe('ADMIN');
+      expect(txRes.err[0].keyValueType).toBe('contractId');
+      expect(txRes.err[0].keyValue).toBe('0xabc');
+      expect(txRes.err[0].err).toBe('Invalid key value');
 
-      expect(tokenCreateRes.err[1].keyType).toBe('FREEZE');
-      expect(tokenCreateRes.err[1].keyValueType).toBe('ECDSA_secp256k1');
-      expect(tokenCreateRes.err[1].keyValue).toBe('0x02bc');
-      expect(tokenCreateRes.err[1].err).toBe('Invalid key value');
+      expect(txRes.err[1].keyType).toBe('FREEZE');
+      expect(txRes.err[1].keyValueType).toBe('ECDSA_secp256k1');
+      expect(txRes.err[1].keyValue).toBe('0x02bc');
+      expect(txRes.err[1].err).toBe('Invalid key value');
 
-      expect(tokenCreateRes.tokenAddress).toBeNull;
+      expect(txRes.tokenAddress).toBeNull;
+    });
+  });
+
+  describe('mintHederaToken', () => {
+    it('should execute mintTokenPublic to mint a FUNGIBLE token then return a transaction hash', async () => {
+      const txRes = await mintHederaToken(
+        baseContract as unknown as Contract,
+        'FUNGIBLE',
+        tokenAddress,
+        1200,
+        'metadata'
+      );
+
+      expect(txRes.err).toBeNull;
+      expect(txRes.transactionHash).toBe(txHash);
+    });
+
+    it('should execute mintTokenPublic to mint a NON-FUNGIBLE token then return a transaction hash', async () => {
+      const txRes = await mintHederaToken(
+        baseContract as unknown as Contract,
+        'NON_FUNGIBLE',
+        tokenAddress,
+        0,
+        'metadata'
+      );
+
+      expect(txRes.err).toBeNull;
+      expect(txRes.transactionHash).toBe(txHash);
+    });
+
+    it('should execute mintTokenPublic to mint a Hedera token and return error when the hederaTokenAddress is invalid', async () => {
+      const txRes = await mintHederaToken(
+        baseContract as unknown as Contract,
+        'FUNGIBLE',
+        '0xabc',
+        1200,
+        'metadata'
+      );
+
+      expect(txRes.err).toBe('invalid Hedera token address');
+      expect(txRes.transactionHash).toBeNull;
+    });
+
+    it('should execute mintTokenPublic to mint a FUNGIBLE token and return error when the amount to mint is a negative number', async () => {
+      const txRes = await mintHederaToken(
+        baseContract as unknown as Contract,
+        'FUNGIBLE',
+        tokenAddress,
+        -1,
+        'metadata'
+      );
+
+      expect(txRes.err).toBe('amount to mint cannot be negative when minting a fungible token');
+      expect(txRes.transactionHash).toBeNull;
+    });
+
+    it('should execute mintTokenPublic to mint a NON-FUNGIBLE token and return error when the amount to mint is a non-zero number', async () => {
+      const txRes = await mintHederaToken(
+        baseContract as unknown as Contract,
+        'NON_FUNGIBLE',
+        tokenAddress,
+        1,
+        'metadata'
+      );
+
+      expect(txRes.err).toBe('amount to mint must be 0 when minting a non-fungible token');
+      expect(txRes.transactionHash).toBeNull;
+    });
+  });
+
+
+    it('should execute mintHederaTokenToAddress to mint a FUNGIBLE token and transfer it to the recipient then return error when the amount to mint is a negative number', async () => {
+      const txRes = await mintHederaTokenToAddress(
+        baseContract as unknown as Contract,
+        'FUNGIBLE',
+        tokenAddress,
+        recipient,
+        -1,
+        'metadata'
+      );
+
+      expect(txRes.err).toBe('amount to mint cannot be negative when minting a fungible token');
+      expect(txRes.transactionHash).toBeNull;
+    });
+
+    it('should execute mintHederaTokenToAddress to mint a NON-FUNGIBLE token and transfer it to the recipient then return error when the amount to mint is a non-zero number', async () => {
+      const txRes = await mintHederaTokenToAddress(
+        baseContract as unknown as Contract,
+        'NON_FUNGIBLE',
+        tokenAddress,
+        recipient,
+        1,
+        'metadata'
+      );
+
+      expect(txRes.err).toBe('amount to mint must be 0 when minting a non-fungible token');
+      expect(txRes.transactionHash).toBeNull;
     });
   });
 });

--- a/system-contract-dapp-playground/__tests__/hedera/hts-interactions/index.test.ts
+++ b/system-contract-dapp-playground/__tests__/hedera/hts-interactions/index.test.ts
@@ -22,6 +22,7 @@ import {
   associateHederaTokensToAccounts,
   createHederaFungibleToken,
   createHederaNonFungibleToken,
+  grantTokenKYCToAccount,
   mintHederaToken,
   mintHederaTokenToAddress,
 } from '@/api/hedera/tokenCreateCustom-interactions';
@@ -34,6 +35,7 @@ describe('createHederaFungibleToken test suite', () => {
   const tokenAddress = '0x00000000000000000000000000000000000084b7';
   const feeTokenAddress = '0x00000000000000000000000000000000000006Ab';
   const associtingAccount = '0x34810E139b451e0a4c67d5743E956Ac8990842A8';
+  const grantingKYCAccount = '0x34810E139b451e0a4c67d5743E956Ac8990842A8';
   const txHash = '0x63424020a69bf46a0669f46dd66addba741b9c02d37fab1686428f5209bc759d';
   const returnedTokenAddress = '0x00000000000000000000000000000000000000000000000000000000000084b7';
   const tokenName = 'WrappedHbar';
@@ -120,6 +122,11 @@ describe('createHederaFungibleToken test suite', () => {
       }),
     }),
     associateTokensPublic: jest.fn().mockResolvedValue({
+      wait: jest.fn().mockResolvedValue({
+        hash: txHash,
+      }),
+    }),
+    grantTokenKycPublic: jest.fn().mockResolvedValue({
       wait: jest.fn().mockResolvedValue({
         hash: txHash,
       }),
@@ -686,6 +693,38 @@ describe('createHederaFungibleToken test suite', () => {
       );
 
       expect((txRes.err as any).invalidTokens).toStrictEqual([invalidTokenAddress]);
+      expect(txRes.transactionHash).toBeNull;
+    });
+  });
+
+  describe('grantTokenKYCToAccount', () => {
+    it('should execute grantTokenKYCToAccount to associate a token KYC to an account then return a transaction hash', async () => {
+      const txRes = await grantTokenKYCToAccount(
+        baseContract as unknown as Contract,
+        tokenAddress,
+        grantingKYCAccount
+      );
+      expect(txRes.err).toBeNull;
+      expect(txRes.transactionHash).toBe(txHash);
+    });
+
+    it('should execute grantTokenKYCToAccount to associate a token KYC to an account then return error when hederaTokenAddress is invalid', async () => {
+      const txRes = await grantTokenKYCToAccount(
+        baseContract as unknown as Contract,
+        '0xabc',
+        grantingKYCAccount
+      );
+      expect(txRes.err).toBe('invalid Hedera token address');
+      expect(txRes.transactionHash).toBeNull;
+    });
+
+    it('should execute grantTokenKYCToAccount to associate a token KYC to an account then return error when grantingKYCAccountAddress is invalid', async () => {
+      const txRes = await grantTokenKYCToAccount(
+        baseContract as unknown as Contract,
+        tokenAddress,
+        '0xabc'
+      );
+      expect(txRes.err).toBe('invalid associating account address');
       expect(txRes.transactionHash).toBeNull;
     });
   });

--- a/system-contract-dapp-playground/__tests__/hedera/hts-interactions/index.test.ts
+++ b/system-contract-dapp-playground/__tests__/hedera/hts-interactions/index.test.ts
@@ -30,8 +30,17 @@ import { Contract } from 'ethers';
 
 describe('createHederaFungibleToken test suite', () => {
   // mock states
-  const contractId = '0xbdcdf69052c9fc01e38377d05cc83c28ee43f24a';
+  const decimals = 8;
+  const tokenSymbol = 'WHBAR';
+  const tokenName = 'WrappedHbar';
+  const tokenMemo = 'Wrapped Hbar';
+  const freezeDefaultStatus = false;
+  const maxSupply = 30000000000; // 300 WHBAR
+  const initialSupply = 900000000; // 9 WHBAR
+  const metadata = ['Zeus', 'Athena', 'Apollo'];
+  const msgValue = '20000000000000000000'; // 20 hbar
   const recipient = '0x34810E139b451e0a4c67d5743E956Ac8990842A8';
+  const contractId = '0xbdcdf69052c9fc01e38377d05cc83c28ee43f24a';
   const tokenAddress = '0x00000000000000000000000000000000000084b7';
   const feeTokenAddress = '0x00000000000000000000000000000000000006Ab';
   const associtingAccount = '0x34810E139b451e0a4c67d5743E956Ac8990842A8';
@@ -42,14 +51,6 @@ describe('createHederaFungibleToken test suite', () => {
     '000000000000000000000000000000000000000000000000000000000000000900000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000';
   const returnedTransferTokenEvent =
     '0x000000000000000000000000000000000000000000000000000000000000abc700000000000000000000000034810e139b451e0a4c67d5743e956ac8990842a80000000000000000000000000000000000000000000000000000000000000001';
-  const tokenName = 'WrappedHbar';
-  const tokenSymbol = 'WHBAR';
-  const tokenMemo = 'Wrapped Hbar';
-  const initialSupply = 900000000; // 9 WHBAR
-  const maxSupply = 30000000000; // 300 WHBAR
-  const decimals = 8;
-  const freezeDefaultStatus = false;
-  const msgValue = '20000000000000000000'; // 20 hbar
 
   // mock baseContract object
   const baseContract = {
@@ -537,7 +538,7 @@ describe('createHederaFungibleToken test suite', () => {
         'FUNGIBLE',
         tokenAddress,
         1200,
-        'metadata'
+        metadata
       );
 
       expect(txRes.err).toBeNull;
@@ -551,7 +552,7 @@ describe('createHederaFungibleToken test suite', () => {
         'NON_FUNGIBLE',
         tokenAddress,
         0,
-        'metadata'
+        metadata
       );
 
       expect(txRes.err).toBeNull;
@@ -565,7 +566,7 @@ describe('createHederaFungibleToken test suite', () => {
         'FUNGIBLE',
         '0xabc',
         1200,
-        'metadata'
+        metadata
       );
 
       expect(txRes.err).toBe('invalid Hedera token address');
@@ -579,7 +580,7 @@ describe('createHederaFungibleToken test suite', () => {
         'FUNGIBLE',
         tokenAddress,
         -1,
-        'metadata'
+        metadata
       );
 
       expect(txRes.err).toBe('amount to mint cannot be negative when minting a fungible token');
@@ -592,7 +593,7 @@ describe('createHederaFungibleToken test suite', () => {
         'NON_FUNGIBLE',
         tokenAddress,
         1,
-        'metadata'
+        metadata
       );
 
       expect(txRes.err).toBe('amount to mint must be 0 when minting a non-fungible token');
@@ -609,7 +610,7 @@ describe('createHederaFungibleToken test suite', () => {
         tokenAddress,
         recipient,
         1200,
-        'metadata'
+        metadata
       );
 
       expect(txRes.err).toBeNull;
@@ -625,7 +626,7 @@ describe('createHederaFungibleToken test suite', () => {
         tokenAddress,
         recipient,
         0,
-        'metadata'
+        metadata
       );
 
       expect(txRes.err).toBeNull;
@@ -641,7 +642,7 @@ describe('createHederaFungibleToken test suite', () => {
         '0xabc',
         recipient,
         1200,
-        'metadata'
+        metadata
       );
 
       expect(txRes.err).toBe('invalid Hedera token address');
@@ -657,7 +658,7 @@ describe('createHederaFungibleToken test suite', () => {
         tokenAddress,
         '0xabc',
         1200,
-        'metadata'
+        metadata
       );
 
       expect(txRes.err).toBe('invalid recipient address');
@@ -673,7 +674,7 @@ describe('createHederaFungibleToken test suite', () => {
         tokenAddress,
         recipient,
         -1,
-        'metadata'
+        metadata
       );
 
       expect(txRes.err).toBe('amount to mint cannot be negative when minting a fungible token');
@@ -689,7 +690,7 @@ describe('createHederaFungibleToken test suite', () => {
         tokenAddress,
         recipient,
         1,
-        'metadata'
+        metadata
       );
 
       expect(txRes.err).toBe('amount to mint must be 0 when minting a non-fungible token');

--- a/system-contract-dapp-playground/__tests__/hedera/hts-interactions/index.test.ts
+++ b/system-contract-dapp-playground/__tests__/hedera/hts-interactions/index.test.ts
@@ -538,6 +538,62 @@ describe('createHederaFungibleToken test suite', () => {
     });
   });
 
+  describe('mintHederaTokenToAddress', () => {
+    it('should execute mintHederaTokenToAddress to mint a FUNGIBLE token and transfer it to the recipient then return a transaction hash', async () => {
+      const txRes = await mintHederaTokenToAddress(
+        baseContract as unknown as Contract,
+        'FUNGIBLE',
+        tokenAddress,
+        recipient,
+        1200,
+        'metadata'
+      );
+
+      expect(txRes.err).toBeNull;
+      expect(txRes.transactionHash).toBe(txHash);
+    });
+
+    it('should execute mintHederaTokenToAddress to mint a NON-FUNGIBLE token and transfer it to the recipient then return a transaction hash', async () => {
+      const txRes = await mintHederaTokenToAddress(
+        baseContract as unknown as Contract,
+        'NON_FUNGIBLE',
+        tokenAddress,
+        recipient,
+        0,
+        'metadata'
+      );
+
+      expect(txRes.err).toBeNull;
+      expect(txRes.transactionHash).toBe(txHash);
+    });
+
+    it('should execute mintHederaTokenToAddress to mint a Hedera token and transfer it to the recipient then return error when the hederaTokenAddress is invalid', async () => {
+      const txRes = await mintHederaTokenToAddress(
+        baseContract as unknown as Contract,
+        'FUNGIBLE',
+        '0xabc',
+        recipient,
+        1200,
+        'metadata'
+      );
+
+      expect(txRes.err).toBe('invalid Hedera token address');
+      expect(txRes.transactionHash).toBeNull;
+    });
+
+    it('should execute mintHederaTokenToAddress to mint a Hedera token and transfer it to the recipient then return error when the recipientAddress is invalid', async () => {
+      const txRes = await mintHederaTokenToAddress(
+        baseContract as unknown as Contract,
+        'FUNGIBLE',
+        tokenAddress,
+        '0xabc',
+        1200,
+        'metadata'
+      );
+
+      expect(txRes.err).toBe('invalid recipient address');
+      expect(txRes.transactionHash).toBeNull;
+    });
 
     it('should execute mintHederaTokenToAddress to mint a FUNGIBLE token and transfer it to the recipient then return error when the amount to mint is a negative number', async () => {
       const txRes = await mintHederaTokenToAddress(

--- a/system-contract-dapp-playground/src/api/hedera/tokenCreateCustom-interactions/index.ts
+++ b/system-contract-dapp-playground/src/api/hedera/tokenCreateCustom-interactions/index.ts
@@ -386,7 +386,7 @@ export const associateHederaTokensToAccounts = async (
   baseContract: Contract,
   hederaTokenAddresses: string[],
   associtingAccountAddress: string
-) => {
+): Promise<TokenCreateCustomSmartContractResult> => {
   // sanitize params
   if (hederaTokenAddresses.length === 0) {
     return { err: 'must have at least one token address to associate' };
@@ -422,6 +422,47 @@ export const associateHederaTokensToAccounts = async (
         }
       );
     }
+
+    const txReceipt = await tx.wait();
+
+    return { transactionHash: txReceipt.hash };
+  } catch (err) {
+    console.log(err);
+    return { err };
+  }
+};
+
+/**
+ * @dev grants token KYC to an account
+ *
+ * @dev integrates tokenCreateCustomContract.grantTokenKycPublic()
+ *
+ * @param baseContract: ethers.Contract
+ *
+ * @param hederaTokenAddress: string
+ *
+ * @param grantingKYCAccountAddress: string
+ *
+ * @return Promise<TokenCreateCustomSmartContractResult>
+ */
+export const grantTokenKYCToAccount = async (
+  baseContract: Contract,
+  hederaTokenAddress: string,
+  grantingKYCAccountAddress: string
+): Promise<TokenCreateCustomSmartContractResult> => {
+  // sanitize params
+  if (!isAddress(hederaTokenAddress)) {
+    return { err: 'invalid Hedera token address' };
+  } else if (!isAddress(grantingKYCAccountAddress)) {
+    return { err: 'invalid associating account address' };
+  }
+
+  try {
+    const tx = await baseContract.grantTokenKycPublic(
+      hederaTokenAddress,
+      grantingKYCAccountAddress,
+      { gasLimit: 1_000_000 }
+    );
 
     const txReceipt = await tx.wait();
 

--- a/system-contract-dapp-playground/src/api/hedera/tokenCreateCustom-interactions/index.ts
+++ b/system-contract-dapp-playground/src/api/hedera/tokenCreateCustom-interactions/index.ts
@@ -291,7 +291,11 @@ export const mintHederaToken = async (
 
     const txReceipt = await tx.wait();
 
-    return { transactionHash: txReceipt.hash };
+    const { data: mintedTokenData } = txReceipt.logs.filter(
+      (event: any) => event.fragment.name === 'MintedToken'
+    )[0];
+
+    return { transactionHash: txReceipt.hash, mintedTokenEventData: mintedTokenData };
   } catch (err: any) {
     console.error(err);
     return { err, transactionHash: err.receipt && err.receipt.hash };
@@ -362,7 +366,19 @@ export const mintHederaTokenToAddress = async (
 
     const txReceipt = await tx.wait();
 
-    return { transactionHash: txReceipt.hash };
+    const { data: mintedTokenData } = txReceipt.logs.filter(
+      (event: any) => event.fragment.name === 'MintedToken'
+    )[0];
+
+    const { data: transferTokenData } = txReceipt.logs.filter(
+      (event: any) => event.fragment.name === 'TransferToken'
+    )[0];
+
+    return {
+      transactionHash: txReceipt.hash,
+      mintedTokenEventData: mintedTokenData,
+      transferTokenEventData: transferTokenData,
+    };
   } catch (err: any) {
     console.error(err);
     return { err, transactionHash: err.receipt && err.receipt.hash };

--- a/system-contract-dapp-playground/src/api/hedera/tokenCreateCustom-interactions/index.ts
+++ b/system-contract-dapp-playground/src/api/hedera/tokenCreateCustom-interactions/index.ts
@@ -258,7 +258,7 @@ export const createHederaNonFungibleToken = async (
  *
  * @param amountToMint: number
  *
- * @param metadata: string
+ * @param metadata: string[]
  *
  * @return Promise<TokenCreateCustomSmartContractResult>
  */
@@ -267,7 +267,7 @@ export const mintHederaToken = async (
   tokenType: 'FUNGIBLE' | 'NON_FUNGIBLE',
   hederaTokenAddress: string,
   amountToMint: number,
-  metadata: string
+  metadata: string[]
 ): Promise<TokenCreateCustomSmartContractResult> => {
   // sanitize params
   if (!isAddress(hederaTokenAddress)) {
@@ -278,12 +278,15 @@ export const mintHederaToken = async (
     return { err: 'amount to mint must be 0 when minting a non-fungible token' };
   }
 
+  // convert metadata to Buffer[]
+  const bufferedMetadata = metadata.map((meta) => Buffer.from(meta));
+
   // execute .mintTokenPublic() method
   try {
     const tx = await baseContract.mintTokenPublic(
       hederaTokenAddress,
       amountToMint,
-      [Buffer.from(metadata)],
+      bufferedMetadata,
       {
         gasLimit: 1_000_000,
       }
@@ -317,7 +320,7 @@ export const mintHederaToken = async (
  *
  * @param amountToMint: number
  *
- * @param metadata: string
+ * @param metadata: string[]
  *
  * @return Promise<TokenCreateCustomSmartContractResult>
  */
@@ -327,7 +330,7 @@ export const mintHederaTokenToAddress = async (
   hederaTokenAddress: string,
   recipientAddress: string,
   amountToMint: number,
-  metadata: string
+  metadata: string[]
 ): Promise<TokenCreateCustomSmartContractResult> => {
   // sanitize params
   if (!isAddress(hederaTokenAddress)) {
@@ -340,6 +343,9 @@ export const mintHederaTokenToAddress = async (
     return { err: 'amount to mint must be 0 when minting a non-fungible token' };
   }
 
+  // convert metadata to Buffer[]
+  const bufferedMetadata = metadata.map((meta) => Buffer.from(meta));
+
   try {
     let tx;
     if (tokenType === 'FUNGIBLE') {
@@ -347,7 +353,7 @@ export const mintHederaTokenToAddress = async (
         hederaTokenAddress,
         recipientAddress,
         amountToMint,
-        [Buffer.from(metadata)],
+        bufferedMetadata,
         {
           gasLimit: 1_000_000,
         }
@@ -357,7 +363,7 @@ export const mintHederaTokenToAddress = async (
         hederaTokenAddress,
         recipientAddress,
         amountToMint,
-        [Buffer.from(metadata)],
+        bufferedMetadata,
         {
           gasLimit: 1_000_000,
         }

--- a/system-contract-dapp-playground/src/api/hedera/tokenCreateCustom-interactions/index.ts
+++ b/system-contract-dapp-playground/src/api/hedera/tokenCreateCustom-interactions/index.ts
@@ -136,9 +136,9 @@ export const createHederaFungibleToken = async (
     const tokenAddress = `0x${data.slice(-40)}`;
 
     return { tokenAddress, transactionHash: txReceipt.hash };
-  } catch (err) {
+  } catch (err: any) {
     console.error(err);
-    return { err };
+    return { err, transactionHash: err.receipt && err.receipt.hash };
   }
 };
 
@@ -239,9 +239,9 @@ export const createHederaNonFungibleToken = async (
     const tokenAddress = `0x${data.slice(-40)}`;
 
     return { tokenAddress, transactionHash: txReceipt.hash };
-  } catch (err) {
+  } catch (err: any) {
     console.error(err);
-    return { err };
+    return { err, transactionHash: err.receipt && err.receipt.hash };
   }
 };
 
@@ -292,9 +292,9 @@ export const mintHederaToken = async (
     const txReceipt = await tx.wait();
 
     return { transactionHash: txReceipt.hash };
-  } catch (err) {
+  } catch (err: any) {
     console.error(err);
-    return { err };
+    return { err, transactionHash: err.receipt && err.receipt.hash };
   }
 };
 
@@ -363,9 +363,9 @@ export const mintHederaTokenToAddress = async (
     const txReceipt = await tx.wait();
 
     return { transactionHash: txReceipt.hash };
-  } catch (err) {
+  } catch (err: any) {
     console.error(err);
-    return { err };
+    return { err, transactionHash: err.receipt && err.receipt.hash };
   }
 };
 
@@ -426,9 +426,9 @@ export const associateHederaTokensToAccounts = async (
     const txReceipt = await tx.wait();
 
     return { transactionHash: txReceipt.hash };
-  } catch (err) {
-    console.log(err);
-    return { err };
+  } catch (err: any) {
+    console.error(err);
+    return { err, transactionHash: err.receipt && err.receipt.hash };
   }
 };
 
@@ -467,8 +467,8 @@ export const grantTokenKYCToAccount = async (
     const txReceipt = await tx.wait();
 
     return { transactionHash: txReceipt.hash };
-  } catch (err) {
-    console.log(err);
-    return { err };
+  } catch (err: any) {
+    console.error(err);
+    return { err, transactionHash: err.receipt && err.receipt.hash };
   }
 };

--- a/system-contract-dapp-playground/src/api/hedera/tokenCreateCustom-interactions/index.ts
+++ b/system-contract-dapp-playground/src/api/hedera/tokenCreateCustom-interactions/index.ts
@@ -244,3 +244,56 @@ export const createHederaNonFungibleToken = async (
     return { err };
   }
 };
+
+/**
+ * @dev mints Hedera tokens
+ *
+ * @dev integrates tokenCreateCustomContract.mintTokenPublic()
+ *
+ * @param baseContract: ethers.Contract
+ *
+ * @param tokenType: 'FUNGIBLE' | 'NON_FUNGIBLE'
+ *
+ * @param hederaTokenAddress: string
+ *
+ * @param amountToMint: number
+ *
+ * @param metadata: string
+ *
+ * @return Promise<TokenCreateCustomSmartContractResult>
+ */
+export const mintHederaToken = async (
+  baseContract: Contract,
+  tokenType: 'FUNGIBLE' | 'NON_FUNGIBLE',
+  hederaTokenAddress: string,
+  amountToMint: number,
+  metadata: string
+): Promise<TokenCreateCustomSmartContractResult> => {
+  // sanitize params
+  if (!isAddress(hederaTokenAddress)) {
+    return { err: 'invalid Hedera token address' };
+  } else if (tokenType === 'FUNGIBLE' && amountToMint < 0) {
+    return { err: 'amount to mint cannot be negative when minting a fungible token' };
+  } else if (tokenType === 'NON_FUNGIBLE' && amountToMint !== 0) {
+    return { err: 'amount to mint must be 0 when minting a non-fungible token' };
+  }
+
+  // execute .mintTokenPublic() method
+  try {
+    const tx = await baseContract.mintTokenPublic(
+      hederaTokenAddress,
+      amountToMint,
+      [Buffer.from(metadata)],
+      {
+        gasLimit: 1_000_000,
+      }
+    );
+
+    const txReceipt = await tx.wait();
+
+    return { transactionHash: txReceipt.hash };
+  } catch (err) {
+    console.error(err);
+    return { err };
+  }
+};

--- a/system-contract-dapp-playground/src/types/contract-interactions/HTS/index.d.ts
+++ b/system-contract-dapp-playground/src/types/contract-interactions/HTS/index.d.ts
@@ -21,8 +21,9 @@
 /** @dev an interface for the results returned back from interacting with Hedera TokenCreateCustom smart contract */
 interface TokenCreateCustomSmartContractResult {
   tokenAddress?: string;
-  mintTokenRes?: boolean;
   transactionHash?: string;
+  mintedTokenEventData?: string;
+  transferTokenEventData?: string;
   err?: any;
 }
 /**


### PR DESCRIPTION
**Description**:
This PR adds a set of APIs and unit tests to support facilitating interacting with TokenCreateCustom contract. The methods exposed in this PR are

- mintTokenPublic()
- mintTokenToAddressPublic()
- mintNonFungibleTokenToAddressPublic()
- associateTokenPublic
- associateTokensPublic()
- grantTokenKycPublic()

**Related issue(s)**: #314

Fixes partial #316

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
