### PR TITLE
feat: added DataAllocation solidity example contract

### DIFF
--- a/contracts/yul/data-allocation/DataAllocation.sol
+++ b/contracts/yul/data-allocation/DataAllocation.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.20;
 
 contract DataAllocation {

--- a/contracts/yul/data-allocation/DataAllocation.sol
+++ b/contracts/yul/data-allocation/DataAllocation.sol
@@ -40,3 +40,4 @@ contract DataAllocation {
         }
     }
 }
+

--- a/contracts/yul/data-allocation/DataAllocation.sol
+++ b/contracts/yul/data-allocation/DataAllocation.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+contract DataAllocation {
+    uint256 a = 0;
+    uint256 b = 12;
+
+    /// mstore - mem[p…(p+32)) := v
+    /// mload - mem[p…(p+32))
+    function allocateMemory(uint256 p, uint256 v) external pure returns (uint256 n) {
+        assembly {
+            mstore(p, v)
+            n := mload(p)
+        }
+        return n;
+    }
+
+    /// mstore8 - mem[p] := v & 0xff (only modifies a single byte)
+    /// mload - mem[p…(p+32))
+    function allocateMemory8(uint256 p, uint8 v) external pure returns (uint8 n) {
+        bytes1 value;
+        assembly {
+            mstore8(p, v)
+            value := mload(p)
+        }
+        n = uint8(value);
+    }
+
+    /// sload - storage[p]
+    function sload(uint256 p) external view returns (uint256 n) {
+        assembly {
+            n := sload(p)
+        }
+    }
+
+    /// sstore - storage[p] := v
+    function sstore(uint256 p, uint256 v) external {
+        assembly {
+            sstore(p, v)
+        }
+    }
+}

--- a/test/yul/data-allocation/DataAllocation.js
+++ b/test/yul/data-allocation/DataAllocation.js
@@ -1,0 +1,69 @@
+/*-
+ *
+ * Hedera Smart Contracts
+ *
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+const { expect } = require('chai')
+const { ethers } = require('hardhat')
+
+describe('@solidityequiv5 Data Allocation Tests', () => {
+  let dataAllocationContract
+  const P = 32
+  const V = 72
+  const SLOT_0_KEY = 0
+  const SLOT_1_KEY = 1
+
+  before(async () => {
+    const dataAllocationContractFactory = await ethers.getContractFactory(
+      'DataAllocation'
+    )
+
+    dataAllocationContract = await dataAllocationContractFactory.deploy()
+  })
+
+  it('Should execute allocateMemory', async () => {
+    const result = await dataAllocationContract.allocateMemory(P, V)
+
+    expect(result).to.eq(V)
+  })
+
+  it('Should execute allocateMemory8', async () => {
+    const result = await dataAllocationContract.allocateMemory8(P, V)
+
+    expect(result).to.eq(V)
+  })
+
+  it('Should execute sload', async () => {
+    const EXPECTED_SLOT_0_VALUE = 0 // state variable `a`
+    const EXPECTED_SLOT_1_VALUE = 12 // state variable `b`
+
+    const result0 = await dataAllocationContract.sload(SLOT_0_KEY)
+    const result1 = await dataAllocationContract.sload(SLOT_1_KEY)
+
+    expect(result0).to.eq(EXPECTED_SLOT_0_VALUE)
+    expect(result1).to.eq(EXPECTED_SLOT_1_VALUE)
+  })
+
+  it('Should execute sstore', async () => {
+    await dataAllocationContract.sstore(SLOT_0_KEY, V)
+
+    const result = await dataAllocationContract.sload(SLOT_0_KEY)
+
+    expect(result).to.eq(V)
+  })
+})


### PR DESCRIPTION
**Description**:
- added DataAllocation solidity example contract to cover below opcodes
  - [x] mload(p)
  - [x] mstore(p, v)
  - [x] mstore8(p, v)
  - [x] sload(p)
  - [x] sstore(p, v)

- added unit tests to cover DataAllocation contract

**Related issue(s)**: #520

Fixes #520

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
