### PR TITLE
ci: Updated source for conventional-pr-title-action

### DIFF
--- a/.github/workflows/flow-pr-title-check.yml
+++ b/.github/workflows/flow-pr-title-check.yml
@@ -40,6 +40,6 @@ jobs:
       statuses: write
     steps:
       - name: Check PR Title
-        uses: aslafy-z/conventional-pr-title-action@v3
+        uses: step-security/conventional-pr-title-action@0eae74515f5a79f8773fa04142dd746df76666ac # v1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/solidity-tests.yml
+++ b/.github/workflows/solidity-tests.yml
@@ -78,7 +78,7 @@ jobs:
     runs-on: [self-hosted, Linux, large, ephemeral]
     steps:
       - name: Download Test Reports
-        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: Test Results
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -135,7 +135,7 @@ jobs:
     runs-on: [self-hosted, Linux, large, ephemeral]
     steps:
       - name: Download Test Reports
-        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: Test Results
 


### PR DESCRIPTION
**Description**:

Update source of conventional-pr-title-action to use step-security's maintained version

Version 4 of upload-artifact action is currently not working on self-hosted runners, download-artifact has been showing the same behavior on version4. Reverted actions/download-artifact to version 3 to allow workflows to finish running

**Related issue(s)**:

Fixes #784
