### PR TITLE
feat: Adding besu local node config

### DIFF
--- a/TEST_SETUP.md
+++ b/TEST_SETUP.md
@@ -38,6 +38,12 @@ At root, create a `.env` file using the `example.env` as the template and fill o
 
 Adjust the `defaultNetwork` field in the [hardhat.config.js](hardhat.config.js) file based on the network your accounts (specified in the .env file) are associated with.
 
+Available Networks:
+   - local for reference and how to setup a local besu node please follow the [link](https://docs.hedera.com/hedera/sdks-and-apis/sdks/set-up-your-local-network)
+   - testnet
+   - previewnet
+   - besu_local for reference and how to setup a local besu node please follow the [link](https://besu.hyperledger.org/)
+
 #### 4. Installing the `foundry-rs` toolkit for the `forge` testing framework
 
 **_Motivation_**: This step is necessary for the project as it utilizes the `hardhat-foundry` plugin, enabling Hardhat to use dependencies from the `./lib` folder, which are installed using `forge`. Consequently, the plugin attempts to execute `forge install` to make these dependencies accessible to Hardhat. Therefore, it is crucial to install the `forge` testing framework, which is a part of the `foundry-rs` toolkit.

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -74,5 +74,21 @@ module.exports = {
         mirrorNode: NETWORKS.previewnet.mirrorNode,
       },
     },
+     // besu local node
+     besu_local: {
+      url: NETWORKS.besu.url,
+      allowUnlimitedContractSize: NETWORKS.besu.allowUnlimitedContractSize,
+      blockGasLimit: NETWORKS.besu.blockGasLimit,
+      gas: NETWORKS.besu.gas,
+      timeout: NETWORKS.besu.timeout,
+      chainId: NETWORKS.besu.chainId,
+      accounts: [
+        // private keys are configured in the genesis file https://github.com/hyperledger/besu/blob/main/config/src/main/resources/dev.json#L20
+        // private key for 0xf17f52151EbEF6C7334FAD080c5704D77216b732
+        "ae6ae8e5ccbfb04590405997ee2d52d2b330726137b875053c36d94e974d162f",
+        // private key for 0x627306090abaB3A6e1400e9345bC60c78a8BEf57
+        "c87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3",
+      ],
+    },
   },
 }

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -43,6 +43,15 @@ const NETWORKS = {
     nodeId: '3',
     mirrorNode: 'https://previewnet.mirrornode.hedera.com',
   },
+  besu: {
+    name: 'besu_local',
+    url: 'http://127.0.0.1:8544',
+    chainId: 1337,
+    allowUnlimitedContractSize: true,
+    blockGasLimit: 0x1fffffffffffff,
+    gas: 1_000_000_000,
+    timeout: 60_000,
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
**Description**:
Adding Besu local node configuration.
This is just for convenience of the user.

Currently we have in our hardhat.config.js configurations for 3 networks. (local, testnet, previewnet)
This task is going to add a 4th one. For a Local Besu instance (if the user of the repo has one)
This local Besu instance is useful for debugging when a problem with our Local Node is identified. 
You can double check our smart contract tests against the pure Besu node. 

**Related issue(s)**:
Add Besu local node configuration #616
