### PR TITLE
chore: downgrade actions/download-artifact to v3.0.2

### DIFF
--- a/.github/workflows/solidity-tests.yml
+++ b/.github/workflows/solidity-tests.yml
@@ -78,7 +78,7 @@ jobs:
     runs-on: [self-hosted, Linux, large, ephemeral]
     steps:
       - name: Download Test Reports
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: Test Results
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,7 +141,7 @@ jobs:
     runs-on: [self-hosted, Linux, large, ephemeral]
     steps:
       - name: Download Test Reports
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: Test Results
 


### PR DESCRIPTION
**Description**:
Download artifact v4 is not compatible with upload artifact v3. A refactoring and update is needed to migrate from v3 to v4.
Currently just the download artifact action has been updated by dependabot. This is a temporary solution to repair the broken pipeline.
The proper fix of the problem is tracked via #812 

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
