### PR TITLE
feat: added new contract to showcase assembly address operations (#459)

### DIFF
--- a/contracts/solidity/address/AssemblyAddress.sol
+++ b/contracts/solidity/address/AssemblyAddress.sol
@@ -30,3 +30,4 @@ contract AssemblyAddress {
         }
     }
 }
+

--- a/contracts/solidity/address/AssemblyAddress.sol
+++ b/contracts/solidity/address/AssemblyAddress.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.20;
+
+contract AssemblyAddress {
+    function codesizeat(address addr) external view returns(uint256 size) {
+        assembly {
+            size := extcodesize(addr)
+        }
+    }
+
+    function codehashat(address addr) external view returns (bytes32 hash) {
+        assembly {
+            hash := extcodehash(addr)
+        }
+    }
+
+    function codecopyat(address addr) external view returns (bytes memory code) {
+        assembly {
+            // retrieve the size of the code, this needs assembly
+            let size := extcodesize(addr)
+            // allocate output byte array - this could also be done without assembly
+            // by using code = new bytes(size)
+            code := mload(0x40)
+            // new "memory end" including padding
+            mstore(0x40, add(code, and(add(add(size, 0x20), 0x1f), not(0x1f))))
+            // store length in memory
+            mstore(code, size)
+            // actually retrieve the code, this needs assembly
+            extcodecopy(addr, add(code, 0x20), 0, size)
+        }
+    }
+}

--- a/test/constants.js
+++ b/test/constants.js
@@ -105,6 +105,7 @@ const Contract = {
   Transaction: 'Transaction',
   MessageFrameAddresses: 'MessageFrameAddresses',
   New: 'New',
+  AssemblyAddress: 'AssemblyAddress',
   AddressContract: 'AddressContract',
   Recipient: 'Recipient',
   Inheritance: 'Inheritance',

--- a/test/solidity/address/AssemblyAddress.js
+++ b/test/solidity/address/AssemblyAddress.js
@@ -1,0 +1,69 @@
+/*-
+ *
+ * Hedera JSON RPC Relay - Hardhat Example
+ *
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+const { expect } = require('chai')
+const { ethers } = require('hardhat')
+const Constants = require('../../constants')
+
+describe('AssemblyAddress tests', () => {
+  let assemblyAddressContract, expectedContractBytecode
+
+  before(async () => {
+    const assemblyAddressContractFactory = await ethers.getContractFactory(
+      Constants.Contract.AssemblyAddress
+    )
+
+    assemblyAddressContract = await assemblyAddressContractFactory.deploy()
+    expectedContractBytecode = await ethers.provider.getCode(
+      assemblyAddressContract.address
+    )
+  })
+
+  it("Should get contract's code size at contract address", async () => {
+    const contractCodeSize = await assemblyAddressContract.codesizeat(
+      assemblyAddressContract.address
+    )
+
+    const expectedContractCodeSize =
+      expectedContractBytecode.replace('0x', '').length / 2
+
+    expect(contractCodeSize).to.eq(expectedContractCodeSize)
+  })
+
+  it("Should get contract's code hash at contract address", async () => {
+    const contractCodeHash = await assemblyAddressContract.codehashat(
+      assemblyAddressContract.address
+    )
+
+    const expectedContractCodeHash = ethers.utils.keccak256(
+      expectedContractBytecode
+    )
+
+    expect(contractCodeHash).to.eq(expectedContractCodeHash)
+  })
+
+  it("Should get contract's code at contract address", async () => {
+    const contractCode = await assemblyAddressContract.codecopyat(
+      assemblyAddressContract.address
+    )
+
+    expect(contractCode).to.eq(expectedContractBytecode)
+  })
+})

--- a/test/solidity/address/AssemblyAddress.js
+++ b/test/solidity/address/AssemblyAddress.js
@@ -41,6 +41,9 @@ describe('AssemblyAddress tests', () => {
       assemblyAddressContract.address
     )
 
+    // @notice Remove the '0x' prefix from the expected contract bytecode, then calculate the length in bytes
+    // @notice Since each hexadeimal character represents 4 bits, and each bute is represented by 2 hexadecimal characters.
+    //         Therefore, the length of bytecode in bytes is half of the length of the bytecode in hexadecimal characters.
     const expectedContractCodeSize =
       expectedContractBytecode.replace('0x', '').length / 2
 

--- a/test/solidity/address/AssemblyAddress.js
+++ b/test/solidity/address/AssemblyAddress.js
@@ -22,7 +22,7 @@ const { expect } = require('chai')
 const { ethers } = require('hardhat')
 const Constants = require('../../constants')
 
-describe('AssemblyAddress tests', () => {
+describe('@solidityevmequiv3 AssemblyAddress', () => {
   let assemblyAddressContract, expectedContractBytecode
 
   before(async () => {


### PR DESCRIPTION
**Description**:

- Added a new Solidity contract to demonstrate assembly address operations, including `extcodesize`, `extcodehash`, and `extcodecopy`.
- Included unit tests to verify the functionality of the contract.

**Related issue(s)**: #459

Fixes #459

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
