### PR TITLE
fix(slither): setting the correct path to the build in dc cofnig

### DIFF
--- a/tools/analysis/slither/docker-compose.yaml
+++ b/tools/analysis/slither/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   slither:
-    build: slither-analysis # WITH ecrecover DETECTOR preinstalled!
+    build: . # WITH ecrecover DETECTOR preinstalled!
     extra_hosts:
       - "host.docker.internal:host-gateway"
     entrypoint: ["sleep", "infinity"]


### PR DESCRIPTION
**Description**:
The path in docker compose was incorrect. Dockerfile is moved to the same directory where yaml is placed.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
