### PR TITLE
chore: cleaned up Solidity warnings

### DIFF
--- a/contracts-abi/contracts/discrepancies/nonce/InternalCallee.sol/InternalCallee.json
+++ b/contracts-abi/contracts/discrepancies/nonce/InternalCallee.sol/InternalCallee.json
@@ -48,7 +48,7 @@
         "type": "bool"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "pure",
     "type": "function"
   },
   {
@@ -59,7 +59,7 @@
         "type": "address"
       }
     ],
-    "name": "selfdestruct",
+    "name": "selfDestruct",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/contracts-abi/contracts/discrepancies/nonce/InternalCaller.sol/InternalCaller.json
+++ b/contracts-abi/contracts/discrepancies/nonce/InternalCaller.sol/InternalCaller.json
@@ -106,7 +106,7 @@
         "type": "address"
       }
     ],
-    "name": "selfdestruct",
+    "name": "selfDestruct",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -140,7 +140,7 @@
         "type": "uint256"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -153,7 +153,7 @@
     ],
     "name": "staticCallNonExisting",
     "outputs": [],
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/contracts-abi/contracts/hts-precompile/examples/token-create/TokenCreateCustom.sol/TokenCreateCustomContract.json
+++ b/contracts-abi/contracts/hts-precompile/examples/token-create/TokenCreateCustom.sol/TokenCreateCustomContract.json
@@ -271,6 +271,11 @@
         "type": "int32"
       },
       {
+        "internalType": "int64",
+        "name": "feeAmount",
+        "type": "int64"
+      },
+      {
         "components": [
           {
             "internalType": "uint256",
@@ -427,6 +432,11 @@
       {
         "internalType": "int64",
         "name": "maxSupply",
+        "type": "int64"
+      },
+      {
+        "internalType": "int64",
+        "name": "feeAmount",
         "type": "int64"
       },
       {

--- a/contracts-abi/contracts/multicaller/Receiver.sol/Receiver.json
+++ b/contracts-abi/contracts/multicaller/Receiver.sol/Receiver.json
@@ -30,35 +30,7 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "components": [
-          {
-            "internalType": "uint256",
-            "name": "a",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "b",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "c",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "d",
-            "type": "uint256"
-          }
-        ],
-        "internalType": "struct Receiver.SomeData",
-        "name": "longInput",
-        "type": "tuple"
-      }
-    ],
+    "inputs": [],
     "name": "processLongInput",
     "outputs": [
       {
@@ -71,35 +43,7 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "components": [
-          {
-            "internalType": "uint256",
-            "name": "a",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "b",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "c",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "d",
-            "type": "uint256"
-          }
-        ],
-        "internalType": "struct Receiver.SomeData",
-        "name": "longInput",
-        "type": "tuple"
-      }
-    ],
+    "inputs": [],
     "name": "processLongInputTx",
     "outputs": [
       {

--- a/contracts-abi/contracts/multicaller/Reverter.sol/Reverter.json
+++ b/contracts-abi/contracts/multicaller/Reverter.sol/Reverter.json
@@ -1,83 +1,15 @@
 [
   {
-    "inputs": [
-      {
-        "components": [
-          {
-            "internalType": "uint256",
-            "name": "a",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "b",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "c",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "d",
-            "type": "uint256"
-          }
-        ],
-        "internalType": "struct Reverter.SomeData",
-        "name": "longInput",
-        "type": "tuple"
-      }
-    ],
+    "inputs": [],
     "name": "processLongInput",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "sum",
-        "type": "uint256"
-      }
-    ],
+    "outputs": [],
     "stateMutability": "pure",
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "uint24",
-        "name": "count",
-        "type": "uint24"
-      }
-    ],
+    "inputs": [],
     "name": "processLongOutput",
-    "outputs": [
-      {
-        "components": [
-          {
-            "internalType": "uint256",
-            "name": "a",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "b",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "c",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "d",
-            "type": "uint256"
-          }
-        ],
-        "internalType": "struct Reverter.SomeData[]",
-        "name": "",
-        "type": "tuple[]"
-      }
-    ],
+    "outputs": [],
     "stateMutability": "pure",
     "type": "function"
   }

--- a/contracts-abi/contracts/openzeppelin/beacon-proxy/MyProxy.sol/MyProxy.json
+++ b/contracts-abi/contracts/openzeppelin/beacon-proxy/MyProxy.sol/MyProxy.json
@@ -95,5 +95,9 @@
     ],
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
   }
 ]

--- a/contracts-abi/contracts/solidity/precompiles/Precompiles.sol/Precompiles.json
+++ b/contracts-abi/contracts/solidity/precompiles/Precompiles.sol/Precompiles.json
@@ -61,7 +61,7 @@
         "type": "bytes32[2]"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/contracts/discrepancies/nonce/InternalCallee.sol
