### PR TITLE
feat: block properties behaviour

### DIFF
--- a/contracts-abi/contracts/solidity/block/BlockInfo.sol/BlockInfo.json
+++ b/contracts-abi/contracts/solidity/block/BlockInfo.sol/BlockInfo.json
@@ -39,7 +39,13 @@
     "type": "function"
   },
   {
-    "inputs": [],
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "blockNumber",
+        "type": "uint256"
+      }
+    ],
     "name": "getBlockHash",
     "outputs": [
       {

--- a/contracts/solidity/block/BlockInfo.sol
+++ b/contracts/solidity/block/BlockInfo.sol
@@ -7,8 +7,8 @@ contract BlockInfo {
         return block.basefee;
     }
 
-    function getBlockHash() public view returns (bytes32) {
-        return blockhash(block.number - 1);
+    function getBlockHash(uint256 blockNumber) public view returns (bytes32) {
+        return blockhash(blockNumber);
     }
 
     function getMinerAddress() public view returns (address) {

--- a/test/solidity/block/BlockInfo.js
+++ b/test/solidity/block/BlockInfo.js
@@ -26,7 +26,7 @@ describe('@solidityequiv1 BlockInfo Test Suite', function () {
 
   before(async function () {
     signers = await ethers.getSigners();
-    provider = ethers.getDefaultProvider();
+    provider = signers[0].provider;
 
     const factory = await ethers.getContractFactory(Constants.Path.BLOCK_INFO);
     blockInfo = await factory.deploy({ gasLimit: 15000000 });
@@ -38,19 +38,11 @@ describe('@solidityequiv1 BlockInfo Test Suite', function () {
     expect(blockBaseFee).to.equal(0);
   });
 
-  // https://github.com/hashgraph/hedera-mirror-node/issues/7045
   it('should be able to get the hash of a given block when the block number is one of the 256 most recent blocks', async function () {
-    try {
-      const blockNumber = await provider.getBlockNumber();
-      await provider.getBlock(blockNumber);
-      await blockInfo.getBlockHash();
-    } catch (e) {
-      expect(e.code).to.equal('CALL_EXCEPTION');
-      expect(e.message).to.contain('missing revert data in call exception');
-      expect(e.reason).to.contain(
-        'missing revert data in call exception; Transaction reverted without a reason string'
-      );
-    }
+    const blockNumber = await provider.getBlockNumber();
+    const block = await provider.getBlock(blockNumber);
+    const blockHash = await blockInfo.getBlockHash(blockNumber);
+    expect(block.hash).to.equal(blockHash);
   });
 
   it('should get the current block coinbase which is the hedera network account', async function () {


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
When retrieving in smart contracts, not all block properties match what's returned to hardhat. 

- Retrieving a blockhash through hardhat returns an actual hash value, but returning it from within a smart contract returns `0x0000000000000000000000000000000000000000000000000000000000000000`.
- Retrieving the block's coinbase returns a different value when called in the smart contract.

**Steps to reproduce**;

- The test `should be able to get the hash of a given block when the block number is one of the 256 most recent blocks` in `BlockInfo` reproduces the hash value issue. - fixed :white_check_mark: 
- The test `should get the current block miners address using block.coinbase` reproduces the coinbase issue. - not reproducible :x: 

**Related issue(s)**:

Fixes #436 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
