### PR TITLE
test: added test coverage to confirm key alias remain the same after key rotations

### DIFF
--- a/test/network/key-rotation.js
+++ b/test/network/key-rotation.js
@@ -1,0 +1,175 @@
+/*-
+ *
+ * Hedera Smart Contracts
+ *
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+const {
+  Hbar,
+  Status,
+  PrivateKey,
+  AccountInfoQuery,
+  AccountCreateTransaction,
+  AccountUpdateTransaction,
+} = require('@hashgraph/sdk');
+const { expect } = require('chai');
+const Utils = require('../system-contracts/hedera-token-service/utils');
+
+describe('Key Rotation Test Suite', function () {
+  let client;
+  let accountId_Alpha;
+  let accountPrivateKey_Alpha;
+  let accountPublicKey_Alpha;
+  let accountEvmAddress_Alpha;
+
+  beforeEach(async function () {
+    client = await Utils.createSDKClient();
+
+    // Generate a new ECDSA keys
+    accountPrivateKey_Alpha = PrivateKey.generateECDSA();
+    accountPublicKey_Alpha = accountPrivateKey_Alpha.publicKey;
+    accountEvmAddress_Alpha = accountPublicKey_Alpha.toEvmAddress();
+
+    // Create new account and assign the ECDSA public key as admin key
+    const newAccountAlphaTx = await new AccountCreateTransaction()
+      .setKey(accountPublicKey_Alpha)
+      .setInitialBalance(Hbar.fromTinybars(1000))
+      .setAlias(accountEvmAddress_Alpha)
+      .execute(client);
+
+    // Get the new account ID
+    const newAccountAlphaTxRceipt = await newAccountAlphaTx.getReceipt(client);
+    accountId_Alpha = newAccountAlphaTxRceipt.accountId;
+  });
+
+  it('Should remain the same EVM key alias after key rotation with a different ECDSA key', async function () {
+    // Generate a new ECDSA key
+    const accountPrivateKey_Beta = PrivateKey.generateECDSA();
+    const accountPublicKey_Beta = accountPrivateKey_Beta.publicKey;
+    const accountEvmAddress_Beta = accountPublicKey_Beta.toEvmAddress();
+
+    // Create the transaction to rotate and change the key to a different ECDSA key
+    const accountUpdateTransaction = new AccountUpdateTransaction()
+      .setAccountId(accountId_Alpha)
+      .setKey(accountPublicKey_Beta)
+      .freezeWith(client);
+
+    // Sign with the old key
+    const signTxByAlpha = await accountUpdateTransaction.sign(
+      accountPrivateKey_Alpha
+    );
+
+    // Sign with the new key
+    const signTxByBeta = await signTxByAlpha.sign(accountPrivateKey_Beta);
+
+    // Submit the transaction
+    const txResponse = await signTxByBeta.execute(client);
+
+    // Get the receipt of the transaction
+    const receipt = await txResponse.getReceipt(client);
+
+    // Get the transaction consensus status
+    const transactionStatus = receipt.status;
+    expect(transactionStatus).to.equal(Status.Success);
+
+    // Check the account info after key rotation
+    const accountInfoAfterKeyRotation = await new AccountInfoQuery()
+      .setAccountId(accountId_Alpha)
+      .execute(client);
+
+    // expect the account ID to be the same
+    expect(accountInfoAfterKeyRotation.accountId).to.deep.equal(
+      accountId_Alpha
+    );
+
+    // expect the key to be the new key
+    expect(accountInfoAfterKeyRotation.key).to.deep.equal(
+      accountPublicKey_Beta
+    );
+
+    // expect the key to not be the old key
+    expect(accountInfoAfterKeyRotation.key).to.not.deep.equal(
+      accountPublicKey_Alpha
+    );
+
+    // expect the contract account ID to be the same
+    expect(accountInfoAfterKeyRotation.contractAccountId).to.equal(
+      accountEvmAddress_Alpha
+    );
+
+    // expect the contract account ID to not be the old EVM address
+    expect(accountInfoAfterKeyRotation.contractAccountId).to.not.equal(
+      accountEvmAddress_Beta
+    );
+  });
+
+  it('Should remain the same EVM key alias after key rotation with a different ED25519 key', async function () {
+    // Generate a new ECDSA key
+    const accountPrivateKey_Charlie = PrivateKey.generateED25519();
+    const accountPublicKey_Charlie =
+      accountPrivateKey_Charlie.publicKey.toStringDer();
+
+    // Create the transaction to rotate and change the key to a different ED25519 key
+    const accountUpdateTransaction = new AccountUpdateTransaction()
+      .setAccountId(accountId_Alpha)
+      .setKey(accountPrivateKey_Charlie.publicKey)
+      .freezeWith(client);
+
+    // Sign with the old key
+    const signTxByAlpha = await accountUpdateTransaction.sign(
+      accountPrivateKey_Alpha
+    );
+
+    // Sign with the new key
+    const signTxByCharlie = await signTxByAlpha.sign(accountPrivateKey_Charlie);
+
+    // Submit the transaction
+    const txResponse = await signTxByCharlie.execute(client);
+
+    // Get the receipt of the transaction
+    const receipt = await txResponse.getReceipt(client);
+
+    // Get the transaction consensus status
+    const transactionStatus = receipt.status;
+    expect(transactionStatus).to.equal(Status.Success);
+
+    // Check the account info after key rotation
+    const accountInfoAfterKeyRotation = await new AccountInfoQuery()
+      .setAccountId(accountId_Alpha)
+      .execute(client);
+
+    // expect the account ID to be the same
+    expect(accountInfoAfterKeyRotation.accountId).to.deep.equal(
+      accountId_Alpha
+    );
+
+    // expect the key to be the new key
+    expect(accountInfoAfterKeyRotation.key.toStringDer()).to.deep.equal(
+      accountPublicKey_Charlie
+    );
+
+    // expect the key to not be the old key
+    expect(accountInfoAfterKeyRotation.key).to.not.deep.equal(
+      accountPublicKey_Alpha
+    );
+
+    // expect the contract account ID to be the same
+    expect(accountInfoAfterKeyRotation.contractAccountId).to.equal(
+      accountEvmAddress_Alpha
+    );
+  });
+});

--- a/test/network/key-rotation.js
+++ b/test/network/key-rotation.js
@@ -2,7 +2,7 @@
  *
  * Hedera Smart Contracts
  *
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/network/key-rotation.js
+++ b/test/network/key-rotation.js
@@ -54,6 +54,11 @@ describe('Key Rotation Test Suite', function () {
     // Get the new account ID
     const newAccountAlphaTxRceipt = await newAccountAlphaTx.getReceipt(client);
     accountId_Alpha = newAccountAlphaTxRceipt.accountId;
+
+    console.log('\n>>>>>>> accountId_Alpha <<<<<<<');
+    console.log(`- accountId: ${accountId_Alpha}`);
+    console.log(`- public key: ${accountPublicKey_Alpha}`);
+    console.log(`- evm address: ${accountEvmAddress_Alpha}`);
   });
 
   it('Should remain the same EVM key alias after key rotation with a different ECDSA key', async function () {
@@ -90,6 +95,13 @@ describe('Key Rotation Test Suite', function () {
     const accountInfoAfterKeyRotation = await new AccountInfoQuery()
       .setAccountId(accountId_Alpha)
       .execute(client);
+
+    console.log('>>>>>>> accountInfoAfterKeyRotation - ECDSA <<<<<<<');
+    console.log(`- accountId: ${accountInfoAfterKeyRotation.accountId}`);
+    console.log(`- public key: ${accountInfoAfterKeyRotation.key}`);
+    console.log(
+      `- evm address: ${accountInfoAfterKeyRotation.contractAccountId}`
+    );
 
     // expect the account ID to be the same
     expect(accountInfoAfterKeyRotation.accountId).to.deep.equal(
@@ -151,6 +163,13 @@ describe('Key Rotation Test Suite', function () {
     const accountInfoAfterKeyRotation = await new AccountInfoQuery()
       .setAccountId(accountId_Alpha)
       .execute(client);
+
+    console.log('>>>>>>> accountInfoAfterKeyRotation - ED25519 <<<<<<<');
+    console.log(`- accountId: ${accountInfoAfterKeyRotation.accountId}`);
+    console.log(`- public key: ${accountInfoAfterKeyRotation.key}`);
+    console.log(
+      `- evm address: ${accountInfoAfterKeyRotation.contractAccountId}`
+    );
 
     // expect the account ID to be the same
     expect(accountInfoAfterKeyRotation.accountId).to.deep.equal(


### PR DESCRIPTION
**Description**:
There has been a report from a community member raising concerns about whether an account's EVM address would be modified or updated if the account's key is changed—for example, from one ECDSA key to another, or from ECDSA to ED25519. 

This PR addresses the concern and confirms that an account's EVM address is fixed at the time of creation and will remain unchanged, regardless of any updates to the account's key.


Fixes #983


**Example Log Output**:

```
  Key Rotation Test Suite

>>>>>>> accountId_Alpha <<<<<<<
- accountId: 0.0.1044
- public key: 302d300706052b8104000a03220002f6de454684020fe47e85c225288b2caae36bae587c4c08d142cb2ca8177fe0f5
- evm address: 9b69fafd7574a2ef5635c7ebddc0e7258569076d
>>>>>>> accountInfoAfterKeyRotation - ECDSA <<<<<<<
- accountId: 0.0.1044
- public key: 302d300706052b8104000a03220003b6b1743fe7f8d6c2dd92a40614431b65c9501673508e4be53c8561891b4cc6d2
- evm address: 9b69fafd7574a2ef5635c7ebddc0e7258569076d
    ✔ Should remain the same EVM key alias after key rotation with a different ECDSA key (559ms)

>>>>>>> accountId_Alpha <<<<<<<
- accountId: 0.0.1045
- public key: 302d300706052b8104000a03220003e58eabbff610e4142f274ab883158835ef0a783e973214ffdad06ab6b723b446
- evm address: 48fa79e6b73f50a601ff4f74100838dff43c16aa
>>>>>>> accountInfoAfterKeyRotation - ED25519 <<<<<<<
- accountId: 0.0.1045
- public key: 302a300506032b657003210032a3386cd825f0c1c8d3f3e8c074ec240418d9887eea6601970797c854bb8d69
- evm address: 48fa79e6b73f50a601ff4f74100838dff43c16aa
    ✔ Should remain the same EVM key alias after key rotation with a different ED25519 key (551ms)
```
