### PR TITLE
Bumped up versions of the mirror node and consensus nodes in the CI w…

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -9,9 +9,9 @@ on:
 
 env:
   RELAY_IMAGE_TAG: 0.31.1
-  NETWORK_NODE_IMAGE_TAG: 0.42.0-alpha.0
-  HAVEGED_IMAGE_TAG: 0.42.0-alpha.0
-  MIRROR_IMAGE_TAG: 0.88.0
+  NETWORK_NODE_IMAGE_TAG: 0.42.1
+  HAVEGED_IMAGE_TAG: 0.42.1
+  MIRROR_IMAGE_TAG: 0.89.0
 
 jobs:
   acceptance-workflow:


### PR DESCRIPTION
Bump PR for mirror and consensus nodes used in CI for JSON RPC relay 0.33.0. issue #1773

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