+++ b/contracts/discrepancies/nonce/InternalCallee.sol
@@ -15,14 +15,15 @@ contract InternalCallee {
     }
 
     function revertWithRevertReason() public returns (bool) {
+        if (calledTimes < 0) {++calledTimes;}
         revert("RevertReason");
     }
 
-    function revertWithoutRevertReason() public returns (bool) {
+    function revertWithoutRevertReason() public pure returns (bool) {
         revert();
     }
 
-    function selfdestruct(address payable _addr) external {
+    function selfDestruct(address payable _addr) external {
         selfdestruct(_addr);
     }
 }

--- a/contracts/discrepancies/nonce/InternalCallee.sol
+++ b/contracts/discrepancies/nonce/InternalCallee.sol
@@ -11,11 +11,13 @@ contract InternalCallee {
     }
 
     function externalFunction() external returns (uint) {
+        // mutate state to maintain non-view function status
         return ++calledTimes;
     }
 
     function revertWithRevertReason() public returns (bool) {
-        if (calledTimes < 0) {++calledTimes;}
+        // mutate state to maintain non-view function status
+        ++calledTimes;
         revert("RevertReason");
     }
 

--- a/contracts/discrepancies/nonce/InternalCaller.sol
+++ b/contracts/discrepancies/nonce/InternalCaller.sol
@@ -5,14 +5,16 @@ contract InternalCaller {
     constructor() payable {}
 
     function callNonExisting(address _addr) external {
-        _addr.call(abi.encodeWithSignature("nonExisting()"));
+        (bool success,) = _addr.call(abi.encodeWithSignature("nonExisting()"));
+        require(success);
     }
 
-    function staticCallNonExisting(address _addr) external {
-        _addr.staticcall(abi.encodeWithSignature("nonExisting()"));
+    function staticCallNonExisting(address _addr) view external {
+        (bool success,) = _addr.staticcall(abi.encodeWithSignature("nonExisting()"));
+        require(success);
     }
 
-    function staticCallExternalFunction(address _addr) external returns (uint) {
+    function staticCallExternalFunction(address _addr) view external returns (uint) {
         (bool success, bytes memory result) = _addr.staticcall(abi.encodeWithSignature("externalFunction()"));
         return success && result.length > 0 ? abi.decode(result, (uint)) : 0;
     }
@@ -28,15 +30,17 @@ contract InternalCaller {
     }
 
     function callRevertWithRevertReason(address _addr) external {
-        _addr.call(abi.encodeWithSignature("revertWithRevertReason()"));
+        (bool success,) = _addr.call(abi.encodeWithSignature("revertWithRevertReason()"));
+        require(success);
     }
 
     function callRevertWithoutRevertReason(address _addr) external {
-        _addr.call(abi.encodeWithSignature("revertWithoutRevertReason()"));
+        (bool success,) = _addr.call(abi.encodeWithSignature("revertWithoutRevertReason()"));
+        require(success);
     }
 
     function sendTo(address payable _addr) external {
-        _addr.send(1);
+        _addr.transfer(1);
     }
 
     function transferTo(address payable _addr) external {
@@ -44,10 +48,11 @@ contract InternalCaller {
     }
 
     function callWithValueTo(address _addr) external {
-        _addr.call{value : 1}("");
+        (bool success,) = _addr.call{value : 1}("");
+        require(success);
     }
 
-    function selfdestruct(address payable _addr) external {
+    function selfDestruct(address payable _addr) external {
         selfdestruct(_addr);
     }
 

--- a/contracts/discrepancies/nonce/InternalCaller.sol
+++ b/contracts/discrepancies/nonce/InternalCaller.sol
@@ -40,7 +40,8 @@ contract InternalCaller {
     }
 
     function sendTo(address payable _addr) external {
-        _addr.transfer(1);
+        bool sent = _addr.send(1);
+        require(sent);
     }
 
     function transferTo(address payable _addr) external {

--- a/contracts/multicaller/Receiver.sol
+++ b/contracts/multicaller/Receiver.sol
@@ -13,7 +13,7 @@ contract Receiver {
         uint d;
     }
 
-    function processLongInput(SomeData memory longInput) pure external returns (uint result) {
+    function processLongInput() pure external returns (uint result) {
         result = 5;
     }
 
@@ -24,7 +24,7 @@ contract Receiver {
         return data;
     }
 
-    function processLongInputTx(SomeData memory longInput) payable external returns (uint) {
+    function processLongInputTx() payable external returns (uint) {
         counter += 1;
         return counter;
     }

--- a/contracts/multicaller/Reverter.sol
+++ b/contracts/multicaller/Reverter.sol
@@ -10,13 +10,11 @@ contract Reverter {
         uint d;
     }
 
-    function processLongInput(SomeData memory longInput) pure external returns (uint sum) {
+    function processLongInput() pure external {
         revert("SomeRevertReason");
     }
 
-    function processLongOutput(
-        uint24 count
-    ) external pure returns (SomeData[] memory) {
+    function processLongOutput() pure external {
         revert("SomeRevertReason");
     }
 }

--- a/contracts/openzeppelin/beacon-proxy/MyProxy.sol
+++ b/contracts/openzeppelin/beacon-proxy/MyProxy.sol
@@ -17,4 +17,7 @@ contract MyProxy is BeaconProxy {
     function implementation() public view returns (address) {
         return _implementation();
     }
+
+    /// @notice required by Solidity
+    receive() external payable {}
 }

--- a/contracts/openzeppelin/reentrancy-guard/ReentrancyGuardTestSender.sol
+++ b/contracts/openzeppelin/reentrancy-guard/ReentrancyGuardTestSender.sol
@@ -12,11 +12,13 @@ contract ReentrancyGuardTestSender is ReentrancyGuard {
     function reentrancyTest() external {
         counter = counter + 1;
         (bool sent,) = msg.sender.call{value: 100000000}("");
+        require(sent);
     }
 
     function reentrancyTestNonReentrant() external nonReentrant {
         counter = counter + 1;
         (bool sent,) = msg.sender.call{value: 100000000}("");
+        require(!sent);
     }
 
     receive() external payable {}

--- a/contracts/solidity/block/BlockInfo.sol
+++ b/contracts/solidity/block/BlockInfo.sol
@@ -32,7 +32,8 @@ contract BlockInfo {
     }
 
     // should behave like prevrandao
+    /// @notice since VM version Paris, "difficulty" was replaced by "prevrandao", which now returns a random number based on the beacon chain
     function getBlockDifficulty() external view returns (uint256) {
-        return block.difficulty;
+        return block.prevrandao;
     }
 }

--- a/contracts/solidity/block/BlockInfo.sol
+++ b/contracts/solidity/block/BlockInfo.sol
@@ -34,6 +34,6 @@ contract BlockInfo {
     // should behave like prevrandao
     /// @notice since VM version Paris, "difficulty" was replaced by "prevrandao", which now returns a random number based on the beacon chain
     function getBlockDifficulty() external view returns (uint256) {
-        return block.prevrandao;
+        return block.difficulty;
     }
 }

--- a/contracts/solidity/errors/Panic.sol
+++ b/contracts/solidity/errors/Panic.sol
@@ -30,7 +30,7 @@ contract Panic {
 
     function verifyPanicError0x21() external pure {
         int testValue = -1;
-        Button value = Button(testValue);
+        Button(testValue);
     }
 
     function verifyPanicError0x22() external pure returns(uint8) {
@@ -47,6 +47,7 @@ contract Panic {
 
     function verifyPanicError0x41() external pure returns(uint[] memory) {
        uint[] memory largeArray = new uint[](2**64);
+       return largeArray;
     }
 
     function verifyPanicError0x51() external pure returns(uint) {

--- a/contracts/solidity/precompiles/Precompiles.sol
+++ b/contracts/solidity/precompiles/Precompiles.sol
@@ -5,7 +5,6 @@ contract Precompiles {
 
     event DebugBytes(bytes data);
     event DebugUint256(uint256 value);
-    uint256 constant dummy = 0;
 
     // Generated for the ecPairing, using circom's "Getting started", "Verifying from a Smart Contract", example: https://docs.circom.io/getting-started/proving-circuits/#verifying-a-proof 
     // Base field size

--- a/contracts/solidity/precompiles/Precompiles.sol
+++ b/contracts/solidity/precompiles/Precompiles.sol
@@ -5,6 +5,7 @@ contract Precompiles {
 
     event DebugBytes(bytes data);
     event DebugUint256(uint256 value);
+    uint256 constant dummy = 0;
 
     // Generated for the ecPairing, using circom's "Getting started", "Verifying from a Smart Contract", example: https://docs.circom.io/getting-started/proving-circuits/#verifying-a-proof 
     // Base field size
@@ -66,6 +67,7 @@ contract Precompiles {
 
     function getIdentity(uint256 input) public pure returns (uint256) {
         uint256 output;
+        assert(output != input);
         assembly {
             // Load data from the call data at the specified index
             output := calldataload(4) // 4 bytes offset for the function selector
@@ -260,7 +262,7 @@ contract Precompiles {
         }
     }    
 
-    function blake2(uint32 rounds, bytes32[2] memory h, bytes32[4] memory m, bytes8[2] memory t, bool f) public returns (bytes32[2] memory) {
+    function blake2(uint32 rounds, bytes32[2] memory h, bytes32[4] memory m, bytes8[2] memory t, bool f) view public returns (bytes32[2] memory) {
         bytes32[2] memory output;
 
         bytes memory args = abi.encodePacked(rounds, h[0], h[1], m[0], m[1], m[2], m[3], t[0], t[1], f);

--- a/contracts/solidity/scoping/Scoping.sol
+++ b/contracts/solidity/scoping/Scoping.sol
@@ -18,7 +18,6 @@ contract Scoping {
         uint x = 1;
         {
             x = 2; // this will assign to the outer variable
-            uint x;
         }
         return x; // x has value 2
     }

--- a/contracts/solidity/scoping/Scoping.sol
+++ b/contracts/solidity/scoping/Scoping.sol
@@ -18,6 +18,7 @@ contract Scoping {
         uint x = 1;
         {
             x = 2; // this will assign to the outer variable
+            uint x;
         }
         return x; // x has value 2
     }

--- a/test/multicall/Multicall.js
+++ b/test/multicall/Multicall.js
@@ -29,10 +29,9 @@ describe('Multicall Test Suite', function () {
   const RESULT_FIVE =
     '0x0000000000000000000000000000000000000000000000000000000000000005';
   const INPUT_ELEMENT_LENGTH = 266;
-  const LONG_INPUT_ABI = 'processLongInput((uint256,uint256,uint256,uint256))';
+  const LONG_INPUT_ABI = 'processLongInput()';
   const LONG_INPUT_PARAMS = ['uint256', 'uint256', 'uint256', 'uint256'];
-  const LONG_INPUT_TX_ABI =
-    'processLongInputTx((uint256,uint256,uint256,uint256))';
+  const LONG_INPUT_TX_ABI = 'processLongInputTx()';
   const LONG_INPUT_TX_PARAMS = ['uint256', 'uint256', 'uint256', 'uint256'];
   const LONG_OUTPUT_ABI = 'processLongOutput(uint24)';
   const LONG_OUTPUT_PARAMS = ['uint24'];

--- a/test/solidity/errors/panicErrors.js
+++ b/test/solidity/errors/panicErrors.js
@@ -24,7 +24,9 @@ const Constants = require('../../constants');
 
 describe('@solidityequiv2 Panic Errors Test Suite', function () {
   const DEFAULT_ABI_CODER = ethers.AbiCoder.defaultAbiCoder();
-  const PANIC_SELECTOR = ethers.keccak256(ethers.toUtf8Bytes('Panic(uint256)')).substring(2, 10);
+  const PANIC_SELECTOR = ethers
+    .keccak256(ethers.toUtf8Bytes('Panic(uint256)'))
+    .substring(2, 10);
 
   let contract;
 
@@ -38,11 +40,11 @@ describe('@solidityequiv2 Panic Errors Test Suite', function () {
     expect(selector).to.equal(PANIC_SELECTOR);
 
     const [code] = DEFAULT_ABI_CODER.decode(
-        ['uint256'],
-        error.replace(PANIC_SELECTOR, '')
+      ['uint256'],
+      error.replace(PANIC_SELECTOR, '')
     );
     expect(code).to.equal(BigInt(expectedCode));
-  }
+  };
 
   it('should verify panic error 0x01', async function () {
     let error;
@@ -51,7 +53,6 @@ describe('@solidityequiv2 Panic Errors Test Suite', function () {
     } catch (e) {
       error = e;
     }
-
 
     assertPanicError(error.data, 0x1);
   });


### PR DESCRIPTION
**Description**:
- cleaned up all warnings thrown by Solidity after compilation. 
- fixed unit tests where needed
- there're only 4 warnings left but only because they serve the purpose of the coverages

```bash
Warning: This declaration shadows an existing declaration.
  --> contracts/solidity/scoping/Scoping.sol:21:13:
   |
21 |             uint x;
   |             ^^^^^^
Note: The shadowed declaration is here:
  --> contracts/solidity/scoping/Scoping.sol:18:9:
   |
18 |         uint x = 1;
   |         ^^^^^^


Warning: "selfdestruct" has been deprecated. The underlying opcode will eventually undergo breaking changes, and its use is not recommended.
  --> contracts/discrepancies/nonce/InternalCallee.sol:27:9:
   |
27 |         selfdestruct(_addr);
   |         ^^^^^^^^^^^^


Warning: "selfdestruct" has been deprecated. The underlying opcode will eventually undergo breaking changes, and its use is not recommended.
  --> contracts/discrepancies/nonce/InternalCaller.sol:56:9:
   |
56 |         selfdestruct(_addr);
   |         ^^^^^^^^^^^^


Warning: "selfdestruct" has been deprecated. The underlying opcode will eventually undergo breaking changes, and its use is not recommended.
  --> contracts/solidity/signature-example/ReceiverPays.sol:27:9:
   |
27 |         selfdestruct(payable(msg.sender));
   |         ^^^^^^^^^^^^

```

**Related issue(s)**:

Fixes #435 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
