### PR TITLE
update: renamed methods in ControlStructures contract (#566)

### DIFF
--- a/contracts/solidity/control/ControlStructures.sol
+++ b/contracts/solidity/control/ControlStructures.sol
@@ -16,7 +16,7 @@ contract ControlStructures {
         testContract = new TestTryCatchContract();
     }
 
-    function testIfElse(bool condition) external pure returns(bool) {
+    function evaluateIfElse(bool condition) external pure returns(bool) {
         if(condition) {
             return true;
         } else {
@@ -24,7 +24,7 @@ contract ControlStructures {
         }
     }
 
-    function testWhile(uint256 total) external pure returns(uint256) {
+    function evaluateWhile(uint256 total) external pure returns(uint256) {
         require(total < 100, "Cannot have more than 100 iterations");
         uint256 it = 0;
         while(++it < total) {}
@@ -32,7 +32,7 @@ contract ControlStructures {
         return it;
     }
 
-    function testDoWhile(uint256 total) external pure returns(uint256) {
+    function evaluateDoWhile(uint256 total) external pure returns(uint256) {
         require(total < 100, "Cannot have more than 100 iterations");
         uint256 it = 0;
         do {
@@ -42,7 +42,7 @@ contract ControlStructures {
         return it;
     }
 
-    function testBreak(uint256 total, uint256 interception) external pure returns(uint256) {
+    function evaluateBreak(uint256 total, uint256 interception) external pure returns(uint256) {
         require(total < 100, "Cannot have more than 100 iterations");
         uint256 it = 0;
         while(it++ < total) {
@@ -52,7 +52,7 @@ contract ControlStructures {
         return it;
     }
 
-    function testContinue(uint256 total, uint256 interception) external pure returns(uint256) {
+    function evaluateContinue(uint256 total, uint256 interception) external pure returns(uint256) {
         require(total < 100, "Cannot have more than 100 iterations");
         uint256 iterableSteps = 0;
         
@@ -64,7 +64,7 @@ contract ControlStructures {
         return iterableSteps;
     }
 
-    function testFor(uint256 total) external pure returns(uint256) {
+    function evaluateFor(uint256 total) external pure returns(uint256) {
         require(total < 100, "Cannot have more than 100 iterations");
         uint256 it = 0;
         for(uint i=0; i < total; i++) {
@@ -79,7 +79,7 @@ contract ControlStructures {
         return "my func was called";
     }
 
-    function testTryCatch(uint256 condition) external view returns(bool) {
+    function evaluateTryCatch(uint256 condition) external view returns(bool) {
         try testContract.myFunc(condition) {
             return true;
         } catch {

--- a/test/solidity/control/control.js
+++ b/test/solidity/control/control.js
@@ -23,55 +23,57 @@ const { ethers } = require('hardhat')
 const Constants = require('../../constants')
 
 describe('Control Structures', function () {
-    let contract;
+  let contract
 
-    before(async function () {
-        const factory = await ethers.getContractFactory(Constants.Contract.ControlStructures)
-        contract = await factory.deploy()
-    })
+  before(async function () {
+    const factory = await ethers.getContractFactory(
+      Constants.Contract.ControlStructures
+    )
+    contract = await factory.deploy()
+  })
 
-    it('should verify is is working correctly', async function () {
-        const res = await contract.testIfElse(false)
-        expect(res).to.equal(false)
-    })
+  it('should verify is is working correctly', async function () {
+    const res = await contract.evaluateIfElse(false)
+    expect(res).to.equal(false)
+  })
 
-    it('should verify else is working correctly', async function () {
-        const res = await contract.testIfElse(true)
-        expect(res).to.equal(true)
-    })
+  it('should verify else is working correctly', async function () {
+    const res = await contract.evaluateIfElse(true)
+    expect(res).to.equal(true)
+  })
 
-    it('should verify while is working correctly', async function () {
-        const res = await contract.testWhile(5)
-        expect(res).to.equal(5) 
-    })
+  it('should verify while is working correctly', async function () {
+    const res = await contract.evaluateWhile(5)
+    expect(res).to.equal(5)
+  })
 
-    it('should verify do is working correctly', async function () {
-        const res = await contract.testDoWhile(5)
-        expect(res).to.equal(5) 
-    })
+  it('should verify do is working correctly', async function () {
+    const res = await contract.evaluateDoWhile(5)
+    expect(res).to.equal(5)
+  })
 
-    it('should verify break is working correctly', async function () {
-        const res = await contract.testBreak(5, 3)
-        expect(res).to.equal(3) 
-    })
+  it('should verify break is working correctly', async function () {
+    const res = await contract.evaluateBreak(5, 3)
+    expect(res).to.equal(3)
+  })
 
-    it('should verify continue is working correctly', async function () {
-        const res = await contract.testContinue(5, 3)
-        expect(res).to.equal(4) 
-    })
+  it('should verify continue is working correctly', async function () {
+    const res = await contract.evaluateContinue(5, 3)
+    expect(res).to.equal(4)
+  })
 
-    it('should verify for is working correctly', async function () {
-        const res = await contract.testFor(5)
-        expect(res).to.equal(4) 
-    })
+  it('should verify for is working correctly', async function () {
+    const res = await contract.evaluateFor(5)
+    expect(res).to.equal(4)
+  })
 
-    it('should verify catch is working correctly', async function () {
-        const res = await contract.testTryCatch(0)
-        expect(res).to.equal(false) 
-    })
+  it('should verify catch is working correctly', async function () {
+    const res = await contract.evaluateTryCatch(0)
+    expect(res).to.equal(false)
+  })
 
-    it('should verify try is working correctly', async function () {
-        const res = await contract.testTryCatch(1)
-        expect(res).to.equal(true) 
-    })
+  it('should verify try is working correctly', async function () {
+    const res = await contract.evaluateTryCatch(1)
+    expect(res).to.equal(true)
+  })
 })


### PR DESCRIPTION
**Description**:
This PR renamed the methods in ControlStructures contract by replacing the special keyword "test" with "evaluate" so that the `forge test` wouldn't pick up these methods hence wouldn't cause disruptions in foundry-test CI 

**Related issue(s)**:

Fixes #566

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
