### PR TITLE
chore: migrate artifact actions v3 to v4

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -33,8 +33,7 @@ jobs:
         run: tar -czf ${{ env.PACKAGE_NAME }}-v${{env.TAG}}.tgz -C ./hedera-smart-contracts .
 
       - name: Upload artifact
-        # There is a bug in v4 of upload-artifact. Recommendation is to remain at v3.
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
         with:
           name: ${{ env.PACKAGE_NAME }}-v${{env.TAG}}
           path: ./*.tgz

--- a/.github/workflows/solidity-tests.yml
+++ b/.github/workflows/solidity-tests.yml
@@ -78,9 +78,10 @@ jobs:
     runs-on: [self-hosted, Linux, large, ephemeral]
     steps:
       - name: Download Test Reports
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
-          name: Test Results
+          pattern: Test Results (*)
+          merge-multiple: true
 
       - name: Publish Test Report
         uses: actionite/publish-unit-test-result-action@1e01e49081c6c4073913aa4b7980fa83e709f322 # v2.3.0

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -63,10 +63,9 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        # There is a bug in v4 of upload-artifact. Recommendation is to remain at v3.
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
         with:
-          name: Test Results
+          name: Test Results (${{ inputs.testfilter }})
           path: test-*.xml
 
       - name: Publish Test Report

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,9 +141,10 @@ jobs:
     runs-on: [self-hosted, Linux, large, ephemeral]
     steps:
       - name: Download Test Reports
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
-          name: Test Results
+          pattern: Test Results (*)
+          merge-multiple: true
 
       - name: Publish Test Report
         uses: actionite/publish-unit-test-result-action@1e01e49081c6c4073913aa4b7980fa83e709f322 # v2.3.0


### PR DESCRIPTION
**Description**:
This PR migrates the `upload-artifact` and `download-artifact` actions from v3 to v4 in advance of the November deprecation of v3.


**Related issue(s)**:

Fixes #812 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
