### PR TITLE
chore: add `isAuthorizedRaw` function

### DIFF
--- a/contracts/system-contracts/hedera-account-service/HederaAccountService.sol
+++ b/contracts/system-contracts/hedera-account-service/HederaAccountService.sol
@@ -35,4 +35,18 @@ abstract contract HederaAccountService {
                 owner, spender, amount));
         responseCode = success ? abi.decode(result, (int32)) : HederaResponseCodes.UNKNOWN;
     }
+
+    /// Determines if the signature is valid for the given message hash and account.
+    /// It is assumed that the signature is composed of a single EDCSA or ED25519 key.
+    /// @param account The account to check the signature against
+    /// @param messageHash The hash of the message to check the signature against
+    /// @param signature The signature to check
+    /// @return response True if the signature is valid, false otherwise
+    function isAuthorizedRaw(address account, bytes memory messageHash, bytes memory signature) internal returns (bool response) {
+        (bool success, bytes memory result) = HASPrecompileAddress.call(
+            abi.encodeWithSelector(IHederaAccountService.isAuthorizedRaw.selector,
+                account, messageHash, signature));
+        response = abi.decode(result, (bool));
+    }
+
 }

--- a/contracts/system-contracts/hedera-account-service/HederaAccountService.sol
+++ b/contracts/system-contracts/hedera-account-service/HederaAccountService.sol
@@ -46,7 +46,7 @@ abstract contract HederaAccountService {
         (bool success, bytes memory result) = HASPrecompileAddress.call(
             abi.encodeWithSelector(IHederaAccountService.isAuthorizedRaw.selector,
                 account, messageHash, signature));
-        response = abi.decode(result, (bool));
+        response = success ? abi.decode(result, (bool)) : false;
     }
 
 }

--- a/contracts/system-contracts/hedera-account-service/IHederaAccountService.sol
+++ b/contracts/system-contracts/hedera-account-service/IHederaAccountService.sol
@@ -24,4 +24,15 @@ interface IHederaAccountService {
         address spender,
         int256 amount
     ) external returns (int64 responseCode);
+
+    /// Determines if the signature is valid for the given message hash and account.
+    /// It is assumed that the signature is composed of a single EDCSA or ED25519 key.
+    /// @param account The account to check the signature against
+    /// @param messageHash The hash of the message to check the signature against
+    /// @param signature The signature to check
+    /// @return response True if the signature is valid, false otherwise
+    function isAuthorizedRaw(
+        address account,
+        bytes memory messageHash,
+        bytes memory signature) external returns (bool response);
 }


### PR DESCRIPTION
**Description**:
The HederaAccountService system contract files are missing the `isAuthorizedRaw` function definitions.  

