### PR TITLE
fix: removed ZeroHashes as private keys

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -59,14 +59,7 @@ module.exports = {
   networks: {
     local: {
       url: NETWORKS.local.url,
-      accounts: [
-        PRIVATE_KEYS[0],
-        PRIVATE_KEYS[1],
-        PRIVATE_KEYS[2],
-        PRIVATE_KEYS[3],
-        PRIVATE_KEYS[4],
-        PRIVATE_KEYS[5],
-      ],
+      accounts: PRIVATE_KEYS,
       chainId: NETWORKS.local.chainId,
       gas: 10000000,
       sdkClient: {
@@ -79,14 +72,7 @@ module.exports = {
     },
     testnet: {
       url: NETWORKS.testnet.url,
-      accounts: [
-        PRIVATE_KEYS[0],
-        PRIVATE_KEYS[1],
-        PRIVATE_KEYS[2],
-        PRIVATE_KEYS[3],
-        PRIVATE_KEYS[4],
-        PRIVATE_KEYS[5],
-      ],
+      accounts: PRIVATE_KEYS,
       chainId: NETWORKS.testnet.chainId,
       sdkClient: {
         operatorId: OPERATOR_ID_A,
@@ -98,14 +84,7 @@ module.exports = {
     },
     previewnet: {
       url: NETWORKS.previewnet.url,
-      accounts: [
-        PRIVATE_KEYS[0],
-        PRIVATE_KEYS[1],
-        PRIVATE_KEYS[2],
-        PRIVATE_KEYS[3],
-        PRIVATE_KEYS[4],
-        PRIVATE_KEYS[5],
-      ],
+      accounts: PRIVATE_KEYS,
       chainId: NETWORKS.previewnet.chainId,
       sdkClient: {
         operatorId: OPERATOR_ID_A,

--- a/test/solidity/voting/Ballot.js
+++ b/test/solidity/voting/Ballot.js
@@ -21,6 +21,11 @@ const { expect } = require('chai');
 const { ethers } = require('hardhat');
 const Constants = require('../../constants');
 
+/**
+ * @notice This specific test suite necessitates the presence of 6 accounts for completion.
+ * @notice Ensure that you include 6 private keys in the .env file under the `PRIVATE_KEYS` variable.
+ */
+
 describe('@solidityequiv3 Ballot Units Test Suite', function () {
   let ballotContract, owner, addressB, addressC, addressD, addressE, addrs;
 

--- a/test/solidity/voting/Ballot.js
+++ b/test/solidity/voting/Ballot.js
@@ -45,21 +45,36 @@ describe('@solidityequiv3 Ballot Units Test Suite', function () {
   });
 
   it('Should give voting rights', async function () {
-    await ballotContract.giveRightToVote(addressB.address);
+    const tx = await ballotContract.giveRightToVote(addressB.address);
+    await tx.wait();
     const voter = await ballotContract.voters(addressB.address);
     expect(voter.weight).to.equal(1);
   });
 
   it('Should allow a voter to delegate their vote', async function () {
-    await ballotContract.giveRightToVote(addressB.address);
-    await ballotContract.connect(addressB).delegate(owner.address);
+    const giveRightToVoteTx = await ballotContract.giveRightToVote(
+      addressB.address
+    );
+    await giveRightToVoteTx.wait();
+
+    const delegateTx = await ballotContract
+      .connect(addressB)
+      .delegate(owner.address);
+    await delegateTx.wait();
+
     const ownerVoter = await ballotContract.voters(owner.address);
     expect(ownerVoter.weight).to.equal(2); // 1 (original) + 1 (delegated)
   });
 
   it('Should allow voting for a proposal', async function () {
-    await ballotContract.giveRightToVote(addressB.address);
-    await ballotContract.connect(addressB).vote(1); // voting for proposal2
+    const giveRightToVoteTx = await ballotContract.giveRightToVote(
+      addressB.address
+    );
+    await giveRightToVoteTx.wait();
+
+    const voteTx = await ballotContract.connect(addressB).vote(1); // voting for proposal2
+    await voteTx.wait();
+
     const proposal = await ballotContract.proposals(1);
     expect(proposal.voteCount).to.equal(1);
   });

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -5,6 +5,7 @@ const { ethers } = require('ethers');
 const OPERATOR_ID_A = process.env.OPERATOR_ID_A
   ? process.env.OPERATOR_ID_A
   : '0.0.0';
+
 /**  @type string */
 const OPERATOR_KEY_A = process.env.OPERATOR_KEY_A
   ? process.env.OPERATOR_KEY_A
@@ -13,10 +14,6 @@ const OPERATOR_KEY_A = process.env.OPERATOR_KEY_A
 const PRIVATE_KEYS = process.env.PRIVATE_KEYS
   ? process.env.PRIVATE_KEYS.split(',').map((key) => key.trim())
   : [];
-
-while (PRIVATE_KEYS.length < 6) {
-  PRIVATE_KEYS.push(ethers.ZeroHash);
-}
 
 const NETWORKS = {
   local: {


### PR DESCRIPTION
**Description**:
"Removed the ZeroHash instances as private keys within the `PRIVATE_KEYS` constant variable. It is not mandatory for the `PRIVATE_KEYS` constant variable to contain exactly six private keys for the process to proceed. Attempting to fill the empty slots in the `PRIVATE_KEYS` variable will result in a `Private keys invalid` error."

**Related issue(s)**:

Fixes #652 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
