### PR TITLE
dapp-feat: added helper functions to help convert Proxy object into regular Typescript object for token query general information

### DIFF
--- a/system-contract-dapp-playground/__tests__/hedera/hts-interactions/token-query-contract/index.test.ts
+++ b/system-contract-dapp-playground/__tests__/hedera/hts-interactions/token-query-contract/index.test.ts
@@ -19,13 +19,26 @@
  */
 
 import {
-  queryTokenGeneralInfomation,
-  queryTokenPermissionInformation,
-  queryTokenRelationInformation,
-  queryTokenSpecificInfomation,
   queryTokenValidity,
+  queryTokenGeneralInfomation,
+  queryTokenSpecificInfomation,
+  queryTokenRelationInformation,
+  queryTokenPermissionInformation,
 } from '@/api/hedera/tokenQuery-interactions';
 import { Contract } from 'ethers';
+
+// mock convertsArgsProxyToHTSTokenInfo
+jest.mock('../../../../src/utils/contract-interactions/HTS/helpers.ts', () => {
+  const actualModule = jest.requireActual(
+    '../../../../src/utils/contract-interactions/HTS/helpers.ts'
+  );
+
+  return {
+    ...actualModule,
+    convertsArgsProxyToHTSTokenInfo: jest.fn().mockReturnValue('mockedEventReturnedValue'),
+    convertsArgsProxyToHTSSpecificInfo: jest.fn().mockReturnValue('mockedEventReturnedValue'),
+  };
+});
 
 describe('TokenQueryContract Test Suite', () => {
   // mock states
@@ -38,6 +51,24 @@ describe('TokenQueryContract Test Suite', () => {
   const txHash = '0x63424020a69bf46a0669f46dd66addba741b9c02d37fab1686428f5209bc759d';
 
   // prepare contract mocked value
+  const contractTokenInfoMockedResolvedValue = (eventName: string) => {
+    return jest.fn().mockResolvedValue({
+      wait: jest.fn().mockResolvedValue({
+        logs: [
+          {
+            fragment: {
+              name: eventName,
+            },
+            data: mockedEventReturnedValue,
+            args: {
+              tokenInfo: mockedEventReturnedValue,
+            },
+          },
+        ],
+        hash: txHash,
+      }),
+    });
+  };
   const contractMockedResolvedValue = (eventName: string) => {
     return jest.fn().mockResolvedValue({
       wait: jest.fn().mockResolvedValue({
@@ -47,6 +78,7 @@ describe('TokenQueryContract Test Suite', () => {
               name: eventName,
             },
             data: mockedEventReturnedValue,
+            args: mockedEventReturnedValue,
           },
         ],
         hash: txHash,
@@ -60,16 +92,16 @@ describe('TokenQueryContract Test Suite', () => {
     isFrozenPublic: contractMockedResolvedValue('Frozen'),
     isKycPublic: contractMockedResolvedValue('KycGranted'),
     getTokenKeyPublic: contractMockedResolvedValue('TokenKey'),
-    getTokenInfoPublic: contractMockedResolvedValue('TokenInfo'),
     getTokenTypePublic: contractMockedResolvedValue('TokenType'),
     allowancePublic: contractMockedResolvedValue('AllowanceValue'),
     isApprovedForAllPublic: contractMockedResolvedValue('Approved'),
     getApprovedPublic: contractMockedResolvedValue('ApprovedAddress'),
+    getTokenInfoPublic: contractTokenInfoMockedResolvedValue('TokenInfo'),
     getTokenCustomFeesPublic: contractMockedResolvedValue('TokenCustomFees'),
     getTokenExpiryInfoPublic: contractMockedResolvedValue('TokenExpiryInfo'),
-    getFungibleTokenInfoPublic: contractMockedResolvedValue('FungibleTokenInfo'),
-    getNonFungibleTokenInfoPublic: contractMockedResolvedValue('NonFungibleTokenInfo'),
     getTokenDefaultKycStatusPublic: contractMockedResolvedValue('TokenDefaultKycStatus'),
+    getFungibleTokenInfoPublic: contractTokenInfoMockedResolvedValue('FungibleTokenInfo'),
+    getNonFungibleTokenInfoPublic: contractTokenInfoMockedResolvedValue('NonFungibleTokenInfo'),
     getTokenDefaultFreezeStatusPublic: contractMockedResolvedValue('TokenDefaultFreezeStatus'),
   };
 
@@ -87,10 +119,10 @@ describe('TokenQueryContract Test Suite', () => {
   });
 
   describe('queryTokenGeneralInfomation test suite', () => {
-    it('should execute queryTokenGeneralInfomation wit API === "TOKEN_INFO" then return info value from event', async () => {
+    it('should execute queryTokenGeneralInfomation wit API === "TOKEN" then return info value from event', async () => {
       const txRes = await queryTokenGeneralInfomation(
         baseContract as unknown as Contract,
-        'TOKEN_INFO',
+        'TOKEN',
         hederaTokenAddress
       );
 
@@ -99,10 +131,10 @@ describe('TokenQueryContract Test Suite', () => {
       expect(txRes.TokenInfo).toBe(mockedEventReturnedValue);
     });
 
-    it('should execute queryTokenGeneralInfomation wit API === "FUNGIBLE_INFO" then return info value from event', async () => {
+    it('should execute queryTokenGeneralInfomation wit API === "FUNGIBLE" then return info value from event', async () => {
       const txRes = await queryTokenGeneralInfomation(
         baseContract as unknown as Contract,
-        'FUNGIBLE_INFO',
+        'FUNGIBLE',
         hederaTokenAddress
       );
 
@@ -111,10 +143,10 @@ describe('TokenQueryContract Test Suite', () => {
       expect(txRes.FungibleTokenInfo).toBe(mockedEventReturnedValue);
     });
 
-    it('should execute queryTokenGeneralInfomation wit API === "NON_FUNFIBLE_INFO" then return info value from event', async () => {
+    it('should execute queryTokenGeneralInfomation wit API === "NON_FUNFIBLE" then return info value from event', async () => {
       const txRes = await queryTokenGeneralInfomation(
         baseContract as unknown as Contract,
-        'NON_FUNFIBLE_INFO',
+        'NON_FUNFIBLE',
         hederaTokenAddress,
         serialNumber
       );

--- a/system-contract-dapp-playground/src/api/hedera/tokenQuery-interactions/index.ts
+++ b/system-contract-dapp-playground/src/api/hedera/tokenQuery-interactions/index.ts
@@ -24,7 +24,11 @@ import {
 } from '@/types/contract-interactions/HTS';
 import { Contract, isAddress } from 'ethers';
 import { KEY_TYPE_MAP } from '@/utils/contract-interactions/HTS/token-create-custom/constant';
-import { handleContractResponseWithDynamicEventNames } from '@/utils/contract-interactions/HTS/helpers';
+import {
+  convertsArgsProxyToHTSSpecificInfo,
+  convertsArgsProxyToHTSTokenInfo,
+  handleContractResponseWithDynamicEventNames,
+} from '@/utils/contract-interactions/HTS/helpers';
 
 /**
  * @dev queries token validity
@@ -82,7 +86,7 @@ export const queryTokenValidity = async (
  */
 export const queryTokenGeneralInfomation = async (
   baseContract: Contract,
-  API: 'TOKEN_INFO' | 'FUNGIBLE_INFO' | 'NON_FUNFIBLE_INFO',
+  API: 'TOKEN' | 'FUNGIBLE' | 'NON_FUNFIBLE',
   hederaTokenAddress: string,
   serialNumber?: number
 ): Promise<TokenQuerySmartContractResult> => {
@@ -97,27 +101,27 @@ export const queryTokenGeneralInfomation = async (
 
   // prepare events map
   const eventMaps = {
-    TOKEN_INFO: 'TokenInfo',
-    FUNGIBLE_INFO: 'FungibleTokenInfo',
-    NON_FUNFIBLE_INFO: 'NonFungibleTokenInfo',
+    TOKEN: 'TokenInfo',
+    FUNGIBLE: 'FungibleTokenInfo',
+    NON_FUNFIBLE: 'NonFungibleTokenInfo',
   };
 
   // invoking contract methods
   try {
     let transactionResult;
     switch (API) {
-      case 'TOKEN_INFO':
+      case 'TOKEN':
         // prepare transaction
         transactionResult = await baseContract.getTokenInfoPublic(hederaTokenAddress);
         break;
-      case 'FUNGIBLE_INFO':
+      case 'FUNGIBLE':
         // prepare transaction
         transactionResult = await baseContract.getFungibleTokenInfoPublic(hederaTokenAddress);
         break;
-      case 'NON_FUNFIBLE_INFO':
+      case 'NON_FUNFIBLE':
         if (!serialNumber) {
-          console.error('Serial number is needed for querying NON_FUNGIBLE_INFO');
-          return { err: 'Serial number is needed for querying NON_FUNGIBLE_INFO' };
+          console.error('Serial number is needed for querying NON_FUNGIBLE');
+          return { err: 'Serial number is needed for querying NON_FUNGIBLE' };
         } else {
           // prepare transaction
           transactionResult = await baseContract.getNonFungibleTokenInfoPublic(
@@ -128,7 +132,18 @@ export const queryTokenGeneralInfomation = async (
         break;
     }
 
-    return await handleContractResponseWithDynamicEventNames(transactionResult, eventMaps, API);
+    // get transaction receipt
+    const txReceipt = await transactionResult.wait();
+
+    // retrieve information from event
+    const { args } = txReceipt.logs.filter(
+      (event: any) => event.fragment.name === eventMaps[API]
+    )[0];
+
+    return {
+      [eventMaps[API]]: convertsArgsProxyToHTSTokenInfo(args.tokenInfo, API),
+      transactionHash: txReceipt.hash,
+    };
   } catch (err: any) {
     console.error(err);
     return { err, transactionHash: err.receipt && err.receipt.hash };
@@ -214,8 +229,8 @@ export const queryTokenSpecificInfomation = async (
         break;
       case 'TOKEN_KEYS':
         if (!keyType) {
-          console.error('Key Type is needed for querying NON_FUNGIBLE_INFO');
-          return { err: 'Key Type is needed for querying NON_FUNGIBLE_INFO' };
+          console.error('Key Type is needed for querying NON_FUNGIBLE');
+          return { err: 'Key Type is needed for querying NON_FUNGIBLE' };
         } else {
           transactionResult = await baseContract.getTokenKeyPublic(
             hederaTokenAddress,
@@ -225,7 +240,20 @@ export const queryTokenSpecificInfomation = async (
         break;
     }
 
-    return await handleContractResponseWithDynamicEventNames(transactionResult, eventMaps, API);
+    // get transaction receipt
+    const txReceipt = await transactionResult.wait();
+
+    // retrieve information from event
+    const tokenInfoResult = txReceipt.logs.filter(
+      (event: any) => event.fragment.name === eventMaps[API]
+    )[0];
+
+    if (API === 'DEFAULT_FREEZE_STATUS' || API === 'DEFAULT_KYC_STATUS' || API === 'TOKEN_TYPE') {
+      return { [eventMaps[API]]: tokenInfoResult.data, transactionHash: txReceipt.hash };
+    } else {
+      const tokenInfo = convertsArgsProxyToHTSSpecificInfo(tokenInfoResult.args, API);
+      return { [eventMaps[API]]: tokenInfo, transactionHash: txReceipt.hash };
+    }
   } catch (err: any) {
     console.error(err);
     return { err, transactionHash: err.receipt && err.receipt.hash };

--- a/system-contract-dapp-playground/src/types/contract-interactions/HTS/index.d.ts
+++ b/system-contract-dapp-playground/src/types/contract-interactions/HTS/index.d.ts
@@ -22,10 +22,16 @@
 export type TransactionResult = {
   status: 'sucess' | 'fail';
   txHash: string;
+  APICalled?: any;
   isToken?: boolean;
+  keyTypeCalled?: any;
   tokenAddress?: string;
   accountAddress?: string;
   tokenAddresses?: string[];
+  tokenInfo?:
+    | IHederaTokenServiceTokenInfo
+    | IHederaTokenServiceFungibleTokenInfo
+    | IHederaTokenServiceNonFungibleTokenInfo;
 };
 
 /** @dev an interface for the results returned back from interacting with Hedera TokenCreateCustom smart contract */
@@ -51,17 +57,17 @@ interface TokenQuerySmartContractResult {
   Approved?: any;
   TokenKey?: any;
   TokenType?: any;
-  TokenInfo?: any;
   KycGranted?: any;
   AllowanceValue?: any;
   ApprovedAddress?: any;
   TokenCustomFees?: any;
   TokenExpiryInfo?: any;
-  FungibleTokenInfo?: any;
   transactionHash?: string;
-  NonFungibleTokenInfo?: any;
   TokenDefaultKycStatus?: any;
   TokenDefaultFreezeStatus?: any;
+  TokenInfo?: IHederaTokenServiceTokenInfo;
+  FungibleTokenInfo?: IHederaTokenServiceFungibleTokenInfo;
+  NonFungibleTokenInfo?: IHederaTokenServiceNonFungibleTokenInfo;
   err?: any;
 }
 
@@ -196,4 +202,154 @@ interface IHederaTokenServiceHederaToken {
   freezeDefault: boolean;
   tokenKeys: IHederaTokenServiceTokenKey[];
   expiry: IHederaTokenServiceExpiry;
+}
+
+/**
+ * @dev an interface that adheres to the IHederaTokenService.FixedFee
+ *
+ * @param amount: number;
+ *
+ * @param tokenId: string;
+ *
+ * @param useHbarsForPayment: boolean;
+ *
+ * @param  useCurrentTokenForPayment: boolean;
+ *
+ * @param feeCollector: string;
+ *
+ * @see https://github.com/hashgraph/hedera-smart-contracts/blob/main/contracts/hts-precompile/IHederaTokenService.sol#L236
+ */
+interface IHederaTokenServiceFixedFee {
+  amount: number;
+  tokenId: string;
+  useHbarsForPayment: boolean;
+  useCurrentTokenForPayment: boolean;
+  feeCollector: string;
+}
+
+/**
+ * @dev an interface that adheres to the IHederaTokenService.FractionalFee
+ *
+ * @param numerator: number;
+ *
+ * @param denominator: number;
+ *
+ * @param minimumAmount: number;
+ *
+ * @param maximumAmount: number;
+ *
+ * @param netOfTransfers: boolean;
+ *
+ * @param feeCollector: string;
+ *
+ * @see https://github.com/hashgraph/hedera-smart-contracts/blob/main/contracts/hts-precompile/IHederaTokenService.sol#L256
+ */
+interface IHederaTokenServiceFractionalFee {
+  numerator: number;
+  denominator: number;
+  minimumAmount: number;
+  maximumAmount: number;
+  netOfTransfers: boolean;
+  feeCollector: string;
+}
+
+/**
+ * @dev an interface that adheres to the IHederaTokenService.RoyaltyFee
+ *
+ * @param numerator: number;
+ *
+ * @param denominator: number;
+ *
+ * @param amount?: number;
+ *
+ * @param tokenId?: string;
+ *
+ * @param useHbarsForPayment: boolean;
+ *
+ * @param feeCollector: string;
+ *
+ * @see https://github.com/hashgraph/hedera-smart-contracts/blob/main/contracts/hts-precompile/IHederaTokenService.sol#L279
+ */
+interface IHederaTokenServiceRoyaltyFee {
+  numerator: number;
+  denominator: number;
+  amount?: number;
+  tokenId?: string;
+  useHbarsForPayment: boolean;
+  feeCollector: string;
+}
+
+/**
+ * @dev an interface that adheres to the IHederaTokenService.TokenInfo
+ *
+ * @param token: IHederaTokenServiceHederaToken;
+ *
+ * @param totalSupply: number;
+ *
+ * @param deleted: boolean;
+ *
+ * @param defaultKycStatus: boolean;
+ *
+ * @param pauseStatus: boolean;
+ *
+ * @Param fixedFees: FixedFee[];
+ *
+ * @param fraztiofractionalFees: FractionalFee[];
+ *
+ * @param royaltyFees: RoyaltyFee[];
+ *
+ * @param ledgerId: string;
+ *
+ * @see https://github.com/hashgraph/hedera-smart-contracts/blob/main/contracts/hts-precompile/IHederaTokenService.sol#L173
+ */
+interface IHederaTokenServiceTokenInfo {
+  token: IHederaTokenServiceHederaToken;
+  totalSupply: number;
+  deleted: boolean;
+  defaultKycStatus: boolean;
+  pauseStatus: boolean;
+  fixedFees: IHederaTokenServiceFixedFee[];
+  fractionalFees: IHederaTokenServiceFractionalFee[];
+  royaltyFees: IHederaTokenServiceRoyaltyFee[];
+  ledgerId: string;
+}
+
+/**
+ * @dev an interface that adheres to the IHederaTokenService.FungibleTokenInfo
+ *
+ * @param tokenInfo: IHederaTokenServiceTokenInfo;
+ *
+ * @param decimals: number;
+ *
+ * @see https://github.com/hashgraph/hedera-smart-contracts/blob/main/contracts/hts-precompile/IHederaTokenService.sol#L203
+ */
+interface IHederaTokenServiceFungibleTokenInfo {
+  tokenInfo: IHederaTokenServiceTokenInfo;
+  decimals: number;
+}
+
+/**
+ * @dev an interface that adheres to the IHederaTokenService.NonFungibleTokenInfo
+ *
+ * @param tokenInfo: IHederaTokenServiceTokenInfo;
+ *
+ * @param serialNumber: number;
+ *
+ * @param ownerId: string;
+ *
+ * @param creationTime: number;
+ *
+ * @param metadata: Uint8Array
+ *
+ * @param spenderId: string
+ *
+ * @see https://github.com/hashgraph/hedera-smart-contracts/blob/main/contracts/hts-precompile/IHederaTokenService.sol#L212
+ */
+interface IHederaTokenServiceNonFungibleTokenInfo {
+  tokenInfo: IHederaTokenServiceTokenInfo;
+  serialNumber: number;
+  ownerId: string;
+  creationTime: number;
+  metadata: Uint8Array;
+  spenderId: string;
 }

--- a/system-contract-dapp-playground/src/utils/contract-interactions/HTS/helpers.ts
+++ b/system-contract-dapp-playground/src/utils/contract-interactions/HTS/helpers.ts
@@ -18,13 +18,30 @@
  *
  */
 
+import {
+  EXPIRY_KEYS,
+  KEY_VALUE_KEYS,
+  FIXED_FEES_KEYS,
+  CUSTOM_FEES_KEYS,
+  TOKEN_INFO_NFT_KEYS,
+  FRACTIONAL_FEES_KEYS,
+  TOKEN_INFO_BASIC_KEYS,
+  TOKEN_INFO_ADVANCED_KEYS,
+} from './token-query/constant';
 import { isAddress } from 'ethers';
 import {
   CommonKeyObject,
+  IHederaTokenServiceExpiry,
   IHederaTokenServiceKeyType,
   IHederaTokenServiceTokenKey,
+  IHederaTokenServiceFixedFee,
+  IHederaTokenServiceTokenInfo,
+  IHederaTokenServiceRoyaltyFee,
   IHederaTokenServiceKeyValueType,
   TokenManagementSmartContractResult,
+  IHederaTokenServiceFractionalFee,
+  IHederaTokenServiceFungibleTokenInfo,
+  IHederaTokenServiceNonFungibleTokenInfo,
 } from '@/types/contract-interactions/HTS';
 import { KEY_TYPE_MAP, DEFAULT_IHTS_KEY_VALUE } from './token-create-custom/constant';
 
@@ -168,4 +185,118 @@ export const handleContractResponseWithDynamicEventNames = async (
   // retrieve information from event
   const { data } = txReceipt.logs.filter((event: any) => event.fragment.name === eventMaps[API])[0];
   return { [eventMaps[API]]: data, transactionHash: txReceipt.hash };
+};
+
+/**
+ * @dev convert an `args` Proxy object returned from events to HTS Token Info object
+ *
+ * @notice applicable for QueryGeneralInfo APIs
+ */
+export const convertsArgsProxyToHTSTokenInfo = (
+  proxyObj: any,
+  API: 'TOKEN' | 'FUNGIBLE' | 'NON_FUNFIBLE'
+) => {
+  // prepare states
+  const htsTokenInfoKeys = ['token', ...TOKEN_INFO_ADVANCED_KEYS];
+  const htsNFTTokenInfoKeys = ['tokenInfo', ...TOKEN_INFO_NFT_KEYS];
+  const commonProxyObject = API === 'TOKEN' ? proxyObj : proxyObj.tokenInfo;
+  const htsTokenInfo = {} as any;
+  htsTokenInfoKeys.forEach((key) => {
+    if (key === 'token') {
+      const htsHederaToken = {} as any;
+      TOKEN_INFO_BASIC_KEYS.forEach((key) => {
+        const value = commonProxyObject.token[key];
+        htsHederaToken[key] = typeof value === 'bigint' ? value.toString() : value;
+      });
+      htsTokenInfo[key] = htsHederaToken;
+    } else {
+      const value = commonProxyObject[key];
+      htsTokenInfo[key] = typeof value === 'bigint' ? value.toString() : value;
+    }
+  });
+
+  switch (API) {
+    case 'TOKEN': {
+      return htsTokenInfo as IHederaTokenServiceTokenInfo;
+    }
+    case 'FUNGIBLE': {
+      const htsFungibleTokenInfo = {
+        tokenInfo: htsTokenInfo as IHederaTokenServiceTokenInfo,
+        decimals: Number(proxyObj.decimals.toString()),
+      };
+
+      return htsFungibleTokenInfo as IHederaTokenServiceFungibleTokenInfo;
+    }
+    case 'NON_FUNFIBLE': {
+      const htsNonFungibleTokenInfo = {} as any;
+      htsNFTTokenInfoKeys.forEach((key) => {
+        if (key === 'tokenInfo') {
+          htsNonFungibleTokenInfo[key] = htsTokenInfo as IHederaTokenServiceTokenInfo;
+        } else {
+          const value = proxyObj[key];
+          htsNonFungibleTokenInfo[key] = typeof value === 'bigint' ? value.toString() : value;
+        }
+      });
+      return htsNonFungibleTokenInfo as IHederaTokenServiceNonFungibleTokenInfo;
+    }
+  }
+};
+
+/**
+ * @dev convert an `args` Proxy object returned from events to HTS FEES/KEYS/EXPIRY info
+ *
+ * @notice applicable for QuerySpecificInfo APIs
+ */
+export const convertsArgsProxyToHTSSpecificInfo = (
+  proxyObj: any,
+  API: 'CUSTOM_FEES' | 'TOKEN_EXPIRY' | 'TOKEN_KEYS'
+) => {
+  // prepare states
+
+  switch (API) {
+    case 'CUSTOM_FEES':
+      let htsFeesInfo = {
+        fixedFees: [] as IHederaTokenServiceFixedFee[],
+        fractionalFees: [] as IHederaTokenServiceFractionalFee[],
+        royaltyFees: [] as IHederaTokenServiceRoyaltyFee[],
+      };
+
+      CUSTOM_FEES_KEYS.forEach((customFeesKey) => {
+        proxyObj[customFeesKey].forEach((fee: any) => {
+          const customFee = {} as any;
+          let keysArray = [];
+          if (customFeesKey === 'fixedFees') {
+            keysArray = FIXED_FEES_KEYS;
+          } else if (customFeesKey === 'fractionalFees') {
+            keysArray = FRACTIONAL_FEES_KEYS;
+          } else {
+            keysArray = FRACTIONAL_FEES_KEYS;
+          }
+          keysArray.forEach((key: any) => {
+            const value = fee[key];
+            customFee[key] = typeof value === 'bigint' ? value.toString() : value;
+          });
+          htsFeesInfo[customFeesKey].push(customFee);
+        });
+      });
+      return htsFeesInfo;
+
+    case 'TOKEN_EXPIRY': {
+      let htsExpiryInfo = {} as any;
+      EXPIRY_KEYS.forEach((key) => {
+        const value = proxyObj.expiryInfo[key];
+        htsExpiryInfo[key] = typeof value === 'bigint' ? value.toString() : value;
+      });
+      return htsExpiryInfo as IHederaTokenServiceExpiry;
+    }
+
+    case 'TOKEN_KEYS': {
+      let htsKeysInfo = {} as any;
+      KEY_VALUE_KEYS.forEach((key) => {
+        const value = proxyObj.key[key];
+        htsKeysInfo[key] = typeof value === 'bigint' ? value.toString() : value;
+      });
+      return htsKeysInfo as IHederaTokenServiceKeyValueType;
+    }
+  }
 };


### PR DESCRIPTION
**Description**: 
This PR adds a couple of helper functions to help convert Proxy object returned from contract calls to regular TypeScript object for the APIs in tokenQueryGeneralInfo group. By doing this enables to ability to cache the token info object into localStorage.


**Related issue(s)**: #314

Fixes partial #318

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
