### PR TITLE
dapp-feat: Remove Current Deployed Contract Instance feature complete

### DIFF
--- a/system-contract-dapp-playground/__tests__/hedera/index.test.ts
+++ b/system-contract-dapp-playground/__tests__/hedera/index.test.ts
@@ -22,6 +22,7 @@ import { ContractFactory } from 'ethers';
 import { deploySmartContract } from '@/api/hedera';
 import { HederaSmartContractResult } from '@/types/common';
 import { HEDERA_SMART_CONTRACTS_ASSETS } from '@/utils/common/constants';
+import { MOCK_CONTRACT_ID, MOCK_TX_HASH } from '../utils/common/constants';
 
 // Mock ethers
 jest.mock('ethers', () => {
@@ -53,13 +54,15 @@ describe('deploySmartContract', () => {
   it('should deploy the smart contract', async () => {
     // prepare states
     const deployParams = [100];
-    const contractAddr = '0x8f18eCFeC4dB88ACe84dD1c8d11eBFeDd9274324';
     const contractABI = HEDERA_SMART_CONTRACTS_ASSETS.EXCHANGE_RATE.contractABI;
     const contractBytecode = HEDERA_SMART_CONTRACTS_ASSETS.EXCHANGE_RATE.contractBytecode;
 
     // mock contractDeployTx
     const mockContractDeployTx = {
-      getAddress: jest.fn().mockResolvedValue(contractAddr),
+      getAddress: jest.fn().mockResolvedValue(MOCK_CONTRACT_ID),
+      deploymentTransaction: jest.fn().mockResolvedValue({
+        hash: MOCK_TX_HASH,
+      }),
     };
 
     // mock contract
@@ -80,7 +83,7 @@ describe('deploySmartContract', () => {
     // validation
     expect(result.err).toBeNull;
     expect(deploySmartContract).toBeCalled;
-    expect(result.contractAddress).toEqual(contractAddr);
+    expect(result.contractAddress).toEqual(MOCK_CONTRACT_ID);
     expect(mockContractDeployTx.getAddress).toHaveBeenCalled();
     expect(mockContract.deploy).toHaveBeenCalledWith(...deployParams, { gasLimit: 4_000_000 });
   });

--- a/system-contract-dapp-playground/src/api/cookies/index.ts
+++ b/system-contract-dapp-playground/src/api/cookies/index.ts
@@ -111,6 +111,15 @@ export const getInfoFromCookies = (
 };
 
 /**
+ * @dev remove specific cookie
+ *
+ * @param key: string
+ */
+export const removeCookieAt = (key: string) => {
+  Cookies.remove(key);
+};
+
+/**
  * @dev clear account information stored in cookies
  */
 export const clearCookies = async () => {

--- a/system-contract-dapp-playground/src/api/hedera/index.ts
+++ b/system-contract-dapp-playground/src/api/hedera/index.ts
@@ -20,7 +20,9 @@
 
 import { ContractFactory } from 'ethers';
 import { getWalletProvider } from '../wallet';
+import { TransactionResult } from '@/types/contract-interactions/HTS';
 import { ContractABI, HederaSmartContractResult } from '@/types/common';
+import { HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 
 /**
  * @dev deploys smart contract to Hedera network
@@ -38,13 +40,18 @@ export const deploySmartContract = async (
   contractBytecode: string,
   params: any[]
 ): Promise<HederaSmartContractResult> => {
-  // get wallet provider
+  // states
+  const transactionResultStorageKey = HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['CONTRACT-CREATE'];
+
+  // get contract create transactions from localStorage
+  const cachedCreateTransactions = localStorage.getItem(transactionResultStorageKey);
+  const contractCreateTransactions = cachedCreateTransactions ? JSON.parse(cachedCreateTransactions) : [];
+
+  // get signer
   const walletProvider = getWalletProvider();
   if (walletProvider.err || !walletProvider.walletProvider) {
     return { err: walletProvider.err };
   }
-
-  // get signer
   const walletSigner = await walletProvider.walletProvider.getSigner();
 
   // Deploy smart contract
@@ -53,11 +60,7 @@ export const deploySmartContract = async (
     const gasLimit = 4_000_000;
 
     // get contract from contract factory
-    const contract = new ContractFactory(
-      JSON.stringify(contractABI),
-      contractBytecode,
-      walletSigner
-    );
+    const contract = new ContractFactory(JSON.stringify(contractABI), contractBytecode, walletSigner);
 
     // execute deploy transaction
     const contractDeployTx = await contract.deploy(...params, {
@@ -66,6 +69,23 @@ export const deploySmartContract = async (
 
     // get contractAddress
     const contractAddress = await contractDeployTx.getAddress();
+
+    // retrieve transaction receipt
+    const txReceipt = contractDeployTx.deploymentTransaction();
+
+    // prepare create transaction result
+    if (txReceipt) {
+      const createTransactionResult: TransactionResult = {
+        status: 'success',
+        transactionTimeStamp: Date.now(),
+        txHash: txReceipt.hash as string,
+        transactionType: 'CONTRACT-CREATE',
+        sessionedContractAddress: contractAddress,
+      };
+      contractCreateTransactions.push(createTransactionResult);
+      localStorage.setItem(transactionResultStorageKey, JSON.stringify(contractCreateTransactions));
+    }
+
     return { contractAddress };
   } catch (err) {
     console.error(err);

--- a/system-contract-dapp-playground/src/api/localStorage/index.ts
+++ b/system-contract-dapp-playground/src/api/localStorage/index.ts
@@ -64,8 +64,10 @@ export const getArrayTypedValuesFromLocalStorage = (key: string) => {
  * @dev clear HEDERA transaction results cached in localStorage
  *
  * @param contractKey?: string
+ *
+ * @param readonly?: boolean
  */
-export const clearCachedTransactions = (contractKey?: string) => {
+export const clearCachedTransactions = (contractKey?: string, readonly?: boolean) => {
   // prepare key
   const targetKey = contractKey ? contractKey : OFFCIAL_NETWORK_NAME;
 
@@ -77,8 +79,15 @@ export const clearCachedTransactions = (contractKey?: string) => {
 
       // remove items that have keys start with HEDERA
       if (key?.includes(targetKey)) {
-        localStorage.removeItem(key);
-        i--;
+        if (readonly) {
+          if (key?.includes('READONLY')) {
+            localStorage.removeItem(key);
+            i--;
+          }
+        } else {
+          localStorage.removeItem(key);
+          i--;
+        }
       }
     }
   }

--- a/system-contract-dapp-playground/src/api/localStorage/index.ts
+++ b/system-contract-dapp-playground/src/api/localStorage/index.ts
@@ -61,9 +61,14 @@ export const getArrayTypedValuesFromLocalStorage = (key: string) => {
 };
 
 /**
- * @dev clear all HEDERA transaction results cached in localStorage
+ * @dev clear HEDERA transaction results cached in localStorage
+ *
+ * @param contractKey?: string
  */
-export const clearTransactionCache = () => {
+export const clearCachedTransactions = (contractKey?: string) => {
+  // prepare key
+  const targetKey = contractKey ? contractKey : OFFCIAL_NETWORK_NAME;
+
   // loop through localStorage items
   if (localStorage) {
     for (let i = 0; i < localStorage.length; i++) {
@@ -71,7 +76,7 @@ export const clearTransactionCache = () => {
       const key = localStorage.key(i);
 
       // remove items that have keys start with HEDERA
-      if (key?.startsWith(OFFCIAL_NETWORK_NAME)) {
+      if (key?.includes(targetKey)) {
         localStorage.removeItem(key);
         i--;
       }

--- a/system-contract-dapp-playground/src/components/common/ConfirmModal.tsx
+++ b/system-contract-dapp-playground/src/components/common/ConfirmModal.tsx
@@ -1,0 +1,74 @@
+/*-
+ *
+ * Hedera Smart Contracts
+ *
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalCloseButton,
+  ModalBody,
+  ModalFooter,
+} from '@chakra-ui/react';
+
+interface PageProps {
+  isOpen: boolean;
+  modalBody: any;
+  onClose: () => void;
+  modalHeader: string;
+  handleAcknowledge: any;
+}
+
+const ConfirmModal = ({
+  isOpen,
+  modalBody,
+  onClose,
+  modalHeader,
+  handleAcknowledge,
+}: PageProps) => {
+  return (
+    <Modal isOpen={isOpen} isCentered onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent
+        className="h-fit flex flex-col gap-3 rounded-xl drop-shadow-xl
+                bg-secondary text-white font-styrene w-[30rem]"
+      >
+        <ModalHeader>{modalHeader}</ModalHeader>
+        <ModalCloseButton />
+
+        {/* break line */}
+        <hr className="border-t border-white/40 -mt-3" />
+
+        <ModalBody>{modalBody}</ModalBody>
+
+        <ModalFooter>
+          <button
+            onClick={handleAcknowledge}
+            className="border border-button-stroke-violet px-6 py-2 rounded-lg font-medium hover:bg-button-stroke-violet hover:text-white transition duration-300"
+          >
+            Acknowledge
+          </button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default ConfirmModal;

--- a/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/mint/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/mint/index.tsx
@@ -18,6 +18,7 @@
  *
  */
 
+import Cookies from 'js-cookie';
 import { useToast } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
 import { Contract, isAddress } from 'ethers';
@@ -25,8 +26,8 @@ import { erc20Mint } from '@/api/hedera/erc20-interactions';
 import { CommonErrorToast } from '@/components/toast/CommonToast';
 import MultiLineMethod from '@/components/common/MultiLineMethod';
 import { TransactionResult } from '@/types/contract-interactions/HTS';
-import { HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { mintParamFields } from '@/utils/contract-interactions/erc/erc20/constant';
+import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { handleAPIErrors } from '@/components/contract-interaction/hts/shared/methods/handleAPIErrors';
 import { useUpdateTransactionResultsToLocalStorage } from '@/components/contract-interaction/hts/shared/hooks/useUpdateLocalStorage';
 
@@ -38,6 +39,7 @@ const Mint = ({ baseContract }: PageProps) => {
   const toaster = useToast();
   const [isLoading, setIsLoading] = useState(false);
   const [isSuccessful, setIsSuccessful] = useState(false);
+  const currentContractAddress = Cookies.get(CONTRACT_NAMES.ERC20) as string;
   const [transactionResults, setTransactionResults] = useState<TransactionResult[]>([]);
   const transactionResultStorageKey = HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['ERC20-RESULT']['TOKEN-MINT'];
   const [mintParams, setMintParams] = useState({
@@ -74,6 +76,7 @@ const Mint = ({ baseContract }: PageProps) => {
         setTransactionResults,
         transactionHash: txHash,
         transactionType: 'ERC20-MINT',
+        sessionedContractAddress: currentContractAddress,
       });
       return;
     } else {
@@ -85,6 +88,7 @@ const Mint = ({ baseContract }: PageProps) => {
           txHash: txHash as string,
           transactionType: 'ERC20-MINT',
           transactionTimeStamp: Date.now(),
+          sessionedContractAddress: currentContractAddress,
         },
       ]);
 

--- a/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/token-permission/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/token-permission/index.tsx
@@ -18,6 +18,7 @@
  *
  */
 
+import Cookies from 'js-cookie';
 import { Contract } from 'ethers';
 import { isAddress } from 'ethers';
 import { BiCopy } from 'react-icons/bi';
@@ -39,7 +40,14 @@ import {
   HEDERA_CHAKRA_INPUT_BOX_SIZES,
   HEDERA_COMMON_WALLET_REVERT_REASONS,
   HEDERA_TRANSACTION_RESULT_STORAGE_KEYS,
+  CONTRACT_NAMES,
 } from '@/utils/common/constants';
+import {
+  approveParamFields,
+  allowanceParamFields,
+  increaseAllowanceParamFields,
+  decreaseAllowanceParamFields,
+} from '@/utils/contract-interactions/erc/erc20/constant';
 import {
   Td,
   Th,
@@ -54,12 +62,6 @@ import {
   PopoverTrigger,
   TableContainer,
 } from '@chakra-ui/react';
-import {
-  approveParamFields,
-  allowanceParamFields,
-  increaseAllowanceParamFields,
-  decreaseAllowanceParamFields,
-} from '@/utils/contract-interactions/erc/erc20/constant';
 
 interface PageProps {
   baseContract: Contract;
@@ -74,6 +76,7 @@ type Allowance = {
 const TokenPermission = ({ baseContract }: PageProps) => {
   const toaster = useToast();
   const [allowances, setAllowances] = useState<Allowance[]>([]);
+  const currentContractAddress = Cookies.get(CONTRACT_NAMES.ERC20) as string;
   const [transactionResults, setTransactionResults] = useState<TransactionResult[]>([]);
   const transactionResultStorageKey =
     HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['ERC20-RESULT']['TOKEN-PERMISSION'];
@@ -212,6 +215,7 @@ const TokenPermission = ({ baseContract }: PageProps) => {
         setTransactionResults,
         err: tokenPermissionRes.err,
         transactionHash: tokenPermissionRes.txHash,
+        sessionedContractAddress: currentContractAddress,
         transactionType: (transferTypeMap as any)[method],
       });
       return;
@@ -263,6 +267,7 @@ const TokenPermission = ({ baseContract }: PageProps) => {
             status: 'success',
             transactionTimeStamp: Date.now(),
             txHash: tokenPermissionRes.txHash as string,
+            sessionedContractAddress: currentContractAddress,
             transactionType: (transferTypeMap as any)[method],
           },
         ]);

--- a/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/token-transfer/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-20/methods/token-transfer/index.tsx
@@ -18,6 +18,7 @@
  *
  */
 
+import Cookies from 'js-cookie';
 import { Contract } from 'ethers';
 import { isAddress } from 'ethers';
 import { useToast } from '@chakra-ui/react';
@@ -27,7 +28,7 @@ import MultiLineMethod from '@/components/common/MultiLineMethod';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { TransactionResult } from '@/types/contract-interactions/HTS';
 import { convertCalmelCaseFunctionName } from '@/utils/common/helpers';
-import { HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
+import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { handleAPIErrors } from '@/components/contract-interaction/hts/shared/methods/handleAPIErrors';
 import { useUpdateTransactionResultsToLocalStorage } from '@/components/contract-interaction/hts/shared/hooks/useUpdateLocalStorage';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '@/components/contract-interaction/hts/shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
@@ -44,6 +45,7 @@ const Transfer = ({ baseContract }: PageProps) => {
   const toaster = useToast();
   const transactionResultStorageKey =
     HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['ERC20-RESULT']['TOKEN-TRANSFER'];
+  const currentContractAddress = Cookies.get(CONTRACT_NAMES.ERC20) as string;
   const [transactionResults, setTransactionResults] = useState<TransactionResult[]>([]);
 
   const [transferParams, setTransferParams] = useState({
@@ -128,6 +130,7 @@ const Transfer = ({ baseContract }: PageProps) => {
         setTransactionResults,
         err: tokenTransferRes.err,
         transactionHash: tokenTransferRes.txHash,
+        sessionedContractAddress: currentContractAddress,
         transactionType: `ERC20-${convertCalmelCaseFunctionName(method).replace(' ', '-')}`,
       });
       return;
@@ -142,6 +145,7 @@ const Transfer = ({ baseContract }: PageProps) => {
           status: 'success',
           transactionTimeStamp: Date.now(),
           txHash: tokenTransferRes.txHash as string,
+          sessionedContractAddress: currentContractAddress,
           transactionType: `ERC20-${convertCalmelCaseFunctionName(method).toUpperCase().replace(' ', '-')}`,
         },
       ]);

--- a/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-721/methods/approve/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-721/methods/approve/index.tsx
@@ -19,6 +19,7 @@
  */
 
 import Image from 'next/image';
+import Cookies from 'js-cookie';
 import { Contract } from 'ethers';
 import { isAddress } from 'ethers';
 import MultiLineMethod from '@/components/common/MultiLineMethod';
@@ -35,6 +36,7 @@ import useRetrieveMapValueFromLocalStorage from '../../../shared/hooks/useRetrie
 import { useUpdateTransactionResultsToLocalStorage } from '@/components/contract-interaction/hts/shared/hooks/useUpdateLocalStorage';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '@/components/contract-interaction/hts/shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 import {
+  CONTRACT_NAMES,
   HEDERA_BRANDING_COLORS,
   HEDERA_CHAKRA_TABLE_VARIANTS,
   HEDERA_CHAKRA_INPUT_BOX_SIZES,
@@ -50,6 +52,7 @@ const ERC721Approve = ({ baseContract }: PageProps) => {
   const [successStatus, setSuccessStatus] = useState(false);
   const [ractNodes, setReactNodes] = useState<ReactNode[]>([]);
   const [getApproveTokenId, setGetApproveTokenId] = useState('');
+  const currentContractAddress = Cookies.get(CONTRACT_NAMES.ERC721) as string;
   const [tokenSpenders, setTokenSpenders] = useState(new Map<number, string>());
   const [transactionResults, setTransactionResults] = useState<TransactionResult[]>([]);
   const tokenSpenderResultsStorageKey =
@@ -121,8 +124,9 @@ const ERC721Approve = ({ baseContract }: PageProps) => {
           toaster,
           setTransactionResults,
           err: erc721ApproveResult.err,
-          transactionHash: erc721ApproveResult.txHash,
           transactionType: 'ERC721-APPROVE',
+          transactionHash: erc721ApproveResult.txHash,
+          sessionedContractAddress: currentContractAddress,
         });
         return;
       } else {
@@ -133,8 +137,9 @@ const ERC721Approve = ({ baseContract }: PageProps) => {
             {
               status: 'success',
               transactionTimeStamp: Date.now(),
-              txHash: erc721ApproveResult.txHash as string,
               transactionType: 'ERC721-APPROVE',
+              txHash: erc721ApproveResult.txHash as string,
+              sessionedContractAddress: currentContractAddress,
             },
           ]);
 
@@ -151,7 +156,14 @@ const ERC721Approve = ({ baseContract }: PageProps) => {
         }
       }
     },
-    [toaster, baseContract, getApproveTokenId, approveParams.spenderAddress, approveParams.tokenId]
+    [
+      toaster,
+      baseContract,
+      getApproveTokenId,
+      approveParams.tokenId,
+      currentContractAddress,
+      approveParams.spenderAddress,
+    ]
   );
 
   /** @dev listen to change event on transactionResults state => load to localStorage  */

--- a/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-721/methods/mint/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-721/methods/mint/index.tsx
@@ -18,6 +18,7 @@
  *
  */
 
+import Cookies from 'js-cookie';
 import { useToast } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
 import { Contract, isAddress } from 'ethers';
@@ -25,7 +26,7 @@ import { erc721Mint } from '@/api/hedera/erc721-interactions';
 import { CommonErrorToast } from '@/components/toast/CommonToast';
 import MultiLineMethod from '@/components/common/MultiLineMethod';
 import { TransactionResult } from '@/types/contract-interactions/HTS';
-import { HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
+import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { mintParamFields } from '@/utils/contract-interactions/erc/erc721/constant';
 import { handleAPIErrors } from '@/components/contract-interaction/hts/shared/methods/handleAPIErrors';
 import { useUpdateTransactionResultsToLocalStorage } from '@/components/contract-interaction/hts/shared/hooks/useUpdateLocalStorage';
@@ -38,6 +39,7 @@ const Mint = ({ baseContract }: PageProps) => {
   const toaster = useToast();
   const [isLoading, setIsLoading] = useState(false);
   const [isSuccessful, setIsSuccessful] = useState(false);
+  const currentContractAddress = Cookies.get(CONTRACT_NAMES.ERC721) as string;
   const [transactionResults, setTransactionResults] = useState<TransactionResult[]>([]);
   const transactionResultStorageKey = HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['ERC721-RESULT']['TOKEN-MINT'];
   const [mintParams, setMintParams] = useState({
@@ -74,6 +76,7 @@ const Mint = ({ baseContract }: PageProps) => {
         setTransactionResults,
         transactionHash: txHash,
         transactionType: 'ERC721-MINT',
+        sessionedContractAddress: currentContractAddress,
       });
       return;
     } else {
@@ -85,6 +88,7 @@ const Mint = ({ baseContract }: PageProps) => {
           txHash: txHash as string,
           transactionType: 'ERC721-MINT',
           transactionTimeStamp: Date.now(),
+          sessionedContractAddress: currentContractAddress,
         },
       ]);
 

--- a/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-721/methods/operator-approve/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-721/methods/operator-approve/index.tsx
@@ -18,6 +18,7 @@
  *
  */
 
+import Cookies from 'js-cookie';
 import { Contract } from 'ethers';
 import { isAddress } from 'ethers';
 import { BiCopy } from 'react-icons/bi';
@@ -49,6 +50,7 @@ import {
   TableContainer,
 } from '@chakra-ui/react';
 import {
+  CONTRACT_NAMES,
   HEDERA_BRANDING_COLORS,
   HEDERA_CHAKRA_TABLE_VARIANTS,
   HEDERA_CHAKRA_INPUT_BOX_SIZES,
@@ -75,6 +77,7 @@ type ApprovalStatus = {
 const ERC721OperatorApproval = ({ baseContract }: PageProps) => {
   const toaster = useToast();
   const [successStatus, setSuccessStatus] = useState(false);
+  const currentContractAddress = Cookies.get(CONTRACT_NAMES.ERC721) as string;
   const [approvalRecords, setApprovalRecords] = useState<ApprovalStatus[]>([]);
   const [transactionResults, setTransactionResults] = useState<TransactionResult[]>([]);
   const approvalStatusStorageKey = HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['ERC721-RESULT']['GET-APPROVAL'];
@@ -167,8 +170,9 @@ const ERC721OperatorApproval = ({ baseContract }: PageProps) => {
         toaster,
         setTransactionResults,
         err: tokenApprovalRes.err,
-        transactionHash: tokenApprovalRes.txHash,
         transactionType: 'ERC721-SET-APPROVAL',
+        transactionHash: tokenApprovalRes.txHash,
+        sessionedContractAddress: currentContractAddress,
       });
       return;
     } else {
@@ -179,8 +183,9 @@ const ERC721OperatorApproval = ({ baseContract }: PageProps) => {
           {
             status: 'success',
             transactionTimeStamp: Date.now(),
-            txHash: tokenApprovalRes.txHash as string,
             transactionType: 'ERC721-SET-APPROVAL',
+            txHash: tokenApprovalRes.txHash as string,
+            sessionedContractAddress: currentContractAddress,
           },
         ]);
 

--- a/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-721/methods/token-transfer/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/erc/erc-721/methods/token-transfer/index.tsx
@@ -18,6 +18,7 @@
  *
  */
 
+import Cookies from 'js-cookie';
 import { Contract } from 'ethers';
 import { isAddress } from 'ethers';
 import { useToast } from '@chakra-ui/react';
@@ -27,7 +28,7 @@ import MultiLineMethod from '@/components/common/MultiLineMethod';
 import { erc721Transfers } from '@/api/hedera/erc721-interactions';
 import { TransactionResult } from '@/types/contract-interactions/HTS';
 import { convertCalmelCaseFunctionName } from '@/utils/common/helpers';
-import { HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
+import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { handleAPIErrors } from '@/components/contract-interaction/hts/shared/methods/handleAPIErrors';
 import { useUpdateTransactionResultsToLocalStorage } from '@/components/contract-interaction/hts/shared/hooks/useUpdateLocalStorage';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '@/components/contract-interaction/hts/shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
@@ -44,6 +45,7 @@ const ERC721Transfer = ({ baseContract }: PageProps) => {
   const toaster = useToast();
   const transactionResultStorageKey =
     HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['ERC721-RESULT']['TOKEN-TRANSFER'];
+  const currentContractAddress = Cookies.get(CONTRACT_NAMES.ERC721) as string;
   const [transactionResults, setTransactionResults] = useState<TransactionResult[]>([]);
 
   const [transferFromParams, setTransferFromParams] = useState({
@@ -120,6 +122,7 @@ const ERC721Transfer = ({ baseContract }: PageProps) => {
         setTransactionResults,
         err: tokenTransferRes.err,
         transactionHash: tokenTransferRes.txHash,
+        sessionedContractAddress: currentContractAddress,
         transactionType: `ERC721-${convertCalmelCaseFunctionName(method).replace(' ', '-')}`,
       });
       return;
@@ -133,6 +136,7 @@ const ERC721Transfer = ({ baseContract }: PageProps) => {
           status: 'success',
           transactionTimeStamp: Date.now(),
           txHash: tokenTransferRes.txHash as string,
+          sessionedContractAddress: currentContractAddress,
           transactionType: `ERC721-${convertCalmelCaseFunctionName(method).toUpperCase().replace(' ', '-')}`,
         },
       ]);

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/shared/hooks/useFilterTransactionsByContractAddress.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/shared/hooks/useFilterTransactionsByContractAddress.tsx
@@ -1,0 +1,36 @@
+/*-
+ *
+ * Hedera Smart Contracts
+ *
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { useMemo } from 'react';
+import { TransactionResult } from '@/types/contract-interactions/HTS';
+
+/** @dev custom hook to filter transactions by contract address */
+
+const useFilterTransactionsByContractAddress = (
+  transactionResults: TransactionResult[],
+  contractAddress: string
+) => {
+  return useMemo(
+    () => transactionResults.filter((result) => result.sessionedContractAddress === contractAddress),
+    [transactionResults, contractAddress]
+  );
+};
+
+export default useFilterTransactionsByContractAddress;

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/shared/methods/handleAPIErrors.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/shared/methods/handleAPIErrors.tsx
@@ -20,8 +20,8 @@
 
 import { Dispatch, SetStateAction } from 'react';
 import { CommonErrorToast } from '@/components/toast/CommonToast';
-import { IHederaTokenServiceKeyType, TransactionResult } from '@/types/contract-interactions/HTS';
 import { HEDERA_COMMON_WALLET_REVERT_REASONS } from '@/utils/common/constants';
+import { IHederaTokenServiceKeyType, TransactionResult } from '@/types/contract-interactions/HTS';
 
 /** @dev handle error returned back from invoking method APIs*/
 export const handleAPIErrors = ({
@@ -36,6 +36,7 @@ export const handleAPIErrors = ({
   transactionHash,
   receiverAddress,
   setTransactionResults,
+  sessionedContractAddress,
 }: {
   err: any;
   toaster: any;
@@ -45,6 +46,7 @@ export const handleAPIErrors = ({
   transactionType: string;
   receiverAddress?: string;
   tokenAddresses?: string[];
+  sessionedContractAddress: string;
   transactionHash: string | undefined;
   keyTypeCalled?: IHederaTokenServiceKeyType;
   setTransactionResults: Dispatch<SetStateAction<TransactionResult[]>>;
@@ -82,6 +84,7 @@ export const handleAPIErrors = ({
         isToken: false,
         transactionType,
         txHash: transactionHash,
+        sessionedContractAddress,
         tokenAddress: tokenAddress ? tokenAddress : '',
         accountAddress: accountAddress ? accountAddress : '',
         tokenAddresses: tokenAddresses ? tokenAddresses : [''],

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-create-custom/methods/AssociateHederaToken.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-create-custom/methods/AssociateHederaToken.tsx
@@ -21,7 +21,7 @@
 import Cookies from 'js-cookie';
 import { Contract } from 'ethers';
 import { useToast } from '@chakra-ui/react';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { CommonErrorToast } from '@/components/toast/CommonToast';
 import { generatedRandomUniqueKey } from '@/utils/common/helpers';
 import { TransactionResult } from '@/types/contract-interactions/HTS';
@@ -29,14 +29,14 @@ import { handleAPIErrors } from '../../shared/methods/handleAPIErrors';
 import { TRANSACTION_PAGE_SIZE } from '../../shared/states/commonStates';
 import { useToastSuccessful } from '../../shared/hooks/useToastSuccessful';
 import { usePaginatedTxResults } from '../../shared/hooks/usePaginatedTxResults';
-import { HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import TokenAddressesInputForm from '../../shared/components/TokenAddressesInputForm';
 import { TransactionResultTable } from '../../shared/components/TransactionResultTable';
-import { associateHederaTokensToAccounts } from '@/api/hedera/hts-interactions/tokenCreateCustom-interactions';
 import { handleSanitizeHederaFormInputs } from '../../shared/methods/handleSanitizeFormInputs';
+import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { SharedFormInputField, SharedExecuteButton } from '../../shared/components/ParamInputForm';
 import { useUpdateTransactionResultsToLocalStorage } from '../../shared/hooks/useUpdateLocalStorage';
 import { htsTokenAssociateParamFields } from '@/utils/contract-interactions/HTS/token-create-custom/constant';
+import { associateHederaTokensToAccounts } from '@/api/hedera/hts-interactions/tokenCreateCustom-interactions';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 
 interface PageProps {
@@ -52,6 +52,7 @@ const AssociateHederaToken = ({ baseContract }: PageProps) => {
   const hederaNetwork = JSON.parse(Cookies.get('_network') as string);
   const [currentTransactionPage, setCurrentTransactionPage] = useState(1);
   const [paramValues, setParamValues] = useState<any>(initialParamValues);
+  const currentContractAddress = Cookies.get(CONTRACT_NAMES.TOKEN_CREATE) as string;
   const [transactionResults, setTransactionResults] = useState<TransactionResult[]>([]);
   const initialTokenAddressesValues = { fieldKey: generatedRandomUniqueKey(9), fieldValue: '' };
   const transactionResultStorageKey =
@@ -59,6 +60,11 @@ const AssociateHederaToken = ({ baseContract }: PageProps) => {
   const [hederaTokenAddresses, setHederaTokenAddresses] = useState<
     { fieldKey: string; fieldValue: string }[]
   >([initialTokenAddressesValues]);
+
+  const transactionResultsToShow = useMemo(
+    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
+    [transactionResults, currentContractAddress]
+  );
 
   /** @dev retrieve token creation results from localStorage to maintain data on re-renders */
   useEffect(() => {
@@ -71,7 +77,7 @@ const AssociateHederaToken = ({ baseContract }: PageProps) => {
   }, [toaster, transactionResultStorageKey]);
 
   // declare a paginatedTransactionResults
-  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResults);
+  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResultsToShow);
 
   /** @dev handle form inputs on change */
   const handleInputOnChange = (e: any, param: string, fieldKey?: string) => {
@@ -147,6 +153,7 @@ const AssociateHederaToken = ({ baseContract }: PageProps) => {
         setTransactionResults,
         accountAddress: associatingAddress,
         transactionType: 'HTS-TOKEN-ASSOCIATE',
+        sessionedContractAddress: currentContractAddress,
       });
       return;
     } else {
@@ -160,6 +167,7 @@ const AssociateHederaToken = ({ baseContract }: PageProps) => {
           txHash: transactionHash as string,
           accountAddress: associatingAddress,
           transactionType: 'HTS-TOKEN-ASSOCIATE',
+          sessionedContractAddress: currentContractAddress,
         },
       ]);
 
@@ -218,7 +226,7 @@ const AssociateHederaToken = ({ baseContract }: PageProps) => {
       </div>
 
       {/* transaction results table */}
-      {transactionResults.length > 0 && (
+      {transactionResultsToShow.length > 0 && (
         <TransactionResultTable
           API="TokenAssociate"
           hederaNetwork={hederaNetwork}

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-create-custom/methods/AssociateHederaToken.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-create-custom/methods/AssociateHederaToken.tsx
@@ -21,7 +21,7 @@
 import Cookies from 'js-cookie';
 import { Contract } from 'ethers';
 import { useToast } from '@chakra-ui/react';
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect } from 'react';
 import { CommonErrorToast } from '@/components/toast/CommonToast';
 import { generatedRandomUniqueKey } from '@/utils/common/helpers';
 import { TransactionResult } from '@/types/contract-interactions/HTS';
@@ -37,6 +37,7 @@ import { SharedFormInputField, SharedExecuteButton } from '../../shared/componen
 import { useUpdateTransactionResultsToLocalStorage } from '../../shared/hooks/useUpdateLocalStorage';
 import { htsTokenAssociateParamFields } from '@/utils/contract-interactions/HTS/token-create-custom/constant';
 import { associateHederaTokensToAccounts } from '@/api/hedera/hts-interactions/tokenCreateCustom-interactions';
+import useFilterTransactionsByContractAddress from '../../shared/hooks/useFilterTransactionsByContractAddress';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 
 interface PageProps {
@@ -61,9 +62,9 @@ const AssociateHederaToken = ({ baseContract }: PageProps) => {
     { fieldKey: string; fieldValue: string }[]
   >([initialTokenAddressesValues]);
 
-  const transactionResultsToShow = useMemo(
-    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
-    [transactionResults, currentContractAddress]
+  const transactionResultsToShow = useFilterTransactionsByContractAddress(
+    transactionResults,
+    currentContractAddress
   );
 
   /** @dev retrieve token creation results from localStorage to maintain data on re-renders */

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-create-custom/methods/FungibleTokenCreate.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-create-custom/methods/FungibleTokenCreate.tsx
@@ -21,7 +21,7 @@
 import Cookies from 'js-cookie';
 import { Contract } from 'ethers';
 import { useToast } from '@chakra-ui/react';
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect } from 'react';
 import { CommonErrorToast } from '@/components/toast/CommonToast';
 import { handleAPIErrors } from '../../shared/methods/handleAPIErrors';
 import { useToastSuccessful } from '../../shared/hooks/useToastSuccessful';
@@ -33,6 +33,7 @@ import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/
 import { useUpdateTransactionResultsToLocalStorage } from '../../shared/hooks/useUpdateLocalStorage';
 import { createHederaFungibleToken } from '@/api/hedera/hts-interactions/tokenCreateCustom-interactions';
 import { htsTokenCreateParamFields } from '@/utils/contract-interactions/HTS/token-create-custom/constant';
+import useFilterTransactionsByContractAddress from '../../shared/hooks/useFilterTransactionsByContractAddress';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 import {
   SharedFormInputField,
@@ -87,9 +88,9 @@ const FungibleTokenCreate = ({ baseContract }: PageProps) => {
   };
   const [paramValues, setParamValues] = useState<any>(initialParamValues);
 
-  const transactionResultsToShow = useMemo(
-    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
-    [transactionResults, currentContractAddress]
+  const transactionResultsToShow = useFilterTransactionsByContractAddress(
+    transactionResults,
+    currentContractAddress
   );
 
   // Keys states

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-create-custom/methods/FungibleTokenCreate.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-create-custom/methods/FungibleTokenCreate.tsx
@@ -21,17 +21,17 @@
 import Cookies from 'js-cookie';
 import { Contract } from 'ethers';
 import { useToast } from '@chakra-ui/react';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { CommonErrorToast } from '@/components/toast/CommonToast';
 import { handleAPIErrors } from '../../shared/methods/handleAPIErrors';
 import { useToastSuccessful } from '../../shared/hooks/useToastSuccessful';
 import { usePaginatedTxResults } from '../../shared/hooks/usePaginatedTxResults';
-import { HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { SharedSigningKeysComponent } from '../../shared/components/SigningKeysForm';
-import { createHederaFungibleToken } from '@/api/hedera/hts-interactions/tokenCreateCustom-interactions';
 import { TransactionResultTable } from '../../shared/components/TransactionResultTable';
 import { handleSanitizeHederaFormInputs } from '../../shared/methods/handleSanitizeFormInputs';
+import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { useUpdateTransactionResultsToLocalStorage } from '../../shared/hooks/useUpdateLocalStorage';
+import { createHederaFungibleToken } from '@/api/hedera/hts-interactions/tokenCreateCustom-interactions';
 import { htsTokenCreateParamFields } from '@/utils/contract-interactions/HTS/token-create-custom/constant';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 import {
@@ -41,13 +41,13 @@ import {
 } from '../../shared/components/ParamInputForm';
 import {
   CommonKeyObject,
-  IHederaTokenServiceKeyType,
   TransactionResult,
+  IHederaTokenServiceKeyType,
 } from '@/types/contract-interactions/HTS';
 import {
   HederaTokenKeyTypes,
-  HederaTokenKeyValueType,
   TRANSACTION_PAGE_SIZE,
+  HederaTokenKeyValueType,
 } from '../../shared/states/commonStates';
 
 interface PageProps {
@@ -61,11 +61,12 @@ const FungibleTokenCreate = ({ baseContract }: PageProps) => {
   const [isSuccessful, setIsSuccessful] = useState(false);
   const [withCustomFee, setWithCustomFee] = useState(false);
   const [isDefaultFreeze, setIsDefaultFreeze] = useState(false);
-  const hederaNetwork = JSON.parse(Cookies.get('_network') as string);
+  const HEDERA_NETWORK = JSON.parse(Cookies.get('_network') as string);
   const [currentTransactionPage, setCurrentTransactionPage] = useState(1);
+  const currentContractAddress = Cookies.get(CONTRACT_NAMES.TOKEN_CREATE) as string;
+  const [transactionResults, setTransactionResults] = useState<TransactionResult[]>([]);
   const transactionResultStorageKey =
     HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['TOKEN-CREATE']['FUNGIBLE-TOKEN'];
-  const [transactionResults, setTransactionResults] = useState<TransactionResult[]>([]);
   const tokenCreateFields = {
     info: ['name', 'symbol', 'memo'],
     supply: ['initSupply', 'maxSupply', 'decimals'],
@@ -86,6 +87,11 @@ const FungibleTokenCreate = ({ baseContract }: PageProps) => {
   };
   const [paramValues, setParamValues] = useState<any>(initialParamValues);
 
+  const transactionResultsToShow = useMemo(
+    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
+    [transactionResults, currentContractAddress]
+  );
+
   // Keys states
   const [keys, setKeys] = useState<CommonKeyObject[]>([]); // keeps track of keys array to pass to the API
   const [chosenKeys, setChosenKeys] = useState(new Set<IHederaTokenServiceKeyType>()); // keeps track of keyTypes which have already been chosen in the list
@@ -102,7 +108,7 @@ const FungibleTokenCreate = ({ baseContract }: PageProps) => {
   }, [toaster, transactionResultStorageKey]);
 
   // declare a paginatedTransactionResults
-  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResults);
+  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResultsToShow);
 
   /** @dev handle form inputs on change */
   const handleInputOnChange = (e: any, param: string) => {
@@ -175,6 +181,7 @@ const FungibleTokenCreate = ({ baseContract }: PageProps) => {
         transactionHash,
         setTransactionResults,
         transactionType: 'HTS-TOKEN-CREATE',
+        sessionedContractAddress: currentContractAddress,
       });
       return;
     } else {
@@ -187,6 +194,7 @@ const FungibleTokenCreate = ({ baseContract }: PageProps) => {
           transactionTimeStamp: Date.now(),
           txHash: transactionHash as string,
           transactionType: 'HTS-TOKEN-CREATE',
+          sessionedContractAddress: currentContractAddress,
         },
       ]);
 
@@ -362,10 +370,10 @@ const FungibleTokenCreate = ({ baseContract }: PageProps) => {
       </div>
 
       {/* transaction results table */}
-      {transactionResults.length > 0 && (
+      {transactionResultsToShow.length > 0 && (
         <TransactionResultTable
           API="TokenCreate"
-          hederaNetwork={hederaNetwork}
+          hederaNetwork={HEDERA_NETWORK}
           transactionResults={transactionResults}
           TRANSACTION_PAGE_SIZE={TRANSACTION_PAGE_SIZE}
           setTransactionResults={setTransactionResults}

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-create-custom/methods/GrantTokenKYC.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-create-custom/methods/GrantTokenKYC.tsx
@@ -21,20 +21,21 @@
 import Cookies from 'js-cookie';
 import { Contract } from 'ethers';
 import { useToast } from '@chakra-ui/react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { CommonErrorToast } from '@/components/toast/CommonToast';
 import { TransactionResult } from '@/types/contract-interactions/HTS';
 import { handleAPIErrors } from '../../shared/methods/handleAPIErrors';
 import { TRANSACTION_PAGE_SIZE } from '../../shared/states/commonStates';
 import { useToastSuccessful } from '../../shared/hooks/useToastSuccessful';
 import { usePaginatedTxResults } from '../../shared/hooks/usePaginatedTxResults';
-import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { TransactionResultTable } from '../../shared/components/TransactionResultTable';
 import { handleSanitizeHederaFormInputs } from '../../shared/methods/handleSanitizeFormInputs';
+import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { SharedFormInputField, SharedExecuteButton } from '../../shared/components/ParamInputForm';
 import { useUpdateTransactionResultsToLocalStorage } from '../../shared/hooks/useUpdateLocalStorage';
 import { grantTokenKYCToAccount } from '@/api/hedera/hts-interactions/tokenCreateCustom-interactions';
 import { htsGrantTokenKYCParamFields } from '@/utils/contract-interactions/HTS/token-create-custom/constant';
+import useFilterTransactionsByContractAddress from '../../shared/hooks/useFilterTransactionsByContractAddress';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 
 interface PageProps {
@@ -58,9 +59,9 @@ const GrantTokenKYC = ({ baseContract }: PageProps) => {
   };
   const [paramValues, setParamValues] = useState<any>(initialParamValues);
 
-  const transactionResultsToShow = useMemo(
-    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
-    [transactionResults, currentContractAddress]
+  const transactionResultsToShow = useFilterTransactionsByContractAddress(
+    transactionResults,
+    currentContractAddress
   );
 
   /** @dev retrieve token creation results from localStorage to maintain data on re-renders */

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-create-custom/methods/MintHederaToken.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-create-custom/methods/MintHederaToken.tsx
@@ -30,16 +30,16 @@ import { TRANSACTION_PAGE_SIZE } from '../../shared/states/commonStates';
 import MetadataInputForm from '../../shared/components/MetadataInputForm';
 import { useToastSuccessful } from '../../shared/hooks/useToastSuccessful';
 import { usePaginatedTxResults } from '../../shared/hooks/usePaginatedTxResults';
-import { HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { TransactionResultTable } from '../../shared/components/TransactionResultTable';
 import { handleSanitizeHederaFormInputs } from '../../shared/methods/handleSanitizeFormInputs';
+import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { useUpdateTransactionResultsToLocalStorage } from '../../shared/hooks/useUpdateLocalStorage';
 import { htsTokenMintParamFields } from '@/utils/contract-interactions/HTS/token-create-custom/constant';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 import {
   SharedFormButton,
-  SharedFormInputField,
   SharedExecuteButton,
+  SharedFormInputField,
 } from '../../shared/components/ParamInputForm';
 import {
   mintHederaToken,
@@ -58,11 +58,12 @@ const MintHederaToken = ({ baseContract }: PageProps) => {
   const [isLoading, setIsLoading] = useState(false);
   const [isSuccessful, setIsSuccessful] = useState(false);
   const [APIMethods, setAPIMethods] = useState<API_NAMES>('FUNGIBLE');
-  const hederaNetwork = JSON.parse(Cookies.get('_network') as string);
+  const HEDERA_NETWORK = JSON.parse(Cookies.get('_network') as string);
   const [currentTransactionPage, setCurrentTransactionPage] = useState(1);
-  const transactionResultStorageKey = HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['TOKEN-CREATE']['MINT-TOKEN'];
+  const currentContractAddress = Cookies.get(CONTRACT_NAMES.TOKEN_CREATE) as string;
   const [transactionResults, setTransactionResults] = useState<TransactionResult[]>([]);
   const [metadata, setMetadata] = useState<{ metaKey: string; metaValue: string }[]>([]);
+  const transactionResultStorageKey = HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['TOKEN-CREATE']['MINT-TOKEN'];
   const tokenMintFields = useMemo(() => {
     return APIMethods === 'FUNGIBLE'
       ? ['tokenAddressToMint', 'amount', 'recipientAddress']
@@ -74,6 +75,11 @@ const MintHederaToken = ({ baseContract }: PageProps) => {
     tokenAddressToMint: '',
   };
   const [paramValues, setParamValues] = useState<any>(initialParamValues);
+
+  const transactionResultsToShow = useMemo(
+    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
+    [transactionResults, currentContractAddress]
+  );
 
   const APIButtonTitles: { API: API_NAMES; apiSwitchTitle: string; executeTitle: string }[] = [
     {
@@ -99,7 +105,7 @@ const MintHederaToken = ({ baseContract }: PageProps) => {
   }, [toaster, transactionResultStorageKey]);
 
   /** @dev declare a paginatedTransactionResults */
-  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResults);
+  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResultsToShow);
 
   /** @dev handle form inputs on change */
   const handleInputOnChange = (e: any, param: string, metaKey?: string) => {
@@ -185,6 +191,7 @@ const MintHederaToken = ({ baseContract }: PageProps) => {
         setTransactionResults,
         tokenAddress: tokenAddressToMint,
         transactionHash: txRes.transactionHash,
+        sessionedContractAddress: currentContractAddress,
         transactionType: `HTS-${APIMethods === 'FUNGIBLE' ? 'TOKEN' : 'NFT'}-MINT`,
       });
       return;
@@ -198,6 +205,7 @@ const MintHederaToken = ({ baseContract }: PageProps) => {
           transactionTimeStamp: Date.now(),
           txHash: txRes.transactionHash as string,
           tokenAddress: paramValues.tokenAddressToMint,
+          sessionedContractAddress: currentContractAddress,
           transactionType: `HTS-${APIMethods === 'FUNGIBLE' ? 'TOKEN' : 'NFT'}-MINT`,
         },
       ]);
@@ -288,10 +296,10 @@ const MintHederaToken = ({ baseContract }: PageProps) => {
       </div>
 
       {/* transaction results table */}
-      {transactionResults.length > 0 && (
+      {transactionResultsToShow.length > 0 && (
         <TransactionResultTable
           API="TokenMint"
-          hederaNetwork={hederaNetwork}
+          hederaNetwork={HEDERA_NETWORK}
           transactionResults={transactionResults}
           setTransactionResults={setTransactionResults}
           TRANSACTION_PAGE_SIZE={TRANSACTION_PAGE_SIZE}

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-create-custom/methods/MintHederaToken.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-create-custom/methods/MintHederaToken.tsx
@@ -35,6 +35,7 @@ import { handleSanitizeHederaFormInputs } from '../../shared/methods/handleSanit
 import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { useUpdateTransactionResultsToLocalStorage } from '../../shared/hooks/useUpdateLocalStorage';
 import { htsTokenMintParamFields } from '@/utils/contract-interactions/HTS/token-create-custom/constant';
+import useFilterTransactionsByContractAddress from '../../shared/hooks/useFilterTransactionsByContractAddress';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 import {
   SharedFormButton,
@@ -76,9 +77,9 @@ const MintHederaToken = ({ baseContract }: PageProps) => {
   };
   const [paramValues, setParamValues] = useState<any>(initialParamValues);
 
-  const transactionResultsToShow = useMemo(
-    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
-    [transactionResults, currentContractAddress]
+  const transactionResultsToShow = useFilterTransactionsByContractAddress(
+    transactionResults,
+    currentContractAddress
   );
 
   const APIButtonTitles: { API: API_NAMES; apiSwitchTitle: string; executeTitle: string }[] = [

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-create-custom/methods/NonFungibleTokenCreate.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-create-custom/methods/NonFungibleTokenCreate.tsx
@@ -21,7 +21,7 @@
 import Cookies from 'js-cookie';
 import { Contract } from 'ethers';
 import { useToast } from '@chakra-ui/react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { CommonErrorToast } from '@/components/toast/CommonToast';
 import { handleAPIErrors } from '../../shared/methods/handleAPIErrors';
 import { useToastSuccessful } from '../../shared/hooks/useToastSuccessful';
@@ -33,6 +33,7 @@ import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/
 import { useUpdateTransactionResultsToLocalStorage } from '../../shared/hooks/useUpdateLocalStorage';
 import { htsTokenCreateParamFields } from '@/utils/contract-interactions/HTS/token-create-custom/constant';
 import { createHederaNonFungibleToken } from '@/api/hedera/hts-interactions/tokenCreateCustom-interactions';
+import useFilterTransactionsByContractAddress from '../../shared/hooks/useFilterTransactionsByContractAddress';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 import {
   SharedFormInputField,
@@ -81,9 +82,9 @@ const NonFungibleTokenCreate = ({ baseContract }: PageProps) => {
   };
   const [paramValues, setParamValues] = useState<any>(initialParamValues);
 
-  const transactionResultsToShow = useMemo(
-    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
-    [transactionResults, currentContractAddress]
+  const transactionResultsToShow = useFilterTransactionsByContractAddress(
+    transactionResults,
+    currentContractAddress
   );
 
   // keys states

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-create-custom/methods/NonFungibleTokenCreate.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-create-custom/methods/NonFungibleTokenCreate.tsx
@@ -21,18 +21,18 @@
 import Cookies from 'js-cookie';
 import { Contract } from 'ethers';
 import { useToast } from '@chakra-ui/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { CommonErrorToast } from '@/components/toast/CommonToast';
 import { handleAPIErrors } from '../../shared/methods/handleAPIErrors';
 import { useToastSuccessful } from '../../shared/hooks/useToastSuccessful';
 import { usePaginatedTxResults } from '../../shared/hooks/usePaginatedTxResults';
-import { HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { SharedSigningKeysComponent } from '../../shared/components/SigningKeysForm';
 import { TransactionResultTable } from '../../shared/components/TransactionResultTable';
-import { createHederaNonFungibleToken } from '@/api/hedera/hts-interactions/tokenCreateCustom-interactions';
 import { handleSanitizeHederaFormInputs } from '../../shared/methods/handleSanitizeFormInputs';
+import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { useUpdateTransactionResultsToLocalStorage } from '../../shared/hooks/useUpdateLocalStorage';
 import { htsTokenCreateParamFields } from '@/utils/contract-interactions/HTS/token-create-custom/constant';
+import { createHederaNonFungibleToken } from '@/api/hedera/hts-interactions/tokenCreateCustom-interactions';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 import {
   SharedFormInputField,
@@ -62,6 +62,7 @@ const NonFungibleTokenCreate = ({ baseContract }: PageProps) => {
   const [withCustomFee, setWithCustomFee] = useState(false);
   const HEDERA_NETWORK = JSON.parse(Cookies.get('_network') as string);
   const [currentTransactionPage, setCurrentTransactionPage] = useState(1);
+  const currentContractAddress = Cookies.get(CONTRACT_NAMES.TOKEN_CREATE) as string;
   const [transactionResults, setTransactionResults] = useState<TransactionResult[]>([]);
   const transactionResultStorageKey =
     HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['TOKEN-CREATE']['NON-FUNGIBLE-TOKEN'];
@@ -80,6 +81,11 @@ const NonFungibleTokenCreate = ({ baseContract }: PageProps) => {
   };
   const [paramValues, setParamValues] = useState<any>(initialParamValues);
 
+  const transactionResultsToShow = useMemo(
+    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
+    [transactionResults, currentContractAddress]
+  );
+
   // keys states
   const [keys, setKeys] = useState<CommonKeyObject[]>([]); // keeps track of keys array to pass to the API
   const [chosenKeys, setChosenKeys] = useState(new Set<IHederaTokenServiceKeyType>()); // keeps track of keyTypes which have already been chosen in the list
@@ -96,7 +102,7 @@ const NonFungibleTokenCreate = ({ baseContract }: PageProps) => {
   }, [toaster, transactionResultStorageKey]);
 
   // declare a paginatedTransactionResults
-  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResults);
+  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResultsToShow);
 
   /** @dev handle form inputs on change */
   const handleInputOnChange = (e: any, param: string) => {
@@ -153,6 +159,7 @@ const NonFungibleTokenCreate = ({ baseContract }: PageProps) => {
         transactionHash,
         setTransactionResults,
         transactionType: 'HTS-NFT-CREATE',
+        sessionedContractAddress: currentContractAddress,
       });
       return;
     } else {
@@ -162,9 +169,10 @@ const NonFungibleTokenCreate = ({ baseContract }: PageProps) => {
         {
           tokenAddress,
           status: 'success',
-          txHash: transactionHash as string,
-          transactionType: 'HTS-NFT-CREATE',
           transactionTimeStamp: Date.now(),
+          transactionType: 'HTS-NFT-CREATE',
+          txHash: transactionHash as string,
+          sessionedContractAddress: currentContractAddress,
         },
       ]);
 
@@ -280,7 +288,7 @@ const NonFungibleTokenCreate = ({ baseContract }: PageProps) => {
       </div>
 
       {/* transaction results table */}
-      {transactionResults.length > 0 && (
+      {transactionResultsToShow.length > 0 && (
         <TransactionResultTable
           API="TokenCreate"
           hederaNetwork={HEDERA_NETWORK}
@@ -288,9 +296,9 @@ const NonFungibleTokenCreate = ({ baseContract }: PageProps) => {
           TRANSACTION_PAGE_SIZE={TRANSACTION_PAGE_SIZE}
           setTransactionResults={setTransactionResults}
           currentTransactionPage={currentTransactionPage}
+          setCurrentTransactionPage={setCurrentTransactionPage}
           transactionResultStorageKey={transactionResultStorageKey}
           paginatedTransactionResults={paginatedTransactionResults}
-          setCurrentTransactionPage={setCurrentTransactionPage}
         />
       )}
     </div>

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-management-contract/methods/manageTokenDelete/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-management-contract/methods/manageTokenDelete/index.tsx
@@ -21,17 +21,17 @@
 import Cookies from 'js-cookie';
 import { Contract } from 'ethers';
 import { useToast } from '@chakra-ui/react';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { CommonErrorToast } from '@/components/toast/CommonToast';
 import { TransactionResult } from '@/types/contract-interactions/HTS';
 import { handleAPIErrors } from '../../../shared/methods/handleAPIErrors';
 import { TRANSACTION_PAGE_SIZE } from '../../../shared/states/commonStates';
 import { useToastSuccessful } from '../../../shared/hooks/useToastSuccessful';
-import { HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { usePaginatedTxResults } from '../../../shared/hooks/usePaginatedTxResults';
 import { TransactionResultTable } from '../../../shared/components/TransactionResultTable';
 import { handleSanitizeHederaFormInputs } from '../../../shared/methods/handleSanitizeFormInputs';
 import { manageTokenDeduction } from '@/api/hedera/hts-interactions/tokenManagement-interactions';
+import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { useUpdateTransactionResultsToLocalStorage } from '../../../shared/hooks/useUpdateLocalStorage';
 import { htsTokenDeductionParamFields } from '@/utils/contract-interactions/HTS/token-management/constant';
 import { SharedFormInputField, SharedExecuteButtonWithFee } from '../../../shared/components/ParamInputForm';
@@ -48,6 +48,7 @@ const ManageTokenDelete = ({ baseContract }: PageProps) => {
   const [isSuccessful, setIsSuccessful] = useState(false);
   const hederaNetwork = JSON.parse(Cookies.get('_network') as string);
   const [currentTransactionPage, setCurrentTransactionPage] = useState(1);
+  const currentContractAddress = Cookies.get(CONTRACT_NAMES.TOKEN_MANAGE) as string;
   const [transactionResults, setTransactionResults] = useState<TransactionResult[]>([]);
   const transactionResultStorageKey = HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['TOKEN-MANAGE']['TOKEN-DELETE'];
   const initialParamValues = {
@@ -55,6 +56,12 @@ const ManageTokenDelete = ({ baseContract }: PageProps) => {
     hederaTokenAddress: '',
   };
   const [paramValues, setParamValues] = useState<any>(initialParamValues);
+
+  const transactionResultsToShow = useMemo(
+    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
+    [transactionResults, currentContractAddress]
+  );
+
   /** @dev retrieve token creation results from localStorage to maintain data on re-renders */
   useEffect(() => {
     handleRetrievingTransactionResultsFromLocalStorage(
@@ -66,7 +73,8 @@ const ManageTokenDelete = ({ baseContract }: PageProps) => {
   }, [toaster, transactionResultStorageKey]);
 
   // declare a paginatedTransactionResults
-  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResults);
+  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResultsToShow);
+
   /** @dev handle form inputs on change */
   const handleInputOnChange = (e: any, param: string) => {
     setParamValues((prev: any) => ({ ...prev, [param]: e.target.value }));
@@ -113,6 +121,7 @@ const ManageTokenDelete = ({ baseContract }: PageProps) => {
         setTransactionResults,
         tokenAddress: hederaTokenAddress,
         transactionType: 'HTS-TOKEN-DELETE',
+        sessionedContractAddress: currentContractAddress,
       });
       return;
     } else {
@@ -125,6 +134,7 @@ const ManageTokenDelete = ({ baseContract }: PageProps) => {
           transactionTimeStamp: Date.now(),
           txHash: transactionHash as string,
           transactionType: 'HTS-TOKEN-DELETE',
+          sessionedContractAddress: currentContractAddress,
         },
       ]);
 
@@ -180,7 +190,7 @@ const ManageTokenDelete = ({ baseContract }: PageProps) => {
       </div>
 
       {/* transaction results table */}
-      {transactionResults.length > 0 && (
+      {transactionResultsToShow.length > 0 && (
         <TransactionResultTable
           API="TokenCreate"
           hederaNetwork={hederaNetwork}

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-management-contract/methods/manageTokenDelete/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-management-contract/methods/manageTokenDelete/index.tsx
@@ -21,7 +21,7 @@
 import Cookies from 'js-cookie';
 import { Contract } from 'ethers';
 import { useToast } from '@chakra-ui/react';
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect } from 'react';
 import { CommonErrorToast } from '@/components/toast/CommonToast';
 import { TransactionResult } from '@/types/contract-interactions/HTS';
 import { handleAPIErrors } from '../../../shared/methods/handleAPIErrors';
@@ -35,6 +35,7 @@ import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/
 import { useUpdateTransactionResultsToLocalStorage } from '../../../shared/hooks/useUpdateLocalStorage';
 import { htsTokenDeductionParamFields } from '@/utils/contract-interactions/HTS/token-management/constant';
 import { SharedFormInputField, SharedExecuteButtonWithFee } from '../../../shared/components/ParamInputForm';
+import useFilterTransactionsByContractAddress from '../../../shared/hooks/useFilterTransactionsByContractAddress';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 
 interface PageProps {
@@ -57,9 +58,9 @@ const ManageTokenDelete = ({ baseContract }: PageProps) => {
   };
   const [paramValues, setParamValues] = useState<any>(initialParamValues);
 
-  const transactionResultsToShow = useMemo(
-    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
-    [transactionResults, currentContractAddress]
+  const transactionResultsToShow = useFilterTransactionsByContractAddress(
+    transactionResults,
+    currentContractAddress
   );
 
   /** @dev retrieve token creation results from localStorage to maintain data on re-renders */

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-management-contract/methods/manageTokenInfo/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-management-contract/methods/manageTokenInfo/index.tsx
@@ -31,6 +31,7 @@ import { usePaginatedTxResults } from '../../../shared/hooks/usePaginatedTxResul
 import { SharedSigningKeysComponent } from '../../../shared/components/SigningKeysForm';
 import { TransactionResultTable } from '../../../shared/components/TransactionResultTable';
 import { HederaTokenKeyTypes, TRANSACTION_PAGE_SIZE } from '../../../shared/states/commonStates';
+import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { handleSanitizeHederaFormInputs } from '../../../shared/methods/handleSanitizeFormInputs';
 import { manageTokenInfomation } from '@/api/hedera/hts-interactions/tokenManagement-interactions';
 import { useUpdateTransactionResultsToLocalStorage } from '../../../shared/hooks/useUpdateLocalStorage';
@@ -53,7 +54,6 @@ import {
   IHederaTokenServiceExpiry,
   IHederaTokenServiceHederaToken,
 } from '@/types/contract-interactions/HTS';
-import { HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 
 interface PageProps {
   baseContract: Contract;
@@ -69,8 +69,9 @@ const ManageTokenInfo = ({ baseContract }: PageProps) => {
   const hederaNetwork = JSON.parse(Cookies.get('_network') as string);
   const [APIMethods, setAPIMethods] = useState<API_NAMES>('UPDATE_INFO');
   const [currentTransactionPage, setCurrentTransactionPage] = useState(1);
-  const transactionResultStorageKey = HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['TOKEN-MANAGE']['TOKEN-INFO'];
+  const currentContractAddress = Cookies.get(CONTRACT_NAMES.TOKEN_MANAGE) as string;
   const [transactionResults, setTransactionResults] = useState<TransactionResult[]>([]);
+  const transactionResultStorageKey = HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['TOKEN-MANAGE']['TOKEN-INFO'];
   const APIButtonTitles: { API: API_NAMES; apiSwitchTitle: string; executeTitle: string }[] = [
     {
       API: 'UPDATE_INFO',
@@ -106,6 +107,11 @@ const ManageTokenInfo = ({ baseContract }: PageProps) => {
     hederaTokenAddress: '',
   };
   const [paramValues, setParamValues] = useState<any>(initialParamValues);
+
+  const transactionResultsToShow = useMemo(
+    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
+    [transactionResults, currentContractAddress]
+  );
 
   const HederaTokenKeyValueType: IHederaTokenServiceKeyValueType[] = [
     'inheritAccountKey',
@@ -156,7 +162,7 @@ const ManageTokenInfo = ({ baseContract }: PageProps) => {
   }, [toaster, transactionResultStorageKey]);
 
   // declare a paginatedTransactionResults
-  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResults);
+  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResultsToShow);
 
   /** @dev handle form inputs on change */
   const handleInputOnChange = (e: any, param: string) => {
@@ -256,6 +262,7 @@ const ManageTokenInfo = ({ baseContract }: PageProps) => {
         transactionHash,
         setTransactionResults,
         tokenAddress: hederaTokenAddress,
+        sessionedContractAddress: currentContractAddress,
         transactionType: `HTS-${APIMethods.replace('_', '-')}`,
       });
       return;
@@ -268,6 +275,7 @@ const ManageTokenInfo = ({ baseContract }: PageProps) => {
           tokenAddress: hederaTokenAddress,
           transactionTimeStamp: Date.now(),
           txHash: transactionHash as string,
+          sessionedContractAddress: currentContractAddress,
           transactionType: `HTS-${APIMethods.replace('_', '-')}`,
         },
       ]);
@@ -392,7 +400,7 @@ const ManageTokenInfo = ({ baseContract }: PageProps) => {
       </div>
 
       {/* transaction results table */}
-      {transactionResults.length > 0 && (
+      {transactionResultsToShow.length > 0 && (
         <TransactionResultTable
           API="TokenCreate"
           hederaNetwork={hederaNetwork}

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-management-contract/methods/manageTokenInfo/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-management-contract/methods/manageTokenInfo/index.tsx
@@ -35,6 +35,7 @@ import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/
 import { handleSanitizeHederaFormInputs } from '../../../shared/methods/handleSanitizeFormInputs';
 import { manageTokenInfomation } from '@/api/hedera/hts-interactions/tokenManagement-interactions';
 import { useUpdateTransactionResultsToLocalStorage } from '../../../shared/hooks/useUpdateLocalStorage';
+import useFilterTransactionsByContractAddress from '../../../shared/hooks/useFilterTransactionsByContractAddress';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 import {
   DEFAULT_HEDERA_TOKEN_INFO_VALUE,
@@ -108,9 +109,9 @@ const ManageTokenInfo = ({ baseContract }: PageProps) => {
   };
   const [paramValues, setParamValues] = useState<any>(initialParamValues);
 
-  const transactionResultsToShow = useMemo(
-    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
-    [transactionResults, currentContractAddress]
+  const transactionResultsToShow = useFilterTransactionsByContractAddress(
+    transactionResults,
+    currentContractAddress
   );
 
   const HederaTokenKeyValueType: IHederaTokenServiceKeyValueType[] = [

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-management-contract/methods/manageTokenPermission/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-management-contract/methods/manageTokenPermission/index.tsx
@@ -21,7 +21,7 @@
 import Cookies from 'js-cookie';
 import { Contract } from 'ethers';
 import { useToast } from '@chakra-ui/react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { CommonErrorToast } from '@/components/toast/CommonToast';
 import { TransactionResult } from '@/types/contract-interactions/HTS';
 import { handleAPIErrors } from '../../../shared/methods/handleAPIErrors';
@@ -34,6 +34,7 @@ import { handleSanitizeHederaFormInputs } from '../../../shared/methods/handleSa
 import { manageTokenPermission } from '@/api/hedera/hts-interactions/tokenManagement-interactions';
 import { useUpdateTransactionResultsToLocalStorage } from '../../../shared/hooks/useUpdateLocalStorage';
 import { htsTokenPermissionParamFields } from '@/utils/contract-interactions/HTS/token-management/constant';
+import useFilterTransactionsByContractAddress from '../../../shared/hooks/useFilterTransactionsByContractAddress';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 import {
   SharedFormButton,
@@ -90,9 +91,9 @@ const ManageTokenPermission = ({ baseContract }: PageProps) => {
     { API: 'SET_APPROVAL', apiSwitchTitle: 'Set Approval', executeTitle: 'Set Approval For All' },
   ];
 
-  const transactionResultsToShow = useMemo(
-    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
-    [transactionResults, currentContractAddress]
+  const transactionResultsToShow = useFilterTransactionsByContractAddress(
+    transactionResults,
+    currentContractAddress
   );
 
   /** @dev retrieve token creation results from localStorage to maintain data on re-renders */

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-management-contract/methods/manageTokenPermission/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-management-contract/methods/manageTokenPermission/index.tsx
@@ -21,24 +21,24 @@
 import Cookies from 'js-cookie';
 import { Contract } from 'ethers';
 import { useToast } from '@chakra-ui/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { CommonErrorToast } from '@/components/toast/CommonToast';
 import { TransactionResult } from '@/types/contract-interactions/HTS';
 import { handleAPIErrors } from '../../../shared/methods/handleAPIErrors';
 import { TRANSACTION_PAGE_SIZE } from '../../../shared/states/commonStates';
 import { useToastSuccessful } from '../../../shared/hooks/useToastSuccessful';
-import { HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { usePaginatedTxResults } from '../../../shared/hooks/usePaginatedTxResults';
 import { TransactionResultTable } from '../../../shared/components/TransactionResultTable';
+import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { handleSanitizeHederaFormInputs } from '../../../shared/methods/handleSanitizeFormInputs';
 import { manageTokenPermission } from '@/api/hedera/hts-interactions/tokenManagement-interactions';
 import { useUpdateTransactionResultsToLocalStorage } from '../../../shared/hooks/useUpdateLocalStorage';
 import { htsTokenPermissionParamFields } from '@/utils/contract-interactions/HTS/token-management/constant';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 import {
-  SharedExecuteButtonWithFee,
   SharedFormButton,
   SharedFormInputField,
+  SharedExecuteButtonWithFee,
 } from '../../../shared/components/ParamInputForm';
 
 interface PageProps {
@@ -56,6 +56,7 @@ const ManageTokenPermission = ({ baseContract }: PageProps) => {
   const [currentTransactionPage, setCurrentTransactionPage] = useState(1);
   const tokenCommonFields = ['hederaTokenAddress', 'targetApprovedAddress'];
   const [APIMethods, setAPIMethods] = useState<API_NAMES>('APPROVED_FUNGIBLE');
+  const currentContractAddress = Cookies.get(CONTRACT_NAMES.TOKEN_MANAGE) as string;
   const [transactionResults, setTransactionResults] = useState<TransactionResult[]>([]);
   const transactionResultStorageKey =
     HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['TOKEN-MANAGE']['TOKEN-PERMISSION'];
@@ -89,6 +90,11 @@ const ManageTokenPermission = ({ baseContract }: PageProps) => {
     { API: 'SET_APPROVAL', apiSwitchTitle: 'Set Approval', executeTitle: 'Set Approval For All' },
   ];
 
+  const transactionResultsToShow = useMemo(
+    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
+    [transactionResults, currentContractAddress]
+  );
+
   /** @dev retrieve token creation results from localStorage to maintain data on re-renders */
   useEffect(() => {
     handleRetrievingTransactionResultsFromLocalStorage(
@@ -100,7 +106,7 @@ const ManageTokenPermission = ({ baseContract }: PageProps) => {
   }, [toaster, transactionResultStorageKey]);
 
   // declare a paginatedTransactionResults
-  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResults);
+  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResultsToShow);
 
   /** @dev handle form inputs on change */
   const handleInputOnChange = (e: any, param: string) => {
@@ -162,6 +168,7 @@ const ManageTokenPermission = ({ baseContract }: PageProps) => {
         setTransactionResults,
         tokenAddress: hederaTokenAddress,
         transactionType: transactionTypeMap[API],
+        sessionedContractAddress: currentContractAddress,
       });
       return;
     } else {
@@ -174,6 +181,7 @@ const ManageTokenPermission = ({ baseContract }: PageProps) => {
           transactionTimeStamp: Date.now(),
           txHash: transactionHash as string,
           transactionType: transactionTypeMap[API],
+          sessionedContractAddress: currentContractAddress,
         },
       ]);
 
@@ -317,7 +325,7 @@ const ManageTokenPermission = ({ baseContract }: PageProps) => {
       </div>
 
       {/* transaction results table */}
-      {transactionResults.length > 0 && (
+      {transactionResultsToShow.length > 0 && (
         <TransactionResultTable
           API="TokenCreate"
           hederaNetwork={hederaNetwork}

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-management-contract/methods/manageTokenRelation/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-management-contract/methods/manageTokenRelation/index.tsx
@@ -37,6 +37,7 @@ import { useUpdateTransactionResultsToLocalStorage } from '../../../shared/hooks
 import { htsTokenRelationParamFields } from '@/utils/contract-interactions/HTS/token-management/constant';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 import {
+  CONTRACT_NAMES,
   HEDERA_BRANDING_COLORS,
   HEDERA_CHAKRA_INPUT_BOX_SIZES,
   HEDERA_TRANSACTION_RESULT_STORAGE_KEYS,
@@ -62,6 +63,7 @@ const ManageTokenRelation = ({ baseContract }: PageProps) => {
   const hederaNetwork = JSON.parse(Cookies.get('_network') as string);
   const [APIMethods, setAPIMethods] = useState<API_NAMES>('REVOKE_KYC');
   const [currentTransactionPage, setCurrentTransactionPage] = useState(1);
+  const currentContractAddress = Cookies.get(CONTRACT_NAMES.TOKEN_MANAGE) as string;
   const [transactionResults, setTransactionResults] = useState<TransactionResult[]>([]);
   const transactionResultStorageKey =
     HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['TOKEN-MANAGE']['TOKEN-RELATION'];
@@ -109,6 +111,11 @@ const ManageTokenRelation = ({ baseContract }: PageProps) => {
     },
   ];
 
+  const transactionResultsToShow = useMemo(
+    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
+    [transactionResults, currentContractAddress]
+  );
+
   /** @dev handle adding metadata */
   const handleModifyTokenAddresses = (type: 'ADD' | 'REMOVE', removingFieldKey?: string) => {
     switch (type) {
@@ -136,7 +143,7 @@ const ManageTokenRelation = ({ baseContract }: PageProps) => {
   }, [toaster, transactionResultStorageKey]);
 
   // declare a paginatedTransactionResults
-  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResults);
+  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResultsToShow);
 
   /** @dev handle form inputs on change */
   const handleInputOnChange = (e: any, param: string, fieldKey?: string) => {
@@ -210,8 +217,9 @@ const ManageTokenRelation = ({ baseContract }: PageProps) => {
         toaster,
         transactionHash,
         setTransactionResults,
-        transactionType: `HTS-${API.replace('_', '-')}`,
         tokenAddress: paramValues.hederaTokenAddress,
+        transactionType: `HTS-${API.replace('_', '-')}`,
+        sessionedContractAddress: currentContractAddress,
       });
       return;
     } else {
@@ -224,6 +232,7 @@ const ManageTokenRelation = ({ baseContract }: PageProps) => {
           txHash: transactionHash as string,
           tokenAddress: paramValues.hederaTokenAddress,
           transactionType: `HTS-${API.replace('_', '-')}`,
+          sessionedContractAddress: currentContractAddress,
         },
       ]);
 
@@ -342,7 +351,7 @@ const ManageTokenRelation = ({ baseContract }: PageProps) => {
       </div>
 
       {/* transaction results table */}
-      {transactionResults.length > 0 && (
+      {transactionResultsToShow.length > 0 && (
         <TransactionResultTable
           API="TokenCreate"
           hederaNetwork={hederaNetwork}

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-management-contract/methods/manageTokenRelation/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-management-contract/methods/manageTokenRelation/index.tsx
@@ -35,6 +35,7 @@ import { manageTokenRelation } from '@/api/hedera/hts-interactions/tokenManageme
 import { handleSanitizeHederaFormInputs } from '../../../shared/methods/handleSanitizeFormInputs';
 import { useUpdateTransactionResultsToLocalStorage } from '../../../shared/hooks/useUpdateLocalStorage';
 import { htsTokenRelationParamFields } from '@/utils/contract-interactions/HTS/token-management/constant';
+import useFilterTransactionsByContractAddress from '../../../shared/hooks/useFilterTransactionsByContractAddress';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 import {
   CONTRACT_NAMES,
@@ -111,9 +112,9 @@ const ManageTokenRelation = ({ baseContract }: PageProps) => {
     },
   ];
 
-  const transactionResultsToShow = useMemo(
-    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
-    [transactionResults, currentContractAddress]
+  const transactionResultsToShow = useFilterTransactionsByContractAddress(
+    transactionResults,
+    currentContractAddress
   );
 
   /** @dev handle adding metadata */

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-management-contract/methods/manageTokenStatus/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-management-contract/methods/manageTokenStatus/index.tsx
@@ -19,9 +19,9 @@
  */
 
 import Cookies from 'js-cookie';
-import { Contract, isAddress } from 'ethers';
+import { useEffect, useState } from 'react';
 import { useToast } from '@chakra-ui/react';
-import { useEffect, useMemo, useState } from 'react';
+import { Contract, isAddress } from 'ethers';
 import { CommonErrorToast } from '@/components/toast/CommonToast';
 import { TransactionResult } from '@/types/contract-interactions/HTS';
 import { handleAPIErrors } from '../../../shared/methods/handleAPIErrors';
@@ -34,6 +34,7 @@ import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/
 import { SharedExecuteButton, SharedFormInputField } from '../../../shared/components/ParamInputForm';
 import { useUpdateTransactionResultsToLocalStorage } from '../../../shared/hooks/useUpdateLocalStorage';
 import { htsTokenStatusParamFields } from '@/utils/contract-interactions/HTS/token-management/constant';
+import useFilterTransactionsByContractAddress from '../../../shared/hooks/useFilterTransactionsByContractAddress';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 
 interface PageProps {
@@ -68,9 +69,9 @@ const ManageTokenStatus = ({ baseContract }: PageProps) => {
     },
   ];
 
-  const transactionResultsToShow = useMemo(
-    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
-    [transactionResults, currentContractAddress]
+  const transactionResultsToShow = useFilterTransactionsByContractAddress(
+    transactionResults,
+    currentContractAddress
   );
 
   /** @dev retrieve token creation results from localStorage to maintain data on re-renders */

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-management-contract/methods/manageTokenStatus/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-management-contract/methods/manageTokenStatus/index.tsx
@@ -21,20 +21,20 @@
 import Cookies from 'js-cookie';
 import { Contract, isAddress } from 'ethers';
 import { useToast } from '@chakra-ui/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { CommonErrorToast } from '@/components/toast/CommonToast';
 import { TransactionResult } from '@/types/contract-interactions/HTS';
 import { handleAPIErrors } from '../../../shared/methods/handleAPIErrors';
 import { TRANSACTION_PAGE_SIZE } from '../../../shared/states/commonStates';
 import { useToastSuccessful } from '../../../shared/hooks/useToastSuccessful';
-import { HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { usePaginatedTxResults } from '../../../shared/hooks/usePaginatedTxResults';
 import { TransactionResultTable } from '../../../shared/components/TransactionResultTable';
 import { manageTokenStatus } from '@/api/hedera/hts-interactions/tokenManagement-interactions';
+import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
+import { SharedExecuteButton, SharedFormInputField } from '../../../shared/components/ParamInputForm';
 import { useUpdateTransactionResultsToLocalStorage } from '../../../shared/hooks/useUpdateLocalStorage';
 import { htsTokenStatusParamFields } from '@/utils/contract-interactions/HTS/token-management/constant';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
-import { SharedExecuteButton, SharedFormInputField } from '../../../shared/components/ParamInputForm';
 
 interface PageProps {
   baseContract: Contract;
@@ -50,6 +50,7 @@ const ManageTokenStatus = ({ baseContract }: PageProps) => {
   const [paramValues, setParamValues] = useState(initialParamValues);
   const hederaNetwork = JSON.parse(Cookies.get('_network') as string);
   const [currentTransactionPage, setCurrentTransactionPage] = useState(1);
+  const currentContractAddress = Cookies.get(CONTRACT_NAMES.TOKEN_MANAGE) as string;
   const [transactionResults, setTransactionResults] = useState<TransactionResult[]>([]);
   const transactionResultStorageKey = HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['TOKEN-MANAGE']['TOKEN-STATUS'];
   const [isLoading, setIsLoading] = useState({
@@ -67,6 +68,11 @@ const ManageTokenStatus = ({ baseContract }: PageProps) => {
     },
   ];
 
+  const transactionResultsToShow = useMemo(
+    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
+    [transactionResults, currentContractAddress]
+  );
+
   /** @dev retrieve token creation results from localStorage to maintain data on re-renders */
   useEffect(() => {
     handleRetrievingTransactionResultsFromLocalStorage(
@@ -78,7 +84,7 @@ const ManageTokenStatus = ({ baseContract }: PageProps) => {
   }, [toaster, transactionResultStorageKey]);
 
   // declare a paginatedTransactionResults
-  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResults);
+  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResultsToShow);
 
   /** @dev handle form inputs on change */
   const handleInputOnChange = (e: any, param: string) => {
@@ -125,6 +131,7 @@ const ManageTokenStatus = ({ baseContract }: PageProps) => {
         setTransactionResults,
         transactionType: `HTS-TOKEN-${API}`,
         tokenAddress: paramValues.hederaTokenAddress,
+        sessionedContractAddress: currentContractAddress,
       });
       return;
     } else {
@@ -137,6 +144,7 @@ const ManageTokenStatus = ({ baseContract }: PageProps) => {
           txHash: transactionHash as string,
           transactionType: `HTS-TOKEN-${API}`,
           tokenAddress: paramValues.hederaTokenAddress,
+          sessionedContractAddress: currentContractAddress,
         },
       ]);
 
@@ -195,7 +203,7 @@ const ManageTokenStatus = ({ baseContract }: PageProps) => {
       </div>
 
       {/* transaction results table */}
-      {transactionResults.length > 0 && (
+      {transactionResultsToShow.length > 0 && (
         <TransactionResultTable
           API="TokenCreate"
           hederaNetwork={hederaNetwork}

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-management-contract/methods/manageTokenSupplyReduction/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-management-contract/methods/manageTokenSupplyReduction/index.tsx
@@ -34,6 +34,7 @@ import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/
 import { handleSanitizeHederaFormInputs } from '../../../shared/methods/handleSanitizeFormInputs';
 import { useUpdateTransactionResultsToLocalStorage } from '../../../shared/hooks/useUpdateLocalStorage';
 import { htsTokenDeductionParamFields } from '@/utils/contract-interactions/HTS/token-management/constant';
+import useFilterTransactionsByContractAddress from '../../../shared/hooks/useFilterTransactionsByContractAddress';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 import {
   SharedFormButton,
@@ -97,9 +98,9 @@ const ManageTokenDeduction = ({ baseContract }: PageProps) => {
     }
   }, [APIMethods]);
 
-  const transactionResultsToShow = useMemo(
-    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
-    [transactionResults, currentContractAddress]
+  const transactionResultsToShow = useFilterTransactionsByContractAddress(
+    transactionResults,
+    currentContractAddress
   );
 
   /** @dev retrieve token creation results from localStorage to maintain data on re-renders */

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-management-contract/methods/manageTokenSupplyReduction/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-management-contract/methods/manageTokenSupplyReduction/index.tsx
@@ -27,10 +27,10 @@ import { TransactionResult } from '@/types/contract-interactions/HTS';
 import { handleAPIErrors } from '../../../shared/methods/handleAPIErrors';
 import { TRANSACTION_PAGE_SIZE } from '../../../shared/states/commonStates';
 import { useToastSuccessful } from '../../../shared/hooks/useToastSuccessful';
-import { HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { usePaginatedTxResults } from '../../../shared/hooks/usePaginatedTxResults';
 import { TransactionResultTable } from '../../../shared/components/TransactionResultTable';
 import { manageTokenDeduction } from '@/api/hedera/hts-interactions/tokenManagement-interactions';
+import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { handleSanitizeHederaFormInputs } from '../../../shared/methods/handleSanitizeFormInputs';
 import { useUpdateTransactionResultsToLocalStorage } from '../../../shared/hooks/useUpdateLocalStorage';
 import { htsTokenDeductionParamFields } from '@/utils/contract-interactions/HTS/token-management/constant';
@@ -55,6 +55,7 @@ const ManageTokenDeduction = ({ baseContract }: PageProps) => {
   const hederaNetwork = JSON.parse(Cookies.get('_network') as string);
   const [currentTransactionPage, setCurrentTransactionPage] = useState(1);
   const [APIMethods, setAPIMethods] = useState<API_NAMES>('WIPE_FUNGIBLE');
+  const currentContractAddress = Cookies.get(CONTRACT_NAMES.TOKEN_MANAGE) as string;
   const [transactionResults, setTransactionResults] = useState<TransactionResult[]>([]);
   const transactionResultStorageKey =
     HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['TOKEN-MANAGE']['TOKEN-REDUCTION'];
@@ -96,6 +97,11 @@ const ManageTokenDeduction = ({ baseContract }: PageProps) => {
     }
   }, [APIMethods]);
 
+  const transactionResultsToShow = useMemo(
+    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
+    [transactionResults, currentContractAddress]
+  );
+
   /** @dev retrieve token creation results from localStorage to maintain data on re-renders */
   useEffect(() => {
     handleRetrievingTransactionResultsFromLocalStorage(
@@ -107,7 +113,7 @@ const ManageTokenDeduction = ({ baseContract }: PageProps) => {
   }, [toaster, transactionResultStorageKey]);
 
   // declare a paginatedTransactionResults
-  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResults);
+  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResultsToShow);
   /** @dev handle form inputs on change */
   const handleInputOnChange = (e: any, param: string) => {
     setParamValues((prev: any) => ({ ...prev, [param]: e.target.value }));
@@ -160,6 +166,7 @@ const ManageTokenDeduction = ({ baseContract }: PageProps) => {
         setTransactionResults,
         tokenAddress: hederaTokenAddress,
         transactionType: transactionTypeMap[API],
+        sessionedContractAddress: currentContractAddress,
       });
       return;
     } else {
@@ -172,6 +179,7 @@ const ManageTokenDeduction = ({ baseContract }: PageProps) => {
           tokenAddress: hederaTokenAddress,
           txHash: transactionHash as string,
           transactionType: transactionTypeMap[API],
+          sessionedContractAddress: currentContractAddress,
         },
       ]);
 
@@ -254,7 +262,7 @@ const ManageTokenDeduction = ({ baseContract }: PageProps) => {
       </div>
 
       {/* transaction results table */}
-      {transactionResults.length > 0 && (
+      {transactionResultsToShow.length > 0 && (
         <TransactionResultTable
           API="TokenCreate"
           hederaNetwork={hederaNetwork}

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-query-contract/methods/querySpecificToken/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-query-contract/methods/querySpecificToken/index.tsx
@@ -19,7 +19,7 @@
  */
 
 import Cookies from 'js-cookie';
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect } from 'react';
 import { Contract, isAddress } from 'ethers';
 import { CommonErrorToast } from '@/components/toast/CommonToast';
 import { Select, useDisclosure, useToast } from '@chakra-ui/react';
@@ -32,10 +32,11 @@ import { IHederaTokenServiceKeyType, TransactionResult } from '@/types/contract-
 import { queryTokenSpecificInfomation } from '@/api/hedera/hts-interactions/tokenQuery-interactions';
 import { htsQueryTokenInfoParamFields } from '@/utils/contract-interactions/HTS/token-query/constant';
 import { useUpdateTransactionResultsToLocalStorage } from '../../../shared/hooks/useUpdateLocalStorage';
+import useFilterTransactionsByContractAddress from '../../../shared/hooks/useFilterTransactionsByContractAddress';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 import {
-  SharedExecuteButton,
   SharedFormButton,
+  SharedExecuteButton,
   SharedFormInputField,
 } from '../../../shared/components/ParamInputForm';
 import {
@@ -130,9 +131,9 @@ const QueryTokenSpecificInfomation = ({ baseContract }: PageProps) => {
     },
   ];
 
-  const transactionResultsToShow = useMemo(
-    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
-    [transactionResults, currentContractAddress]
+  const transactionResultsToShow = useFilterTransactionsByContractAddress(
+    transactionResults,
+    currentContractAddress
   );
 
   /** @dev retrieve token creation results from localStorage to maintain data on re-renders */

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-query-contract/methods/queryTokenGeneralInfo/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-query-contract/methods/queryTokenGeneralInfo/index.tsx
@@ -34,10 +34,11 @@ import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/
 import { queryTokenGeneralInfomation } from '@/api/hedera/hts-interactions/tokenQuery-interactions';
 import { htsQueryTokenInfoParamFields } from '@/utils/contract-interactions/HTS/token-query/constant';
 import { useUpdateTransactionResultsToLocalStorage } from '../../../shared/hooks/useUpdateLocalStorage';
+import useFilterTransactionsByContractAddress from '../../../shared/hooks/useFilterTransactionsByContractAddress';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 import {
-  SharedExecuteButton,
   SharedFormButton,
+  SharedExecuteButton,
   SharedFormInputField,
 } from '../../../shared/components/ParamInputForm';
 
@@ -110,9 +111,9 @@ const QueryTokenGeneralInfomation = ({ baseContract }: PageProps) => {
     },
   ];
 
-  const transactionResultsToShow = useMemo(
-    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
-    [transactionResults, currentContractAddress]
+  const transactionResultsToShow = useFilterTransactionsByContractAddress(
+    transactionResults,
+    currentContractAddress
   );
 
   /** @dev retrieve token creation results from localStorage to maintain data on re-renders */

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-query-contract/methods/queryTokenGeneralInfo/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-query-contract/methods/queryTokenGeneralInfo/index.tsx
@@ -26,11 +26,11 @@ import { CommonErrorToast } from '@/components/toast/CommonToast';
 import { TransactionResult } from '@/types/contract-interactions/HTS';
 import { handleAPIErrors } from '../../../shared/methods/handleAPIErrors';
 import { TRANSACTION_PAGE_SIZE } from '../../../shared/states/commonStates';
-import { HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { usePaginatedTxResults } from '../../../shared/hooks/usePaginatedTxResults';
 import TokenGeneralInfoModal from '../../../shared/components/TokenGeneralInfoModal';
 import { TransactionResultTable } from '../../../shared/components/TransactionResultTable';
 import { handleSanitizeHederaFormInputs } from '../../../shared/methods/handleSanitizeFormInputs';
+import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { queryTokenGeneralInfomation } from '@/api/hedera/hts-interactions/tokenQuery-interactions';
 import { htsQueryTokenInfoParamFields } from '@/utils/contract-interactions/HTS/token-query/constant';
 import { useUpdateTransactionResultsToLocalStorage } from '../../../shared/hooks/useUpdateLocalStorage';
@@ -61,6 +61,7 @@ const QueryTokenGeneralInfomation = ({ baseContract }: PageProps) => {
   const [currentTransactionPage, setCurrentTransactionPage] = useState(1);
   const [tokenInfoFromTxResult, setTokenInfoFromTxResult] = useState<any>();
   const [tokenAddressFromTxResult, setTokenAddressFromTxResult] = useState('');
+  const currentContractAddress = Cookies.get(CONTRACT_NAMES.TOKEN_QUERY) as string;
   const [transactionResults, setTransactionResults] = useState<TransactionResult[]>([]);
   const transactionResultStorageKey =
     HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['TOKEN-QUERY']['TOKEN-GENERAL-INFO'];
@@ -109,6 +110,11 @@ const QueryTokenGeneralInfomation = ({ baseContract }: PageProps) => {
     },
   ];
 
+  const transactionResultsToShow = useMemo(
+    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
+    [transactionResults, currentContractAddress]
+  );
+
   /** @dev retrieve token creation results from localStorage to maintain data on re-renders */
   useEffect(() => {
     handleRetrievingTransactionResultsFromLocalStorage(
@@ -120,7 +126,7 @@ const QueryTokenGeneralInfomation = ({ baseContract }: PageProps) => {
   }, [toaster, transactionResultStorageKey]);
 
   // declare a paginatedTransactionResults
-  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResults);
+  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResultsToShow);
 
   /** @dev handle form inputs on change */
   const handleInputOnChange = (e: any, param: string) => {
@@ -169,6 +175,7 @@ const QueryTokenGeneralInfomation = ({ baseContract }: PageProps) => {
         transactionHash: transactionHash,
         transactionType: transactionTypeMap[API],
         tokenAddress: paramValues.hederaTokenAddress,
+        sessionedContractAddress: currentContractAddress,
       });
       return;
     } else {
@@ -184,6 +191,7 @@ const QueryTokenGeneralInfomation = ({ baseContract }: PageProps) => {
           transactionType: transactionTypeMap[API],
           tokenInfo: tokenInfoResult[eventMaps[API]],
           tokenAddress: paramValues.hederaTokenAddress,
+          sessionedContractAddress: currentContractAddress,
         },
       ]);
       setIsSuccessful(true);
@@ -249,7 +257,7 @@ const QueryTokenGeneralInfomation = ({ baseContract }: PageProps) => {
       </div>
 
       {/* transaction results table */}
-      {transactionResults.length > 0 && (
+      {transactionResultsToShow.length > 0 && (
         <TransactionResultTable
           API="QueryTokenGeneralInfo"
           onOpen={onOpen}

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-query-contract/methods/queryTokenPermission/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-query-contract/methods/queryTokenPermission/index.tsx
@@ -34,6 +34,7 @@ import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/
 import { useUpdateTransactionResultsToLocalStorage } from '../../../shared/hooks/useUpdateLocalStorage';
 import { queryTokenPermissionInformation } from '@/api/hedera/hts-interactions/tokenQuery-interactions';
 import { htsQueryTokenPermissionParamFields } from '@/utils/contract-interactions/HTS/token-query/constant';
+import useFilterTransactionsByContractAddress from '../../../shared/hooks/useFilterTransactionsByContractAddress';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 import {
   SharedExecuteButton,
@@ -108,9 +109,9 @@ const QueryTokenPermissionInfomation = ({ baseContract }: PageProps) => {
     GET_APPROVED: 'ApprovedAddress',
   };
 
-  const transactionResultsToShow = useMemo(
-    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
-    [transactionResults, currentContractAddress]
+  const transactionResultsToShow = useFilterTransactionsByContractAddress(
+    transactionResults,
+    currentContractAddress
   );
 
   /** @dev retrieve token creation results from localStorage to maintain data on re-renders */

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-query-contract/methods/queryTokenStatus/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-query-contract/methods/queryTokenStatus/index.tsx
@@ -20,21 +20,22 @@
 
 import Cookies from 'js-cookie';
 import { Contract } from 'ethers';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useToast } from '@chakra-ui/react';
 import { CommonErrorToast } from '@/components/toast/CommonToast';
 import { TransactionResult } from '@/types/contract-interactions/HTS';
 import { handleAPIErrors } from '../../../shared/methods/handleAPIErrors';
 import { TRANSACTION_PAGE_SIZE } from '../../../shared/states/commonStates';
 import { useToastSuccessful } from '../../../shared/hooks/useToastSuccessful';
-import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { usePaginatedTxResults } from '../../../shared/hooks/usePaginatedTxResults';
 import { TransactionResultTable } from '../../../shared/components/TransactionResultTable';
 import { handleSanitizeHederaFormInputs } from '../../../shared/methods/handleSanitizeFormInputs';
+import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { queryTokenStatusInformation } from '@/api/hedera/hts-interactions/tokenQuery-interactions';
 import { SharedExecuteButton, SharedFormInputField } from '../../../shared/components/ParamInputForm';
 import { useUpdateTransactionResultsToLocalStorage } from '../../../shared/hooks/useUpdateLocalStorage';
 import { htsQueryTokenStatusParamFields } from '@/utils/contract-interactions/HTS/token-query/constant';
+import useFilterTransactionsByContractAddress from '../../../shared/hooks/useFilterTransactionsByContractAddress';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 
 interface PageProps {
@@ -83,9 +84,9 @@ const QueryTokenStatusInfomation = ({ baseContract }: PageProps) => {
     IS_FROZEN: 'Frozen',
   };
 
-  const transactionResultsToShow = useMemo(
-    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
-    [transactionResults, currentContractAddress]
+  const transactionResultsToShow = useFilterTransactionsByContractAddress(
+    transactionResults,
+    currentContractAddress
   );
 
   /** @dev retrieve token creation results from localStorage to maintain data on re-renders */

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-query-contract/methods/queryTokenValidity/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-query-contract/methods/queryTokenValidity/index.tsx
@@ -19,9 +19,9 @@
  */
 
 import Cookies from 'js-cookie';
-import { useEffect, useState } from 'react';
 import { useToast } from '@chakra-ui/react';
 import { Contract, isAddress } from 'ethers';
+import { useEffect, useMemo, useState } from 'react';
 import { CommonErrorToast } from '@/components/toast/CommonToast';
 import { TransactionResult } from '@/types/contract-interactions/HTS';
 import { handleAPIErrors } from '../../../shared/methods/handleAPIErrors';
@@ -30,6 +30,7 @@ import { useToastSuccessful } from '../../../shared/hooks/useToastSuccessful';
 import { usePaginatedTxResults } from '../../../shared/hooks/usePaginatedTxResults';
 import { TransactionResultTable } from '../../../shared/components/TransactionResultTable';
 import { queryTokenValidity } from '@/api/hedera/hts-interactions/tokenQuery-interactions';
+import { SharedExecuteButton, SharedFormInputField } from '../../../shared/components/ParamInputForm';
 import { useUpdateTransactionResultsToLocalStorage } from '../../../shared/hooks/useUpdateLocalStorage';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 import {
@@ -37,8 +38,8 @@ import {
   HEDERA_CHAKRA_INPUT_BOX_SIZES,
   HEDERA_TRANSACTION_RESULT_STORAGE_KEYS,
   HEDERA_CHAKRA_INPUT_BOX_SHARED_CLASSNAME,
+  CONTRACT_NAMES,
 } from '@/utils/common/constants';
-import { SharedExecuteButton, SharedFormInputField } from '../../../shared/components/ParamInputForm';
 
 interface PageProps {
   baseContract: Contract;
@@ -53,8 +54,13 @@ const QueryTokenValidity = ({ baseContract }: PageProps) => {
   const [paramValues, setParamValues] = useState(initialParamValues);
   const hederaNetwork = JSON.parse(Cookies.get('_network') as string);
   const [currentTransactionPage, setCurrentTransactionPage] = useState(1);
-  const transactionResultStorageKey = HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['TOKEN-QUERY']['TOKEN-VALIDITY'];
+  const currentContractAddress = Cookies.get(CONTRACT_NAMES.TOKEN_QUERY) as string;
   const [transactionResults, setTransactionResults] = useState<TransactionResult[]>([]);
+  const transactionResultStorageKey = HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['TOKEN-QUERY']['TOKEN-VALIDITY'];
+  const transactionResultsToShow = useMemo(
+    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
+    [transactionResults, currentContractAddress]
+  );
 
   /** @dev retrieve token creation results from localStorage to maintain data on re-renders */
   useEffect(() => {
@@ -67,7 +73,7 @@ const QueryTokenValidity = ({ baseContract }: PageProps) => {
   }, [toaster, transactionResultStorageKey]);
 
   // declare a paginatedTransactionResults
-  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResults);
+  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResultsToShow);
 
   /** @dev handle form inputs on change */
   const handleInputOnChange = (e: any, param: string) => {
@@ -106,6 +112,7 @@ const QueryTokenValidity = ({ baseContract }: PageProps) => {
         setTransactionResults,
         transactionType: 'HTS-IS-TOKEN',
         tokenAddress: paramValues.hederaTokenAddress,
+        sessionedContractAddress: currentContractAddress,
       });
       return;
     } else {
@@ -119,6 +126,7 @@ const QueryTokenValidity = ({ baseContract }: PageProps) => {
           txHash: transactionHash as string,
           transactionTimeStamp: Date.now(),
           tokenAddress: paramValues.hederaTokenAddress,
+          sessionedContractAddress: currentContractAddress,
         },
       ]);
 
@@ -169,7 +177,7 @@ const QueryTokenValidity = ({ baseContract }: PageProps) => {
       </div>
 
       {/* transaction results table */}
-      {transactionResults.length > 0 && (
+      {transactionResultsToShow.length > 0 && (
         <TransactionResultTable
           API="QueryValidity"
           hederaNetwork={hederaNetwork}

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-query-contract/methods/queryTokenValidity/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-query-contract/methods/queryTokenValidity/index.tsx
@@ -20,8 +20,8 @@
 
 import Cookies from 'js-cookie';
 import { useToast } from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
 import { Contract, isAddress } from 'ethers';
-import { useEffect, useMemo, useState } from 'react';
 import { CommonErrorToast } from '@/components/toast/CommonToast';
 import { TransactionResult } from '@/types/contract-interactions/HTS';
 import { handleAPIErrors } from '../../../shared/methods/handleAPIErrors';
@@ -32,13 +32,14 @@ import { TransactionResultTable } from '../../../shared/components/TransactionRe
 import { queryTokenValidity } from '@/api/hedera/hts-interactions/tokenQuery-interactions';
 import { SharedExecuteButton, SharedFormInputField } from '../../../shared/components/ParamInputForm';
 import { useUpdateTransactionResultsToLocalStorage } from '../../../shared/hooks/useUpdateLocalStorage';
+import useFilterTransactionsByContractAddress from '../../../shared/hooks/useFilterTransactionsByContractAddress';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 import {
+  CONTRACT_NAMES,
   HEDERA_BRANDING_COLORS,
   HEDERA_CHAKRA_INPUT_BOX_SIZES,
   HEDERA_TRANSACTION_RESULT_STORAGE_KEYS,
   HEDERA_CHAKRA_INPUT_BOX_SHARED_CLASSNAME,
-  CONTRACT_NAMES,
 } from '@/utils/common/constants';
 
 interface PageProps {
@@ -57,9 +58,9 @@ const QueryTokenValidity = ({ baseContract }: PageProps) => {
   const currentContractAddress = Cookies.get(CONTRACT_NAMES.TOKEN_QUERY) as string;
   const [transactionResults, setTransactionResults] = useState<TransactionResult[]>([]);
   const transactionResultStorageKey = HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['TOKEN-QUERY']['TOKEN-VALIDITY'];
-  const transactionResultsToShow = useMemo(
-    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
-    [transactionResults, currentContractAddress]
+  const transactionResultsToShow = useFilterTransactionsByContractAddress(
+    transactionResults,
+    currentContractAddress
   );
 
   /** @dev retrieve token creation results from localStorage to maintain data on re-renders */

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-transfer-contract/method/transferCrypto/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-transfer-contract/method/transferCrypto/index.tsx
@@ -20,9 +20,9 @@
 
 import Cookies from 'js-cookie';
 import { Contract } from 'ethers';
+import { useEffect, useState } from 'react';
 import { useToast } from '@chakra-ui/react';
 import TokenTransferForm from './TokenTransferForm';
-import { useEffect, useMemo, useState } from 'react';
 import CryptoTransferForm from './CryptoTransferForm';
 import { handleAPIErrors } from '../../../shared/methods/handleAPIErrors';
 import { TRANSACTION_PAGE_SIZE } from '../../../shared/states/commonStates';
@@ -34,6 +34,7 @@ import { TransactionResultTable } from '../../../shared/components/TransactionRe
 import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { useUpdateTransactionResultsToLocalStorage } from '../../../shared/hooks/useUpdateLocalStorage';
 import { prepareCryptoTransferList, prepareTokenTransferList } from './helpers/prepareCryptoTransferValues';
+import useFilterTransactionsByContractAddress from '../../../shared/hooks/useFilterTransactionsByContractAddress';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 import {
   IHederaTokenServiceTokenTransferList,
@@ -65,10 +66,9 @@ const CryptoTransfer = ({ baseContract }: PageProps) => {
   const [cryptoTransferParamValues, setCryptoTransferParamValues] = useState<CryptoTransferParam[]>([]);
   const transactionResultStorageKey =
     HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['TOKEN-TRANSFER']['CRYPTO-TRANSFER'];
-
-  const transactionResultsToShow = useMemo(
-    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
-    [transactionResults, currentContractAddress]
+  const transactionResultsToShow = useFilterTransactionsByContractAddress(
+    transactionResults,
+    currentContractAddress
   );
 
   /** @dev retrieve token creation results from localStorage to maintain data on re-renders */

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-transfer-contract/method/transferCrypto/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-transfer-contract/method/transferCrypto/index.tsx
@@ -20,19 +20,20 @@
 
 import Cookies from 'js-cookie';
 import { Contract } from 'ethers';
-import { useEffect, useState } from 'react';
 import { useToast } from '@chakra-ui/react';
 import TokenTransferForm from './TokenTransferForm';
+import { useEffect, useMemo, useState } from 'react';
 import CryptoTransferForm from './CryptoTransferForm';
 import { handleAPIErrors } from '../../../shared/methods/handleAPIErrors';
 import { TRANSACTION_PAGE_SIZE } from '../../../shared/states/commonStates';
 import { useToastSuccessful } from '../../../shared/hooks/useToastSuccessful';
-import { HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { usePaginatedTxResults } from '../../../shared/hooks/usePaginatedTxResults';
 import { SharedExecuteButtonWithFee } from '../../../shared/components/ParamInputForm';
 import { transferCrypto } from '@/api/hedera/hts-interactions/tokenTransfer-interactions';
 import { TransactionResultTable } from '../../../shared/components/TransactionResultTable';
+import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { useUpdateTransactionResultsToLocalStorage } from '../../../shared/hooks/useUpdateLocalStorage';
+import { prepareCryptoTransferList, prepareTokenTransferList } from './helpers/prepareCryptoTransferValues';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 import {
   IHederaTokenServiceTokenTransferList,
@@ -44,7 +45,6 @@ import {
   TokenTransferParam,
   generateInitialTokenTransferParamValues,
 } from './helpers/generateInitialValues';
-import { prepareCryptoTransferList, prepareTokenTransferList } from './helpers/prepareCryptoTransferValues';
 
 interface PageProps {
   baseContract: Contract;
@@ -59,11 +59,17 @@ const CryptoTransfer = ({ baseContract }: PageProps) => {
   const hederaNetwork = JSON.parse(Cookies.get('_network') as string);
   const [currentTransactionPage, setCurrentTransactionPage] = useState(1);
   const contractCaller = JSON.parse(Cookies.get('_connectedAccounts') as string)[0];
+  const currentContractAddress = Cookies.get(CONTRACT_NAMES.TOKEN_TRANSFER) as string;
   const [transactionResults, setTransactionResults] = useState<TransactionResult[]>([]);
-  const transactionResultStorageKey =
-    HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['TOKEN-TRANSFER']['CRYPTO-TRANSFER'];
   const [tokenTransferParamValues, setTokenTransferParamValues] = useState<TokenTransferParam[]>([]);
   const [cryptoTransferParamValues, setCryptoTransferParamValues] = useState<CryptoTransferParam[]>([]);
+  const transactionResultStorageKey =
+    HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['TOKEN-TRANSFER']['CRYPTO-TRANSFER'];
+
+  const transactionResultsToShow = useMemo(
+    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
+    [transactionResults, currentContractAddress]
+  );
 
   /** @dev retrieve token creation results from localStorage to maintain data on re-renders */
   useEffect(() => {
@@ -246,6 +252,7 @@ const CryptoTransfer = ({ baseContract }: PageProps) => {
         transactionHash,
         setTransactionResults,
         transactionType: 'HTS-CRYPTO-TRANSFER',
+        sessionedContractAddress: currentContractAddress,
       });
       return;
     } else {
@@ -257,6 +264,7 @@ const CryptoTransfer = ({ baseContract }: PageProps) => {
           transactionTimeStamp: Date.now(),
           txHash: transactionHash as string,
           transactionType: 'HTS-CRYPTO-TRANSFER',
+          sessionedContractAddress: currentContractAddress,
         },
       ]);
 
@@ -314,7 +322,7 @@ const CryptoTransfer = ({ baseContract }: PageProps) => {
       </div>
 
       {/* transaction results table */}
-      {transactionResults.length > 0 && (
+      {transactionResultsToShow.length > 0 && (
         <TransactionResultTable
           API="CryptoTransfer"
           hederaNetwork={hederaNetwork}

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-transfer-contract/method/transferMultipleTokens/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-transfer-contract/method/transferMultipleTokens/index.tsx
@@ -33,6 +33,7 @@ import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/
 import { handleSanitizeHederaFormInputs } from '../../../shared/methods/handleSanitizeFormInputs';
 import { SmartContractExecutionResult, TransactionResult } from '@/types/contract-interactions/HTS';
 import { useUpdateTransactionResultsToLocalStorage } from '../../../shared/hooks/useUpdateLocalStorage';
+import useFilterTransactionsByContractAddress from '../../../shared/hooks/useFilterTransactionsByContractAddress';
 import { htsMultiTokensTransferParamFields } from '@/utils/contract-interactions/HTS/token-transfer/paramFieldConstant';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 import {
@@ -101,9 +102,9 @@ const TransferMultipleTokens = ({ baseContract }: PageProps) => {
     generateInitialNonFungibleParamValue(),
   ]);
 
-  const transactionResultsToShow = useMemo(
-    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
-    [transactionResults, currentContractAddress]
+  const transactionResultsToShow = useFilterTransactionsByContractAddress(
+    transactionResults,
+    currentContractAddress
   );
 
   /** @dev retrieve token creation results from localStorage to maintain data on re-renders */

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-transfer-contract/method/transferMultipleTokens/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-transfer-contract/method/transferMultipleTokens/index.tsx
@@ -22,12 +22,14 @@ import Cookies from 'js-cookie';
 import { Contract } from 'ethers';
 import { useToast } from '@chakra-ui/react';
 import { useEffect, useMemo, useState } from 'react';
+import TransferRecordForm from './TransferRecordForm';
 import { CommonErrorToast } from '@/components/toast/CommonToast';
 import { handleAPIErrors } from '../../../shared/methods/handleAPIErrors';
 import { TRANSACTION_PAGE_SIZE } from '../../../shared/states/commonStates';
 import { useToastSuccessful } from '../../../shared/hooks/useToastSuccessful';
 import { usePaginatedTxResults } from '../../../shared/hooks/usePaginatedTxResults';
 import { TransactionResultTable } from '../../../shared/components/TransactionResultTable';
+import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { handleSanitizeHederaFormInputs } from '../../../shared/methods/handleSanitizeFormInputs';
 import { SmartContractExecutionResult, TransactionResult } from '@/types/contract-interactions/HTS';
 import { useUpdateTransactionResultsToLocalStorage } from '../../../shared/hooks/useUpdateLocalStorage';
@@ -48,8 +50,6 @@ import {
   SharedFormInputField,
   SharedExecuteButtonWithFee,
 } from '../../../shared/components/ParamInputForm';
-import TransferRecordForm from './TransferRecordForm';
-import { HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 
 interface PageProps {
   baseContract: Contract;
@@ -60,16 +60,17 @@ type API_NAMES = 'FUNGIBLE' | 'NON_FUNGIBLE';
 const TransferMultipleTokens = ({ baseContract }: PageProps) => {
   // general states
   const toaster = useToast();
-  const [isLoading, setIsLoading] = useState({
-    FUNGIBLE: false,
-    NON_FUNGIBLE: false,
-  });
   const [isSuccessful, setIsSuccessful] = useState(false);
   const hederaNetwork = JSON.parse(Cookies.get('_network') as string);
   const [APIMethods, setAPIMethods] = useState<API_NAMES>('FUNGIBLE');
   const [currentTransactionPage, setCurrentTransactionPage] = useState(1);
   const contractCaller = JSON.parse(Cookies.get('_connectedAccounts') as string)[0];
+  const currentContractAddress = Cookies.get(CONTRACT_NAMES.TOKEN_TRANSFER) as string;
   const [transactionResults, setTransactionResults] = useState<TransactionResult[]>([]);
+  const [isLoading, setIsLoading] = useState({
+    FUNGIBLE: false,
+    NON_FUNGIBLE: false,
+  });
   const transactionResultStorageKey =
     HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['TOKEN-TRANSFER']['MULTIPLE-TOKENS'];
   const tokenCommonFields = useMemo(() => {
@@ -100,6 +101,11 @@ const TransferMultipleTokens = ({ baseContract }: PageProps) => {
     generateInitialNonFungibleParamValue(),
   ]);
 
+  const transactionResultsToShow = useMemo(
+    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
+    [transactionResults, currentContractAddress]
+  );
+
   /** @dev retrieve token creation results from localStorage to maintain data on re-renders */
   useEffect(() => {
     handleRetrievingTransactionResultsFromLocalStorage(
@@ -111,7 +117,7 @@ const TransferMultipleTokens = ({ baseContract }: PageProps) => {
   }, [toaster, transactionResultStorageKey]);
 
   // declare a paginatedTransactionResults
-  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResults);
+  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResultsToShow);
 
   /** @dev handle modifying transfer records */
   const handleModifyTransferRecords = (
@@ -235,6 +241,7 @@ const TransferMultipleTokens = ({ baseContract }: PageProps) => {
         setTransactionResults,
         err: transactionResult.err,
         transactionType: 'HTS-TOKENS-TRANSFER',
+        sessionedContractAddress: currentContractAddress,
         tokenAddress: commonParamValues.hederaTokenAddress,
         transactionHash: transactionResult.transactionHash,
       });
@@ -248,6 +255,7 @@ const TransferMultipleTokens = ({ baseContract }: PageProps) => {
           status: 'success',
           transactionTimeStamp: Date.now(),
           transactionType: 'HTS-TOKENS-TRANSFER',
+          sessionedContractAddress: currentContractAddress,
           tokenAddress: commonParamValues.hederaTokenAddress,
           txHash: transactionResult.transactionHash as string,
         },
@@ -389,7 +397,7 @@ const TransferMultipleTokens = ({ baseContract }: PageProps) => {
       </div>
 
       {/* transaction results table */}
-      {transactionResults.length > 0 && (
+      {transactionResultsToShow.length > 0 && (
         <TransactionResultTable
           API="TokenCreate"
           hederaNetwork={hederaNetwork}

--- a/system-contract-dapp-playground/src/components/contract-interaction/hts/token-transfer-contract/method/transferSingleToken/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/hts/token-transfer-contract/method/transferSingleToken/index.tsx
@@ -21,7 +21,7 @@
 import Cookies from 'js-cookie';
 import { Contract } from 'ethers';
 import { useToast } from '@chakra-ui/react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { CommonErrorToast } from '@/components/toast/CommonToast';
 import { TransactionResult } from '@/types/contract-interactions/HTS';
 import { handleAPIErrors } from '../../../shared/methods/handleAPIErrors';
@@ -34,6 +34,7 @@ import { handleSanitizeHederaFormInputs } from '../../../shared/methods/handleSa
 import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { SharedExecuteButton, SharedFormInputField } from '../../../shared/components/ParamInputForm';
 import { useUpdateTransactionResultsToLocalStorage } from '../../../shared/hooks/useUpdateLocalStorage';
+import useFilterTransactionsByContractAddress from '../../../shared/hooks/useFilterTransactionsByContractAddress';
 import { htsTokenTransferParamFields } from '@/utils/contract-interactions/HTS/token-transfer/paramFieldConstant';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../../shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 
@@ -75,9 +76,9 @@ const TransferSingleToken = ({ baseContract }: PageProps) => {
   };
   const [paramValues, setParamValues] = useState<any>(initialParamValues);
 
-  const transactionResultsToShow = useMemo(
-    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
-    [transactionResults, currentContractAddress]
+  const transactionResultsToShow = useFilterTransactionsByContractAddress(
+    transactionResults,
+    currentContractAddress
   );
 
   /** @dev retrieve token creation results from localStorage to maintain data on re-renders */

--- a/system-contract-dapp-playground/src/components/contract-interaction/ihrc/methods/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/ihrc/methods/index.tsx
@@ -122,6 +122,7 @@ const HederaIHRC719Methods = ({ network }: PageProps) => {
         toaster,
         transactionHash,
         setTransactionResults,
+        sessionedContractAddress: '',
         transactionType: `IHRC719-${API}`,
         tokenAddress: paramValues.hederaTokenAddress,
       });
@@ -132,6 +133,7 @@ const HederaIHRC719Methods = ({ network }: PageProps) => {
         ...prev,
         {
           status: 'success',
+          sessionedContractAddress: '',
           transactionTimeStamp: Date.now(),
           txHash: transactionHash as string,
           transactionType: `IHRC719-${API}`,

--- a/system-contract-dapp-playground/src/components/contract-interaction/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/index.tsx
@@ -21,34 +21,29 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { Contract } from 'ethers';
+import { BsTrash } from 'react-icons/bs';
 import HederaPRNGMethods from './prng/methods';
-import ERC20Methods from './erc/erc-20/methods';
 import { FiExternalLink } from 'react-icons/fi';
-import HederaIHRC719Methods from './ihrc/methods';
+import ERC20Methods from './erc/erc-20/methods';
+import ConfirmModal from '../common/ConfirmModal';
 import ERC721Methods from './erc/erc-721/methods';
+import HederaIHRC719Methods from './ihrc/methods';
 import { deploySmartContract } from '@/api/hedera';
 import HederaAlertDialog from '../common/AlertDialog';
 import { useCallback, useEffect, useState } from 'react';
 import { generateBaseContractInstance } from '@/api/ethers';
+import { clearCachedTransactions } from '@/api/localStorage';
 import ERC20DeployField from './erc/deployment/ERCDeployField';
 import { HederaContractAsset, NetworkName } from '@/types/common';
 import { getHederaNativeIDFromEvmAddress } from '@/api/mirror-node';
 import { CommonErrorToast, NoWalletToast } from '../toast/CommonToast';
-import { getInfoFromCookies, storeInfoInCookies } from '@/api/cookies';
 import { convertCalmelCaseFunctionName } from '@/utils/common/helpers';
 import HederaTokenCreateMethods from './hts/token-create-custom/methods';
 import HederaTokenQueryMethods from './hts/token-query-contract/methods';
 import HederaTokenTransferMethods from './hts/token-transfer-contract/method';
 import HederaTokenManagementMethods from './hts/token-management-contract/methods';
+import { getInfoFromCookies, removeCookieAt, storeInfoInCookies } from '@/api/cookies';
 import ExchangeRateDeployField from './exchange-rate-hip-475/deployment/ExchangeRateDeployField';
-import {
-  HASHSCAN_BASE_URL,
-  OFFCIAL_NETWORK_NAME,
-  HEDERA_BRANDING_COLORS,
-  HEDERA_CHAKRA_TABLE_VARIANTS,
-  HEDERA_SMART_CONTRACTS_ASSETS,
-  HEDERA_COMMON_WALLET_REVERT_REASONS,
-} from '@/utils/common/constants';
 import {
   Tab,
   Tabs,
@@ -58,9 +53,19 @@ import {
   TabPanel,
   useToast,
   TabPanels,
+  useDisclosure,
   PopoverContent,
   PopoverTrigger,
 } from '@chakra-ui/react';
+import {
+  HASHSCAN_BASE_URL,
+  OFFCIAL_NETWORK_NAME,
+  HEDERA_BRANDING_COLORS,
+  HEDERA_CHAKRA_TABLE_VARIANTS,
+  HEDERA_SMART_CONTRACTS_ASSETS,
+  CONTRACT_NAME_TO_STORAGE_KEY_VALUE,
+  HEDERA_COMMON_WALLET_REVERT_REASONS,
+} from '@/utils/common/constants';
 
 interface PageProps {
   contract: HederaContractAsset;
@@ -70,6 +75,7 @@ const ContractInteraction = ({ contract }: PageProps) => {
   const toaster = useToast();
   const [mounted, setMounted] = useState(false);
   const [contractId, setContractId] = useState('');
+  const { isOpen, onOpen, onClose } = useDisclosure();
   const [isDeployed, setIsDeployed] = useState(false);
   const [isDeploying, setIsDeploying] = useState(false);
   const [network, setNetwork] = useState<NetworkName>();
@@ -213,6 +219,24 @@ const ContractInteraction = ({ contract }: PageProps) => {
     })();
   }, [network, contractAddress, toaster]);
 
+  // handle removing contract instance
+  const handleRemoveContractInstance = () => {
+    // close the modal
+    onClose();
+
+    // remove contract record in cookies
+    removeCookieAt(contract.name);
+
+    // remove all transactions
+    clearCachedTransactions(CONTRACT_NAME_TO_STORAGE_KEY_VALUE[contract.name]);
+
+    // reset states
+    setContractId('');
+    setIsDeployed(false);
+    setContractAddress('');
+    setBaseContract(undefined);
+  };
+
   useEffect(() => setMounted(true), []);
   if (!mounted) return null;
   return (
@@ -261,7 +285,19 @@ const ContractInteraction = ({ contract }: PageProps) => {
                   {/* Contract information - not for IHRC729Contract*/}
                   {contract.name !== HEDERA_SMART_CONTRACTS_ASSETS.TOKEN_ASSOCIATION.name && (
                     <>
-                      <div className="pb-6 flex flex-col gap-1 px-3">
+                      <div className="pb-6 flex flex-col gap-1 px-3 relative">
+                        {/* remove contract instance button */}
+                        <div className="absolute right-3 -top-3">
+                          <Tooltip label="Remove this contract instance" placement="top">
+                            <button
+                              onClick={onOpen}
+                              className={`border border-white/30 p-2 rounded-lg flex items-center justify-center cursor-pointer hover:bg-red-400 transition duration-300`}
+                            >
+                              <BsTrash />
+                            </button>
+                          </Tooltip>
+                        </div>
+
                         {/* Contract ID */}
                         <div className="flex gap-3 w-full justify-">
                           <p>Hedera contract ID: </p>
@@ -469,6 +505,21 @@ const ContractInteraction = ({ contract }: PageProps) => {
           confirmCallBack={() => setIsDeployed(true)}
         />
       )}
+
+      {/* remove current contract intance modal */}
+      <ConfirmModal
+        isOpen={isOpen}
+        onClose={onClose}
+        modalBody={
+          <p className="text-white/70">
+            By completing this action, the current contract instance and all the transactions you have made
+            against this contract will be permanently erased from the DApp&apos;s cache, but they will still
+            be accessible through HashScan or other explorer solutions.
+          </p>
+        }
+        modalHeader={'Sure to remove contract instance?'}
+        handleAcknowledge={handleRemoveContractInstance}
+      />
     </Tabs>
   );
 };

--- a/system-contract-dapp-playground/src/components/contract-interaction/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/index.tsx
@@ -63,7 +63,9 @@ import {
   HEDERA_BRANDING_COLORS,
   HEDERA_CHAKRA_TABLE_VARIANTS,
   HEDERA_COMMON_WALLET_REVERT_REASONS,
+  CONTRACT_NAME_TO_STORAGE_KEY_VALUE,
 } from '@/utils/common/constants';
+import { clearCachedTransactions } from '@/api/localStorage';
 
 interface PageProps {
   contract: HederaContractAsset;
@@ -224,6 +226,9 @@ const ContractInteraction = ({ contract }: PageProps) => {
 
     // remove contract record in cookies
     removeCookieAt(contract.name);
+
+    // remove all readonly transactions
+    clearCachedTransactions(CONTRACT_NAME_TO_STORAGE_KEY_VALUE[contract.name], true);
 
     // reset states
     setContractId('');

--- a/system-contract-dapp-playground/src/components/contract-interaction/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/index.tsx
@@ -32,7 +32,6 @@ import { deploySmartContract } from '@/api/hedera';
 import HederaAlertDialog from '../common/AlertDialog';
 import { useCallback, useEffect, useState } from 'react';
 import { generateBaseContractInstance } from '@/api/ethers';
-import { clearCachedTransactions } from '@/api/localStorage';
 import ERC20DeployField from './erc/deployment/ERCDeployField';
 import { HederaContractAsset, NetworkName } from '@/types/common';
 import { getHederaNativeIDFromEvmAddress } from '@/api/mirror-node';
@@ -58,12 +57,11 @@ import {
   PopoverTrigger,
 } from '@chakra-ui/react';
 import {
+  CONTRACT_NAMES,
   HASHSCAN_BASE_URL,
   OFFCIAL_NETWORK_NAME,
   HEDERA_BRANDING_COLORS,
   HEDERA_CHAKRA_TABLE_VARIANTS,
-  HEDERA_SMART_CONTRACTS_ASSETS,
-  CONTRACT_NAME_TO_STORAGE_KEY_VALUE,
   HEDERA_COMMON_WALLET_REVERT_REASONS,
 } from '@/utils/common/constants';
 
@@ -227,9 +225,6 @@ const ContractInteraction = ({ contract }: PageProps) => {
     // remove contract record in cookies
     removeCookieAt(contract.name);
 
-    // remove all transactions
-    clearCachedTransactions(CONTRACT_NAME_TO_STORAGE_KEY_VALUE[contract.name]);
-
     // reset states
     setContractId('');
     setIsDeployed(false);
@@ -247,7 +242,7 @@ const ContractInteraction = ({ contract }: PageProps) => {
       className="bg-panel rounded-xl max-w-4xl text-white border border-white/30 shadow-2xl text-lg"
     >
       {/* @notice TokenAssociation IHRC719 does not need to deploy */}
-      {isDeployed || contract.name === HEDERA_SMART_CONTRACTS_ASSETS.TOKEN_ASSOCIATION.name ? (
+      {isDeployed || contract.name === CONTRACT_NAMES.IHRC719 ? (
         <>
           {/* Tab headers */}
           <TabList
@@ -283,7 +278,7 @@ const ContractInteraction = ({ contract }: PageProps) => {
               return (
                 <TabPanel className={`whitespace-nowrap py-4`} key={method}>
                   {/* Contract information - not for IHRC729Contract*/}
-                  {contract.name !== HEDERA_SMART_CONTRACTS_ASSETS.TOKEN_ASSOCIATION.name && (
+                  {contract.name !== CONTRACT_NAMES.IHRC719 && (
                     <>
                       <div className="pb-6 flex flex-col gap-1 px-3 relative">
                         {/* remove contract instance button */}
@@ -381,12 +376,12 @@ const ContractInteraction = ({ contract }: PageProps) => {
                   {/* Contract methods */}
                   <div className="flex py-9 text-xl w-full h-full justify-center items-center">
                     {/* HTS Token Create */}
-                    {contract.name === HEDERA_SMART_CONTRACTS_ASSETS.HTS_PRECOMPILED[0].name && (
+                    {contract.name === CONTRACT_NAMES.TOKEN_CREATE && (
                       <HederaTokenCreateMethods method={method} baseContract={baseContract! as Contract} />
                     )}
 
                     {/* HTS Token Management*/}
-                    {contract.name === HEDERA_SMART_CONTRACTS_ASSETS.HTS_PRECOMPILED[1].name && (
+                    {contract.name === CONTRACT_NAMES.TOKEN_MANAGE && (
                       <HederaTokenManagementMethods
                         method={method}
                         baseContract={baseContract! as Contract}
@@ -394,32 +389,32 @@ const ContractInteraction = ({ contract }: PageProps) => {
                     )}
 
                     {/* HTS Token Query*/}
-                    {contract.name === HEDERA_SMART_CONTRACTS_ASSETS.HTS_PRECOMPILED[2].name && (
+                    {contract.name === CONTRACT_NAMES.TOKEN_QUERY && (
                       <HederaTokenQueryMethods method={method} baseContract={baseContract! as Contract} />
                     )}
 
                     {/* HTS Token Transfer*/}
-                    {contract.name === HEDERA_SMART_CONTRACTS_ASSETS.HTS_PRECOMPILED[3].name && (
+                    {contract.name === CONTRACT_NAMES.TOKEN_TRANSFER && (
                       <HederaTokenTransferMethods method={method} baseContract={baseContract! as Contract} />
                     )}
 
                     {/* IHRC719 contract */}
-                    {contract.name === HEDERA_SMART_CONTRACTS_ASSETS.TOKEN_ASSOCIATION.name && (
+                    {contract.name === CONTRACT_NAMES.IHRC719 && (
                       <HederaIHRC719Methods network={network as string} />
                     )}
 
                     {/* HRC contract */}
-                    {contract.name === 'PrngSystemContract' && (
+                    {contract.name === CONTRACT_NAMES.PRNG && (
                       <HederaPRNGMethods baseContract={baseContract! as Contract} />
                     )}
 
                     {/* ERC-20 */}
-                    {contract.name === HEDERA_SMART_CONTRACTS_ASSETS.ERC_20.name && (
+                    {contract.name === CONTRACT_NAMES.ERC20 && (
                       <ERC20Methods method={method} baseContract={baseContract! as Contract} />
                     )}
 
                     {/* ERC-721 */}
-                    {contract.name === HEDERA_SMART_CONTRACTS_ASSETS.ERC_721.name && (
+                    {contract.name === CONTRACT_NAMES.ERC721 && (
                       <ERC721Methods method={method} baseContract={baseContract! as Contract} />
                     )}
                   </div>
@@ -434,7 +429,7 @@ const ContractInteraction = ({ contract }: PageProps) => {
             <p>Let&apos;s get started by deploying this contract first!</p>
 
             {/* ExchangeRate contract needs params to deploy */}
-            {contract.name === HEDERA_SMART_CONTRACTS_ASSETS.EXCHANGE_RATE.name && (
+            {contract.name === CONTRACT_NAMES.EXCHANGE_RATE && (
               <ExchangeRateDeployField
                 isDeploying={isDeploying}
                 setDeployedParams={setDeployedParams}
@@ -443,8 +438,7 @@ const ContractInteraction = ({ contract }: PageProps) => {
             )}
 
             {/* ERC20 & ERC721 contract needs params to deploy */}
-            {(contract.name === HEDERA_SMART_CONTRACTS_ASSETS.ERC_20.name ||
-              contract.name === HEDERA_SMART_CONTRACTS_ASSETS.ERC_721.name) && (
+            {(contract.name === CONTRACT_NAMES.ERC20 || contract.name === CONTRACT_NAMES.ERC721) && (
               <ERC20DeployField
                 isDeploying={isDeploying}
                 setDeployedParams={setDeployedParams}
@@ -453,9 +447,9 @@ const ContractInteraction = ({ contract }: PageProps) => {
             )}
 
             {/* Contracts other than ExchangeRate, ERC20, ERC20 does not need params to deploy */}
-            {contract.name !== HEDERA_SMART_CONTRACTS_ASSETS.EXCHANGE_RATE.name &&
-              contract.name !== HEDERA_SMART_CONTRACTS_ASSETS.ERC_20.name &&
-              contract.name !== HEDERA_SMART_CONTRACTS_ASSETS.ERC_721.name && (
+            {contract.name !== CONTRACT_NAMES.EXCHANGE_RATE &&
+              contract.name !== CONTRACT_NAMES.ERC20 &&
+              contract.name !== CONTRACT_NAMES.ERC721 && (
                 <button
                   onClick={handleDeployContract}
                   disabled={isDeploying}

--- a/system-contract-dapp-playground/src/components/contract-interaction/prng/methods/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/prng/methods/index.tsx
@@ -21,18 +21,19 @@
 import Cookies from 'js-cookie';
 import { Contract } from 'ethers';
 import { useToast } from '@chakra-ui/react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { handlePRGNAPI } from '@/api/hedera/prng-interactions';
 import { CommonErrorToast } from '@/components/toast/CommonToast';
 import { TransactionResult } from '@/types/contract-interactions/HTS';
 import { handleAPIErrors } from '../../hts/shared/methods/handleAPIErrors';
 import { TRANSACTION_PAGE_SIZE } from '../../hts/shared/states/commonStates';
 import { useToastSuccessful } from '../../hts/shared/hooks/useToastSuccessful';
-import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { usePaginatedTxResults } from '../../hts/shared/hooks/usePaginatedTxResults';
 import { SharedExecuteButtonWithFee } from '../../hts/shared/components/ParamInputForm';
 import { TransactionResultTable } from '../../hts/shared/components/TransactionResultTable';
+import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { useUpdateTransactionResultsToLocalStorage } from '../../hts/shared/hooks/useUpdateLocalStorage';
+import useFilterTransactionsByContractAddress from '../../hts/shared/hooks/useFilterTransactionsByContractAddress';
 import { handleRetrievingTransactionResultsFromLocalStorage } from '../../hts/shared/methods/handleRetrievingTransactionResultsFromLocalStorage';
 
 interface PageProps {
@@ -51,10 +52,9 @@ const HederaPRNGMethods = ({ baseContract }: PageProps) => {
   const currentContractAddress = Cookies.get(CONTRACT_NAMES.PRNG) as string;
   const [transactionResults, setTransactionResults] = useState<TransactionResult[]>([]);
   const transactionResultStorageKey = HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['PRNG-RESULT']['PSEUDO-RANDOM'];
-
-  const transactionResultsToShow = useMemo(
-    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
-    [transactionResults, currentContractAddress]
+  const transactionResultsToShow = useFilterTransactionsByContractAddress(
+    transactionResults,
+    currentContractAddress
   );
 
   /** @dev retrieve token creation results from localStorage to maintain data on re-renders */

--- a/system-contract-dapp-playground/src/components/contract-interaction/prng/methods/index.tsx
+++ b/system-contract-dapp-playground/src/components/contract-interaction/prng/methods/index.tsx
@@ -21,14 +21,14 @@
 import Cookies from 'js-cookie';
 import { Contract } from 'ethers';
 import { useToast } from '@chakra-ui/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { handlePRGNAPI } from '@/api/hedera/prng-interactions';
 import { CommonErrorToast } from '@/components/toast/CommonToast';
 import { TransactionResult } from '@/types/contract-interactions/HTS';
 import { handleAPIErrors } from '../../hts/shared/methods/handleAPIErrors';
 import { TRANSACTION_PAGE_SIZE } from '../../hts/shared/states/commonStates';
 import { useToastSuccessful } from '../../hts/shared/hooks/useToastSuccessful';
-import { HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
+import { CONTRACT_NAMES, HEDERA_TRANSACTION_RESULT_STORAGE_KEYS } from '@/utils/common/constants';
 import { usePaginatedTxResults } from '../../hts/shared/hooks/usePaginatedTxResults';
 import { SharedExecuteButtonWithFee } from '../../hts/shared/components/ParamInputForm';
 import { TransactionResultTable } from '../../hts/shared/components/TransactionResultTable';
@@ -48,8 +48,14 @@ const HederaPRNGMethods = ({ baseContract }: PageProps) => {
   const [gasLimit, setGasLimit] = useState(initialParamValues);
   const hederaNetwork = JSON.parse(Cookies.get('_network') as string);
   const [currentTransactionPage, setCurrentTransactionPage] = useState(1);
+  const currentContractAddress = Cookies.get(CONTRACT_NAMES.PRNG) as string;
   const [transactionResults, setTransactionResults] = useState<TransactionResult[]>([]);
   const transactionResultStorageKey = HEDERA_TRANSACTION_RESULT_STORAGE_KEYS['PRNG-RESULT']['PSEUDO-RANDOM'];
+
+  const transactionResultsToShow = useMemo(
+    () => transactionResults.filter((result) => result.sessionedContractAddress === currentContractAddress),
+    [transactionResults, currentContractAddress]
+  );
 
   /** @dev retrieve token creation results from localStorage to maintain data on re-renders */
   useEffect(() => {
@@ -62,7 +68,7 @@ const HederaPRNGMethods = ({ baseContract }: PageProps) => {
   }, [toaster, transactionResultStorageKey]);
 
   // declare a paginatedTransactionResults
-  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResults);
+  const paginatedTransactionResults = usePaginatedTxResults(currentTransactionPage, transactionResultsToShow);
 
   /** @dev handle form inputs on change */
   const handleInputOnChange = async (e: any, param: string) => {
@@ -108,6 +114,7 @@ const HederaPRNGMethods = ({ baseContract }: PageProps) => {
         transactionHash,
         setTransactionResults,
         transactionType: `PRNG`,
+        sessionedContractAddress: currentContractAddress,
       });
       return;
     } else {
@@ -116,10 +123,11 @@ const HederaPRNGMethods = ({ baseContract }: PageProps) => {
         ...prev,
         {
           status: 'success',
+          pseudoRandomSeed,
           transactionType: `PRNG`,
           transactionTimeStamp: Date.now(),
           txHash: transactionHash as string,
-          pseudoRandomSeed,
+          sessionedContractAddress: currentContractAddress,
         },
       ]);
 
@@ -159,7 +167,7 @@ const HederaPRNGMethods = ({ baseContract }: PageProps) => {
       </div>
 
       {/* transaction results table */}
-      {transactionResults.length > 0 && (
+      {transactionResultsToShow.length > 0 && (
         <TransactionResultTable
           API="PRNG"
           hederaNetwork={hederaNetwork}

--- a/system-contract-dapp-playground/src/components/wallet-popup/index.tsx
+++ b/system-contract-dapp-playground/src/components/wallet-popup/index.tsx
@@ -23,7 +23,9 @@ import Image from 'next/image';
 import { ethers } from 'ethers';
 import { clearCookies } from '@/api/cookies';
 import { NetworkName } from '@/types/common';
+import ConfirmModal from '../common/ConfirmModal';
 import { BiCopy, BiCheckDouble } from 'react-icons/bi';
+import { clearCachedTransactions } from '@/api/localStorage';
 import { getBalance, getWalletProvider } from '@/api/wallet';
 import { getHederaNativeIDFromEvmAddress } from '@/api/mirror-node';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
@@ -31,16 +33,6 @@ import { CommonErrorToast, NoWalletToast } from '../toast/CommonToast';
 import { SkeletonText, useDisclosure, useToast } from '@chakra-ui/react';
 import { BsChevronDown, BsFillQuestionOctagonFill } from 'react-icons/bs';
 import { HASHSCAN_BASE_URL, HEDERA_COMMON_WALLET_REVERT_REASONS } from '@/utils/common/constants';
-import {
-  Modal,
-  ModalOverlay,
-  ModalContent,
-  ModalHeader,
-  ModalFooter,
-  ModalBody,
-  ModalCloseButton,
-} from '@chakra-ui/react';
-import { clearTransactionCache } from '@/api/localStorage';
 
 interface PageProps {
   network: NetworkName;
@@ -135,7 +127,7 @@ const WalletPopup = ({ setIsOpen, userAddress, network }: PageProps) => {
     await clearCookies();
 
     // clear localStorage cache
-    clearTransactionCache();
+    clearCachedTransactions();
 
     // redirect user to landing page
     setIsOpen(false);
@@ -278,36 +270,20 @@ const WalletPopup = ({ setIsOpen, userAddress, network }: PageProps) => {
               </p>
             </button>
 
-            <Modal isOpen={isOpen} isCentered onClose={onClose}>
-              <ModalOverlay />
-              <ModalContent
-                className="h-fit flex flex-col gap-3 rounded-xl drop-shadow-xl
-                bg-secondary text-white font-styrene w-[30rem]"
-              >
-                <ModalHeader>Sure to disconnect?</ModalHeader>
-                <ModalCloseButton />
-
-                {/* break line */}
-                <hr className="border-t border-white/40 -mt-3" />
-
-                <ModalBody>
-                  <p className="text-white/70">
-                    By completing this action, all the transactions you have made during this session will be
-                    permanently erased from the DApp&apos;s cache, but they will still be accessible through
-                    HashScan or other explorer solutions.
-                  </p>
-                </ModalBody>
-
-                <ModalFooter>
-                  <button
-                    onClick={handleDisconnect}
-                    className="border border-button-stroke-violet px-6 py-2 rounded-lg font-medium hover:bg-button-stroke-violet hover:text-white transition duration-300"
-                  >
-                    Acknowledge
-                  </button>
-                </ModalFooter>
-              </ModalContent>
-            </Modal>
+            <ConfirmModal
+              isOpen={isOpen}
+              onClose={onClose}
+              modalBody={
+                <p className="text-white/70">
+                  By completing this action, all the deployed smart contract instances and all the
+                  transactions you have made during this session will be permanently erased from the
+                  DApp&apos;s cache, but they will still be accessible through HashScan or other explorer
+                  solutions.
+                </p>
+              }
+              modalHeader={'Sure to disconnect?'}
+              handleAcknowledge={handleDisconnect}
+            />
           </div>
         </div>
       </div>

--- a/system-contract-dapp-playground/src/types/contract-interactions/HTS/index.d.ts
+++ b/system-contract-dapp-playground/src/types/contract-interactions/HTS/index.d.ts
@@ -34,6 +34,7 @@ export type TransactionResult = {
   pseudoRandomSeed?: string;
   tokenAddresses?: string[];
   transactionTimeStamp: number;
+  sessionedContractAddress: string;
 };
 
 /** @dev an interface for the results returned back from interacting with Hedera System Smart Contracts */

--- a/system-contract-dapp-playground/src/utils/common/constants.ts
+++ b/system-contract-dapp-playground/src/utils/common/constants.ts
@@ -315,6 +315,21 @@ export const HEDERA_SHARED_PARAM_INPUT_FIELDS = {
 };
 
 /**
+ * @notice a shared object maping contract name to storage key value
+ */
+export const CONTRACT_NAME_TO_STORAGE_KEY_VALUE: Record<ContractName, string> = {
+  ERC20Mock: 'ERC-20',
+  ERC721Mock: 'ERC-721',
+  IHRC729Contract: 'IHRC719',
+  PrngSystemContract: 'PRNG',
+  TokenQueryContract: 'TOKEN-QUERY',
+  TokenTransferContract: 'TOKEN-TRANSFER',
+  ExchangeRatePrecompile: 'EXCHANGE-RATE',
+  TokenManagementContract: 'TOKEN-MANAGE',
+  TokenCreateCustomContract: 'TOKEN-CREATE',
+};
+
+/**
  * @notice a shared object stores all transaction result storage keys
  */
 const prepareTransactionResultStorageKey = (

--- a/system-contract-dapp-playground/src/utils/common/constants.ts
+++ b/system-contract-dapp-playground/src/utils/common/constants.ts
@@ -181,6 +181,21 @@ export const LEFT_SIDE_BAR_ITEMS = [
 ];
 
 /**
+ * @notice an object storing contract names
+ */
+export const CONTRACT_NAMES: Record<string, ContractName> = {
+  ERC20: 'ERC20Mock',
+  ERC721: 'ERC721Mock',
+  PRNG: 'PrngSystemContract',
+  IHRC719: 'IHRC729Contract',
+  TOKEN_QUERY: 'TokenQueryContract',
+  TOKEN_TRANSFER: 'TokenTransferContract',
+  EXCHANGE_RATE: 'ExchangeRatePrecompile',
+  TOKEN_MANAGE: 'TokenManagementContract',
+  TOKEN_CREATE: 'TokenCreateCustomContract',
+};
+
+/**
  * @notice information about Hedera Smart Contract assets
  */
 export const HEDERA_SMART_CONTRACTS_ASSETS = {

--- a/system-contract-dapp-playground/src/utils/common/constants.ts
+++ b/system-contract-dapp-playground/src/utils/common/constants.ts
@@ -356,6 +356,7 @@ const prepareTransactionResultStorageKey = (
   return `HEDERA.${contractKey}.${methodKey}.${resultKey}-RESULTS${readonly ? `.READONLY` : ``}`;
 };
 export const HEDERA_TRANSACTION_RESULT_STORAGE_KEYS = {
+  'CONTRACT-CREATE': 'HEDERA.CONTRACT-CREATE-RESULTS',
   'TOKEN-CREATE': {
     'TOKEN-KYC': prepareTransactionResultStorageKey('HTS', 'TOKEN-CREATE', 'TOKEN-KYC'),
     'MINT-TOKEN': prepareTransactionResultStorageKey('HTS', 'TOKEN-CREATE', 'MINT-TOKEN'),


### PR DESCRIPTION
**Description**:
This PR adds a new feature to let users remove current deployed contract instance so they can redeploy a new instance if desired

**Related issue(s)**: #399

Fixes #401 

** UI Demo **:

https://github.com/hashgraph/hedera-smart-contracts/assets/66233296/fe0845ed-22c7-4ece-9020-d06acda6e325

** Updated UI **:
This video demonstrates the capability to retain transactions even after wiping off the deployed contract instance from cookies, and they still appear on the /activity page.

https://github.com/hashgraph/hedera-smart-contracts/assets/66233296/262b0553-28e8-4546-b685-712ab3c145fe


This video showcase the ability to cache `contract create transactions` to the main storage and expose them to `/activity` page

https://github.com/hashgraph/hedera-smart-contracts/assets/66233296/e75f64f3-5e5e-42b2-b82d-890229cd87a9




**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
