### PR TITLE
update: renamed methods in Panic contract to fix foundry-test in CI (#578)

### DIFF
--- a/contracts/solidity/errors/Panic.sol
+++ b/contracts/solidity/errors/Panic.sol
@@ -12,44 +12,44 @@ contract Panic {
     constructor() {
     }
 
-    function testPanicError0x01() external pure {
+    function verifyPanicError0x01() external pure {
         assert(false);
     }
 
-    function testPanicError0x11() external pure returns(uint8) {
+    function verifyPanicError0x11() external pure returns(uint8) {
         uint8 test = 255;
         uint8 test2 = 1;
         return test + test2;
     }
 
-    function testPanicError0x12() external pure returns(uint8) {
+    function verifyPanicError0x12() external pure returns(uint8) {
         uint8 number1 = 5;
         uint8 number2 = 12-12;
         return number1 / number2;
     }
 
-    function testPanicError0x21() external pure {
+    function verifyPanicError0x21() external pure {
         int testValue = -1;
         Button value = Button(testValue);
     }
 
-    function testPanicError0x22() external pure returns(uint8) {
+    function verifyPanicError0x22() external pure returns(uint8) {
         return 0;
     }
 
-    function testPanicError0x31() external {
+    function verifyPanicError0x31() external {
        someArray.pop();
     }
 
-    function testPanicError0x32() external view returns(uint) {
+    function verifyPanicError0x32() external view returns(uint) {
        return anotherArray[5];
     }
 
-    function testPanicError0x41() external pure returns(uint[] memory) {
+    function verifyPanicError0x41() external pure returns(uint[] memory) {
        uint[] memory largeArray = new uint[](2**64);
     }
 
-    function testPanicError0x51() external pure returns(uint) {
+    function verifyPanicError0x51() external pure returns(uint) {
        function (uint, uint) internal pure returns (uint) funcPtr;
 
        return funcPtr(5, 6);

--- a/test/solidity/errors/panicErrors.js
+++ b/test/solidity/errors/panicErrors.js
@@ -31,93 +31,93 @@ describe('@solidityequiv3 Panic Errors', function () {
   })
 
   it('should verify panic error 0x01', async function () {
-    let error;
+    let error
     try {
-      await contract.testPanicError0x01();
-    } catch(e) {
-      error = e;
+      await contract.verifyPanicError0x01()
+    } catch (e) {
+      error = e
     }
-    expect(error.errorName).to.eq('Panic');
+    expect(error.errorName).to.eq('Panic')
     expect(error.errorArgs).to.deep.eq([ethers.BigNumber.from(1)])
   })
 
   it('should verify panic error 0x11', async function () {
-    let error;
+    let error
     try {
-      await contract.testPanicError0x11();
-    } catch(e) {
-      error = e;
+      await contract.verifyPanicError0x11()
+    } catch (e) {
+      error = e
     }
-    expect(error.errorName).to.eq('Panic');
+    expect(error.errorName).to.eq('Panic')
     expect(error.errorArgs).to.deep.eq([ethers.BigNumber.from(17)])
   })
 
   it('should verify panic error 0x12', async function () {
-    let error;
+    let error
     try {
-      await contract.testPanicError0x12();
-    } catch(e) {
-      error = e;
+      await contract.verifyPanicError0x12()
+    } catch (e) {
+      error = e
     }
-    expect(error.errorName).to.eq('Panic');
+    expect(error.errorName).to.eq('Panic')
     expect(error.errorArgs).to.deep.eq([ethers.BigNumber.from(18)])
   })
 
   it('should verify panic error 0x21', async function () {
-    let error;
+    let error
     try {
-      await contract.testPanicError0x21();
-    } catch(e) {
-      error = e;
+      await contract.verifyPanicError0x21()
+    } catch (e) {
+      error = e
     }
-    expect(error.errorName).to.eq('Panic');
+    expect(error.errorName).to.eq('Panic')
     expect(error.errorArgs).to.deep.eq([ethers.BigNumber.from(33)])
   })
 
   it('should verify panic error 0x31', async function () {
-    let error;
+    let error
     try {
-      const result = await contract.getSomeArray();
-      console.log(result);
-      await contract.testPanicError0x31();
-    } catch(e) {
-      error = e;
+      const result = await contract.getSomeArray()
+      console.log(result)
+      await contract.verifyPanicError0x31()
+    } catch (e) {
+      error = e
     }
-    expect(error.errorName).to.eq('Panic');
+    expect(error.errorName).to.eq('Panic')
     expect(error.errorArgs).to.deep.eq([ethers.BigNumber.from(18)])
   })
 
   it('should verify panic error 0x32', async function () {
-    let error;
+    let error
     try {
-      await contract.testPanicError0x32();
-    } catch(e) {
-      error = e;
+      await contract.verifyPanicError0x32()
+    } catch (e) {
+      error = e
     }
-    expect(error.errorName).to.eq('Panic');
+    expect(error.errorName).to.eq('Panic')
     expect(error.errorArgs).to.deep.eq([ethers.BigNumber.from(50)])
   })
 
   it('should verify panic error 0x41', async function () {
-    let error;
+    let error
     try {
-      await contract.testPanicError0x41();
-    } catch(e) {
+      await contract.verifyPanicError0x41()
+    } catch (e) {
       console.log(e)
-      error = e;
+      error = e
     }
-    expect(error.errorName).to.eq('Panic');
+    expect(error.errorName).to.eq('Panic')
     expect(error.errorArgs).to.deep.eq([ethers.BigNumber.from(65)])
   })
 
   it('should verify panic error 0x51', async function () {
-    let error;
+    let error
     try {
-      await contract.testPanicError0x51();
-    } catch(e) {
-      error = e;
+      await contract.verifyPanicError0x51()
+    } catch (e) {
+      error = e
     }
-    expect(error.errorName).to.eq('Panic');
+    expect(error.errorName).to.eq('Panic')
     expect(error.errorArgs).to.deep.eq([ethers.BigNumber.from(81)])
   })
 })


### PR DESCRIPTION
**Description**:
This PR renamed the methods in Panic contract by replacing the special keyword "test" with "verify" so that the forge test wouldn't pick up these methods hence wouldn't cause disruptions in foundry-test CI


**Related issue(s)**:

Fixes #578 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
