### PR TITLE
Update files to include mocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Hedera Smart Contract Service supporting files",
   "files": [
     "/contracts/**/*.sol",
-    "/contracts/**/**/**/*.sol"
+    "/contracts/**/**/**/*.sol",
+    "/test/foundry/mocks/**/*.sol",
+    "/test/foundry/mocks/**/**/**/*.sol"
   ],
   "repository": {
     "type": "git",

--- a/test/foundry/mocks/hts-precompile/HtsSystemContractMock.sol
+++ b/test/foundry/mocks/hts-precompile/HtsSystemContractMock.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.9;
 
-import 'forge-std/console.sol';
-
 import '../../../../contracts/hts-precompile/HederaResponseCodes.sol';
 import '../../../../contracts/hts-precompile/KeyHelper.sol';
 import './HederaFungibleToken.sol';

--- a/test/foundry/mocks/hts-precompile/HtsSystemContractMock.sol
+++ b/test/foundry/mocks/hts-precompile/HtsSystemContractMock.sol
@@ -43,6 +43,11 @@ contract HtsSystemContractMock is NoDelegateCall, KeyHelper, IHtsPrecompileMock 
     // HTS token -> paused
     mapping(address => TokenConfig) internal _tokenPaused;
 
+    // - - - - - - EVENTS - - - - - -
+
+    // emitted for convenience of having the token address accessible in a Hardhat environment
+    event TokenCreated(address indexed token);
+
     constructor() NoDelegateCall(HTS_PRECOMPILE) {}
 
     // peripheral internal helpers:
@@ -1222,6 +1227,7 @@ contract HtsSystemContractMock is NoDelegateCall, KeyHelper, IHtsPrecompileMock 
 
         /// @dev no need to register newly created HederaFungibleToken in this context as the constructor will call HtsSystemContractMock#registerHederaFungibleToken
         HederaFungibleToken hederaFungibleToken = new HederaFungibleToken(fungibleTokenInfo);
+        emit TokenCreated(address(hederaFungibleToken));
         return (HederaResponseCodes.SUCCESS, address(hederaFungibleToken));
     }
 
@@ -1238,6 +1244,7 @@ contract HtsSystemContractMock is NoDelegateCall, KeyHelper, IHtsPrecompileMock 
 
         /// @dev no need to register newly created HederaNonFungibleToken in this context as the constructor will call HtsSystemContractMock#registerHederaNonFungibleToken
         HederaNonFungibleToken hederaNonFungibleToken = new HederaNonFungibleToken(tokenInfo);
+        emit TokenCreated(address(hederaNonFungibleToken));
         return (HederaResponseCodes.SUCCESS, address(hederaNonFungibleToken));
     }
 
@@ -1267,6 +1274,7 @@ contract HtsSystemContractMock is NoDelegateCall, KeyHelper, IHtsPrecompileMock 
 
         /// @dev no need to register newly created HederaFungibleToken in this context as the constructor will call HtsSystemContractMock#registerHederaFungibleToken
         HederaFungibleToken hederaFungibleToken = new HederaFungibleToken(fungibleTokenInfo);
+        emit TokenCreated(address(hederaFungibleToken));
         return (HederaResponseCodes.SUCCESS, address(hederaFungibleToken));
     }
 
@@ -1288,6 +1296,7 @@ contract HtsSystemContractMock is NoDelegateCall, KeyHelper, IHtsPrecompileMock 
 
         /// @dev no need to register newly created HederaNonFungibleToken in this context as the constructor will call HtsSystemContractMock#registerHederaNonFungibleToken
         HederaNonFungibleToken hederaNonFungibleToken = new HederaNonFungibleToken(tokenInfo);
+        emit TokenCreated(address(hederaNonFungibleToken));
         return (HederaResponseCodes.SUCCESS, address(hederaNonFungibleToken));
     }
 


### PR DESCRIPTION
**Description**:

This PR adds the `test/foundry/mocks` folder to enable the use of the system contract mocks in a hardhat project that installs the hedera-smart-contracts as a dependency.

It also adds a `TokenCreated` event which is emitted by the `HtsSystemContractMock` contract when a `HederaFungibleToken` or  `HederaNonFungibleToken` contract is created, to make it easier to determine the address of the token contract in a hardhat development environment.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
