### PR TITLE
Adding tests for the default values of all types in Solidity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ cache
 artifacts/@openzeppelin
 artifacts/build-info
 artifacts/contracts
+artifacts/
 .openzeppelin/unknown-298.json
 .env
 test-results.*

--- a/contracts/solidity/defaults/Defaults.sol
+++ b/contracts/solidity/defaults/Defaults.sol
@@ -59,6 +59,10 @@ contract Defaults {
         bytes[] bytesArr;
     }
 
+    mapping(string => uint) public strUintMap;
+    mapping(address => bool) public addrBoolMap;
+    mapping(int => bytes) public bytesBytesMap;
+
     function getUintDefaults() external pure returns (UintDefaults memory) {
         UintDefaults memory defaults;
         return defaults;

--- a/contracts/solidity/defaults/Defaults.sol
+++ b/contracts/solidity/defaults/Defaults.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+contract Defaults {
+    struct UintDefaults {
+        uint uInt;
+        uint8 uInt8;
+        uint16 uInt16;
+        uint32 uInt32;
+        uint64 uInt64;
+        uint128 uInt128;
+        uint256 uInt256;
+    }
+
+    struct IntDefaults {
+        int intDef;
+        int8 intDef8;
+        int16 intDef16;
+        int32 intDef32;
+        int64 intDef64;
+        int128 intDef128;
+        int256 intDef256;
+    }
+
+    // struct FixedDefaults {
+    //     fixed fixedVar;
+    //     fixed8x18 fixed8x18Var;
+    //     fixed16x12 fixed16x12Var;
+    //     fixed32x10 fixed32x10Var;
+    //     fixed64x8 fixed64x8Var;
+    //     fixed128x6 fixed128x6Var;
+    //     fixed256x4 fixed256x4Var;
+    // }
+
+    // struct UFixedDefaults {
+    //     ufixed ufixedVar;
+    //     ufixed8x18 ufixed8x18Var;
+    //     ufixed16x12 ufixed16x12Var;
+    //     ufixed32x10 ufixed32x10Var;
+    //     ufixed64x8 ufixed64x8Var;
+    //     ufixed128x6 ufixed128x6Var;
+    //     ufixed256x4 ufixed256x4Var;
+    // }
+
+    struct BytesDefaults {
+        bytes3 bytesDef3;
+        bytes10 bytesDef10;
+        bytes15 bytesDef15;
+        bytes20 bytesDef20;
+        bytes25 bytesDef25;
+        bytes30 bytesDef30;
+        bytes32 bytesDef32;
+    }
+
+    struct ArrayDefaults {
+        string[] strArr;
+        uint[] uintArr;
+        bool[] boolArr;
+        bytes[] bytesArr;
+    }
+
+    function getUintDefaults() external pure returns (UintDefaults memory) {
+        UintDefaults memory defaults;
+        return defaults;
+    }
+
+    function getIntDefaults() external pure returns (UintDefaults memory) {
+        UintDefaults memory defaults;
+        return defaults;
+    }
+
+    // Not supported by solidity yet
+    // function getFixedDefaults() external pure returns (FixedDefaults memory) {
+    //     FixedDefaults memory defaults;
+    //     return defaults;
+    // }
+
+    // Not supported by solidity yet
+    // function getUFixedDefaults() external pure returns (UFixedDefaults memory) {
+    //     UFixedDefaults memory defaults;
+    //     return defaults;
+    // }
+
+    function getBytesDefaults() external pure returns (BytesDefaults memory) {
+        BytesDefaults memory defaults;
+        return defaults;
+    }
+
+    function getStringDefaults() external pure returns (string memory) {
+        string memory defaults;
+        return defaults;
+    }
+
+    function getArrayDefaults() external pure returns (ArrayDefaults memory) {
+        ArrayDefaults memory defaults;
+        return defaults;
+    }
+
+    function getAddressDefaults() external pure returns (address) {
+        address defaults;
+        return defaults;
+    }
+
+}

--- a/test/constants.js
+++ b/test/constants.js
@@ -113,7 +113,8 @@ const Contract = {
   FunctionsChild: 'FunctionsChild',
   FunctionsParent: 'FunctionsParent',
   Scoping: 'Scoping',
-  Arithmetic: "Arithmetic"
+  Arithmetic: "Arithmetic",
+  Defaults: "Defaults",
 }
 
 const CALL_EXCEPTION = 'CALL_EXCEPTION'

--- a/test/solidity/defaults/defaults.js
+++ b/test/solidity/defaults/defaults.js
@@ -54,12 +54,14 @@ describe('@solidityequiv3 Solidity Defaults', function () {
     expect(res.uInt).to.equal(ethers.BigNumber.from(0))
   })
 
-  // Not supported by solidity yet
+  // Fixed point numbers are Not supported by Solidity yet
+  // You can find the documentation: https://docs.soliditylang.org/en/latest/types.html#fixed-point-numbers
   xit('confirm solidity functionality: fixed defaults', async function () {
     const res = await contract.getFixedDefaults()
   })
 
-  // Not supported by solidity yet
+  // Fixed point numbers are Not supported by Solidity yet
+  // You can find the documentation: https://docs.soliditylang.org/en/latest/types.html#fixed-point-numbers
   xit('confirm solidity functionality: ufixed defaults', async function () {
     const res = await contract.getUFixedDefaults()
   })

--- a/test/solidity/defaults/defaults.js
+++ b/test/solidity/defaults/defaults.js
@@ -21,7 +21,7 @@ const { expect } = require('chai')
 const { ethers } = require('hardhat')
 const Constants = require('../../constants')
 
-describe('@solidityevmequiv2 Solidity Defaults', function () {
+describe('@solidityequiv3 Solidity Defaults', function () {
   let signers
   let contract
 

--- a/test/solidity/defaults/defaults.js
+++ b/test/solidity/defaults/defaults.js
@@ -28,7 +28,7 @@ describe('@solidityequiv3 Solidity Defaults', function () {
   before(async function () {
     signers = await ethers.getSigners()
 
-    const factory = await ethers.getContractFactory(Constants.Contract.Defaults)
+    const factory = await ethers.getContractFactory("Defaults")
     contract = await factory.deploy()
   })
 

--- a/test/solidity/defaults/defaults.js
+++ b/test/solidity/defaults/defaults.js
@@ -1,0 +1,100 @@
+/*-
+ *
+ * Hedera Smart Contracts
+ *
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const { expect } = require('chai')
+const { ethers } = require('hardhat')
+const Constants = require('../../constants')
+
+describe('@solidityevmequiv2 Solidity Defaults', function () {
+  let signers
+  let contract
+
+  before(async function () {
+    signers = await ethers.getSigners()
+
+    const factory = await ethers.getContractFactory(Constants.Contract.Defaults)
+    contract = await factory.deploy()
+  })
+
+  it('confirm solidity functionality: uint defaults', async function () {
+    const res = await contract.getUintDefaults()
+    expect(res.uInt8).to.equal(0)
+    expect(res.uInt16).to.equal(0)
+    expect(res.uInt32).to.equal(0)
+    expect(res.uInt64).to.equal(ethers.BigNumber.from(0))
+    expect(res.uInt128).to.equal(ethers.BigNumber.from(0))
+    expect(res.uInt256).to.equal(ethers.BigNumber.from(0))
+    expect(res.uInt).to.equal(ethers.BigNumber.from(0))
+  })
+
+  it('confirm solidity functionality: int defaults', async function () {
+    const res = await contract.getIntDefaults()
+    expect(res.uInt8).to.equal(0)
+    expect(res.uInt16).to.equal(0)
+    expect(res.uInt32).to.equal(0)
+    expect(res.uInt64).to.equal(ethers.BigNumber.from(0))
+    expect(res.uInt128).to.equal(ethers.BigNumber.from(0))
+    expect(res.uInt256).to.equal(ethers.BigNumber.from(0))
+    expect(res.uInt).to.equal(ethers.BigNumber.from(0))
+  })
+
+  // Not supported by solidity yet
+  xit('confirm solidity functionality: fixed defaults', async function () {
+    const res = await contract.getFixedDefaults()
+  })
+
+  // Not supported by solidity yet
+  xit('confirm solidity functionality: ufixed defaults', async function () {
+    const res = await contract.getUFixedDefaults()
+  })
+
+  it('confirm solidity functionality: bytes defaults', async function () {
+    const res = await contract.getBytesDefaults()
+    expect(res.bytesDef3).to.equal(ethers.utils.hexZeroPad(ethers.utils.hexlify(0), 3))
+    expect(res.bytesDef10).to.equal(ethers.utils.hexZeroPad(ethers.utils.hexlify(0), 10))
+    expect(res.bytesDef15).to.equal(ethers.utils.hexZeroPad(ethers.utils.hexlify(0), 15))
+    expect(res.bytesDef20).to.equal(ethers.utils.hexZeroPad(ethers.utils.hexlify(0), 20))
+    expect(res.bytesDef25).to.equal(ethers.utils.hexZeroPad(ethers.utils.hexlify(0), 25))
+    expect(res.bytesDef30).to.equal(ethers.utils.hexZeroPad(ethers.utils.hexlify(0), 30))
+    expect(res.bytesDef32).to.equal(ethers.utils.hexZeroPad(ethers.utils.hexlify(0), 32))
+  })
+
+  it('confirm solidity functionality: string defaults', async function () {
+    const res = await contract.getStringDefaults()
+    expect(res).to.equal('')
+  })
+
+  it('confirm solidity functionality: array defaults', async function () {
+    const res = await contract.getArrayDefaults()
+    expect(Array.isArray(res.strArr)).to.be.true
+    expect(Array.isArray(res.uintArr)).to.be.true
+    expect(Array.isArray(res.boolArr)).to.be.true
+    expect(Array.isArray(res.bytesArr)).to.be.true
+  })
+
+  it('confirm solidity functionality: address defaults', async function () {
+    const res = await contract.getAddressDefaults()
+    expect(res).to.equal(ethers.utils.hexZeroPad(ethers.utils.hexlify(0), 20))
+  })
+
+  // mapping cannot be returned from solidity
+  xit('confirm solidity functionality: mapping', async function () {
+    
+  })
+})

--- a/test/solidity/defaults/defaults.js
+++ b/test/solidity/defaults/defaults.js
@@ -93,8 +93,12 @@ describe('@solidityevmequiv2 Solidity Defaults', function () {
     expect(res).to.equal(ethers.utils.hexZeroPad(ethers.utils.hexlify(0), 20))
   })
 
-  // mapping cannot be returned from solidity
-  xit('confirm solidity functionality: mapping', async function () {
-    
+  it('confirm solidity functionality: mapping', async function () {
+    const res1 = await contract.strUintMap('')
+    const res2 = await contract.addrBoolMap(contract.address)
+    const res3 = await contract.bytesBytesMap(10)
+    expect(res1).to.equal(ethers.BigNumber.from(0))
+    expect(res2).to.equal(false)
+    expect(res3).to.equal('0x')
   })
 })


### PR DESCRIPTION
**Description**:
Adding tests for the default values of all types in Solidity

**Related issue(s)**:
https://github.com/hashgraph/hedera-smart-contracts/issues/471