### PR TITLE
fix: renamed .github/README.md to ./github/workflows_documentation.md

### DIFF
--- a/.github/workflows_documentation.md
+++ b/.github/workflows_documentation.md
@@ -11,6 +11,7 @@ When there is a new version released, no matter if it is network-node, mirror-no
 Another concern with switching the network node's versions is "the migration" that is running under the hood. It occurs every time a node has been started and detects if there is data for migration. The migration testing workflow offers this type of testing where we can choose versions for pre/post image tags.
 
 Available workflow inputs are:
+
 - **initialNetworkNodeTag** - Specify the initial Network Node image tag
 - **initialMirrorNodeTag** - Specify the initial Mirror Node image tag
 - **initialRelayTag** - Specify the initial Relay image tag
@@ -21,32 +22,33 @@ Available workflow inputs are:
 - **postMigrationTestTags** - Specify the post-migration test tags. Default: @post-migration. It could be every tag we want (e.g. **@OZERC20**)
 
 Examples:
+
 - if we want to test possible state corruption between mono and mod versions, we could use a setup like this:
-    - initialNetworkNodeTag: 0.48.1 # last tag for mono module
-    - initialMirrorNodeTag: 0.103.0
-    - initialRelayTag: 0.47.0
-    - targetNetworkNodeTag: 0.49.7 # first stable tag for modular module
-    - targetMirrorNodeTag: 0.103.0
-    - targetRelayTag: 0.47.0
-    - preMigrationTestTags: @pre-migration
-    - postMigrationTestTags: @post-migration
+  - initialNetworkNodeTag: 0.48.1 # last tag for mono module
+  - initialMirrorNodeTag: 0.103.0
+  - initialRelayTag: 0.47.0
+  - targetNetworkNodeTag: 0.49.7 # first stable tag for modular module
+  - targetMirrorNodeTag: 0.103.0
+  - targetRelayTag: 0.47.0
+  - preMigrationTestTags: @pre-migration
+  - postMigrationTestTags: @post-migration
 - if we want to check for regressions on @OZERC20 suite after the relay's version update, we could use a setup like this:
-    - initialNetworkNodeTag: 0.49.7
-    - initialMirrorNodeTag: 0.104.0
-    - initialRelayTag: 0.47.0
-    - targetNetworkNodeTag: 0.49.7
-    - targetMirrorNodeTag: 0.104.0
-    - targetRelayTag: 0.48.0
-    - preMigrationTestTags: @OZERC20
-    - postMigrationTestTags: @OZERC20
+  - initialNetworkNodeTag: 0.49.7
+  - initialMirrorNodeTag: 0.104.0
+  - initialRelayTag: 0.47.0
+  - targetNetworkNodeTag: 0.49.7
+  - targetMirrorNodeTag: 0.104.0
+  - targetRelayTag: 0.48.0
+  - preMigrationTestTags: @OZERC20
+  - postMigrationTestTags: @OZERC20
 - if we want to simulate the mirror node's version update, we could use a setup like this:
-    - initialNetworkNodeTag: 0.49.7
-    - initialMirrorNodeTag: 0.103.0
-    - initialRelayTag: 0.47.0
-    - targetNetworkNodeTag: 0.49.7
-    - targetMirrorNodeTag: 0.104.0
-    - targetRelayTag: 0.47.0
-    - preMigrationTestTags: @pre-migration
-    - postMigrationTestTags: @post-migration
+  - initialNetworkNodeTag: 0.49.7
+  - initialMirrorNodeTag: 0.103.0
+  - initialRelayTag: 0.47.0
+  - targetNetworkNodeTag: 0.49.7
+  - targetMirrorNodeTag: 0.104.0
+  - targetRelayTag: 0.47.0
+  - preMigrationTestTags: @pre-migration
+  - postMigrationTestTags: @post-migration
 
 The testing matrix offers pretty big coverage as we can see. All options and combinations rely on us, and what's our end goal.


### PR DESCRIPTION
**Description**:
Currently, there is a `README.md` file in the `.github` folder. This `.github/README.md` overlaps with the `README.md` in the root directory, which is displayed on the repository landing page. This PR is to rename the `.github/README.md` to resolve the issue.

Fixes #843