### PR TITLE
test: added E2E coverage for `isAuthorizedRaw()` in HIP-632.

### DIFF
--- a/contracts-abi/contracts/system-contracts/hedera-account-service/examples/crypto-allowance/cryptoAllowance.sol/CryptoAllowance.json
+++ b/contracts-abi/contracts/system-contracts/hedera-account-service/examples/crypto-allowance/cryptoAllowance.sol/CryptoAllowance.json
@@ -48,6 +48,25 @@
     "inputs": [
       {
         "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "response",
+        "type": "bool"
+      }
+    ],
+    "name": "IsAuthorizedRaw",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
         "internalType": "int256",
         "name": "responseCode",
         "type": "int256"
@@ -213,6 +232,40 @@
         "internalType": "int64",
         "name": "responseCode",
         "type": "int64"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "messageHash",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "signature",
+        "type": "bytes"
+      }
+    ],
+    "name": "isAuthorizedRawPublic",
+    "outputs": [
+      {
+        "internalType": "int64",
+        "name": "responseCode",
+        "type": "int64"
+      },
+      {
+        "internalType": "bool",
+        "name": "response",
+        "type": "bool"
       }
     ],
     "stateMutability": "nonpayable",

--- a/contracts/system-contracts/hedera-account-service/HederaAccountService.sol
+++ b/contracts/system-contracts/hedera-account-service/HederaAccountService.sol
@@ -41,12 +41,13 @@ abstract contract HederaAccountService {
     /// @param account The account to check the signature against
     /// @param messageHash The hash of the message to check the signature against
     /// @param signature The signature to check
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
     /// @return response True if the signature is valid, false otherwise
-    function isAuthorizedRaw(address account, bytes memory messageHash, bytes memory signature) internal returns (bool response) {
+    function isAuthorizedRaw(address account, bytes memory messageHash, bytes memory signature) internal returns (int64 responseCode, bool response) {
         (bool success, bytes memory result) = HASPrecompileAddress.call(
             abi.encodeWithSelector(IHederaAccountService.isAuthorizedRaw.selector,
                 account, messageHash, signature));
-        response = success ? abi.decode(result, (bool)) : false;
+        (responseCode, response) = success ? (HederaResponseCodes.SUCCESS, abi.decode(result, (bool))) : (HederaResponseCodes.UNKNOWN, false);
     }
 
 }

--- a/contracts/system-contracts/hedera-account-service/examples/crypto-allowance/cryptoAllowance.sol
+++ b/contracts/system-contracts/hedera-account-service/examples/crypto-allowance/cryptoAllowance.sol
@@ -7,6 +7,7 @@ import "../../../hedera-token-service/HederaTokenService.sol";
 contract CryptoAllowance is HederaAccountService, HederaTokenService {
     event ResponseCode(int responseCode);
     event HbarAllowance(address owner, address spender, int256 allowance);
+    event IsAuthorizedRaw(address account, bool response);
 
     function hbarApprovePublic(address owner, address spender, int256 amount) public returns (int64 responseCode) {
         responseCode = HederaAccountService.hbarApprove(owner, spender, amount);
@@ -24,6 +25,15 @@ contract CryptoAllowance is HederaAccountService, HederaTokenService {
             revert();
         }
         emit HbarAllowance(owner, spender, allowance);
+    }
+
+    function isAuthorizedRawPublic(address account, bytes memory messageHash, bytes memory signature) public returns (int64 responseCode, bool response) {
+        (responseCode, response) = HederaAccountService.isAuthorizedRaw(account, messageHash, signature);
+        emit ResponseCode(responseCode);
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert("mehehehehe");
+        }
+        emit IsAuthorizedRaw(account, response);
     }
 
     function cryptoTransferPublic(IHederaTokenService.TransferList calldata transferList, IHederaTokenService.TokenTransferList[] calldata tokenTransferList) public returns (int responseCode) {

--- a/test/system-contracts/hedera-account-service/crypto-allowance/cryptoAllowance.js
+++ b/test/system-contracts/hedera-account-service/crypto-allowance/cryptoAllowance.js
@@ -41,7 +41,6 @@ describe('@CryptoAllowance Test Suite', () => {
     cryptoAllowanceAddress,
     cryptoOwnerAddress;
   const amount = 3000;
-  const messageToSign = 'Hedera Account Service';
 
   before(async () => {
     [walletA, walletB, walletC, receiver] = await ethers.getSigners();
@@ -309,94 +308,143 @@ describe('@CryptoAllowance Test Suite', () => {
     }
   });
 
-  it('Should verify message signature using isAuthorizedRawPublic for ECDSA account', async () => {
-    const messageHash = ethers.hashMessage(messageToSign);
-    const signature = await walletB.signMessage(messageToSign);
-    expect(signature.slice(2).length).to.eq(65 * 2); // 65 bytes ECDSA signature
+  describe(`isAuthorizedRaw`, () => {
+    const messageToSign = 'Hedera Account Service';
+    const messageHashEC = ethers.hashMessage(messageToSign);
+    const messageHashED = Buffer.from(messageToSign);
+    const EDItems = [];
 
-    const correctSignerReceipt = await (
-      await cryptoAllowanceContract.isAuthorizedRawPublic(
-        walletB.address, // correct signer
-        messageHash,
-        signature,
-        Constants.GAS_LIMIT_1_000_000
-      )
-    ).wait();
+    before(async () => {
+      for (let i = 0; i < 2; i++) {
+        const newEdPK = PrivateKey.generateED25519();
+        const newEdPubKey = newEdPK.publicKey;
+        const client = await Utils.createSDKClient();
 
-    const correctSignerReceiptResponseCode = correctSignerReceipt.logs.find(
-      (l) => l.fragment.name === 'ResponseCode'
-    ).args[0];
+        const edSignerAccount = (
+          await (
+            await new AccountCreateTransaction()
+              .setKey(newEdPubKey)
+              .setInitialBalance(Hbar.fromTinybars(1000))
+              .execute(client)
+          ).getReceipt(client)
+        ).accountId;
+        const signerAlias = `0x${edSignerAccount.toSolidityAddress()}`;
+        const signature = `0x${Buffer.from(newEdPK.sign(messageHashED)).toString('hex')}`;
 
-    const correctSignerReceiptResponse = correctSignerReceipt.logs.find(
-      (l) => l.fragment.name === 'IsAuthorizedRaw'
-    ).args;
+        const obj = {
+          signature,
+          signerAlias,
+        };
 
-    expect(correctSignerReceiptResponseCode).to.eq(22n);
-    expect(correctSignerReceiptResponse[0]).to.eq(walletB.address);
-    expect(correctSignerReceiptResponse[1]).to.be.true;
+        EDItems.push(obj);
+      }
+    });
 
-    const incorrectSignerReceipt = await (
-      await cryptoAllowanceContract.isAuthorizedRawPublic(
-        walletC.address, // incorrect signer
-        messageHash,
-        signature,
-        Constants.GAS_LIMIT_1_000_000
-      )
-    ).wait();
+    it('Should verify message signature and return TRUE using isAuthorizedRawPublic for ECDSA account', async () => {
+      const signature = await walletB.signMessage(messageToSign);
+      expect(signature.slice(2).length).to.eq(65 * 2); // 65 bytes ECDSA signature
 
-    const incorrectSignerReceiptResponseCode = incorrectSignerReceipt.logs.find(
-      (l) => l.fragment.name === 'ResponseCode'
-    ).args[0];
+      const correctSignerReceipt = await (
+        await cryptoAllowanceContract.isAuthorizedRawPublic(
+          walletB.address, // correct signer
+          messageHashEC,
+          signature,
+          Constants.GAS_LIMIT_1_000_000
+        )
+      ).wait();
 
-    const incorrectSignerReceiptResponse = incorrectSignerReceipt.logs.find(
-      (l) => l.fragment.name === 'IsAuthorizedRaw'
-    ).args;
+      const correctSignerReceiptResponseCode = correctSignerReceipt.logs.find(
+        (l) => l.fragment.name === 'ResponseCode'
+      ).args[0];
 
-    expect(incorrectSignerReceiptResponseCode).to.eq(22n);
-    expect(incorrectSignerReceiptResponse[0]).to.eq(walletC.address);
-    expect(incorrectSignerReceiptResponse[1]).to.be.false;
-  });
+      const correctSignerReceiptResponse = correctSignerReceipt.logs.find(
+        (l) => l.fragment.name === 'IsAuthorizedRaw'
+      ).args;
 
-  it('Should verify message signature using isAuthorizedRawPublic for ED25519 account', async () => {
-    const newEdPK = PrivateKey.generateED25519();
-    const messageHash = Buffer.from(messageToSign);
-    const signature = `0x${Buffer.from(newEdPK.sign(messageHash)).toString('hex')}`;
+      expect(correctSignerReceiptResponseCode).to.eq(22n);
+      expect(correctSignerReceiptResponse[0]).to.eq(walletB.address);
+      expect(correctSignerReceiptResponse[1]).to.be.true;
+    });
 
-    const newEdPubKey = newEdPK.publicKey;
-    const client = await Utils.createSDKClient();
+    it('Should verify message signature and return FALSE using isAuthorizedRawPublic for ECDSA account', async () => {
+      const signature = await walletB.signMessage(messageToSign);
+      expect(signature.slice(2).length).to.eq(65 * 2); // 65 bytes ECDSA signature
 
-    const edSignerAccount = (
-      await (
-        await new AccountCreateTransaction()
-          .setKey(newEdPubKey)
-          .setInitialBalance(Hbar.fromTinybars(1000))
-          .execute(client)
-      ).getReceipt(client)
-    ).accountId;
+      const incorrectSignerReceipt = await (
+        await cryptoAllowanceContract.isAuthorizedRawPublic(
+          walletC.address, // incorrect signer
+          messageHashEC,
+          signature,
+          Constants.GAS_LIMIT_1_000_000
+        )
+      ).wait();
 
-    const signerAlias = `0x${edSignerAccount.toSolidityAddress()}`;
+      const incorrectSignerReceiptResponseCode =
+        incorrectSignerReceipt.logs.find(
+          (l) => l.fragment.name === 'ResponseCode'
+        ).args[0];
 
-    const correctSignerReceipt = await (
-      await cryptoAllowanceContract.isAuthorizedRawPublic(
-        signerAlias,
-        messageHash,
-        signature,
-        Constants.GAS_LIMIT_10_000_000
-      )
-    ).wait();
+      const incorrectSignerReceiptResponse = incorrectSignerReceipt.logs.find(
+        (l) => l.fragment.name === 'IsAuthorizedRaw'
+      ).args;
 
-    const correctSignerReceiptResponseCode = correctSignerReceipt.logs.find(
-      (l) => l.fragment.name === 'ResponseCode'
-    ).args[0];
+      expect(incorrectSignerReceiptResponseCode).to.eq(22n);
+      expect(incorrectSignerReceiptResponse[0]).to.eq(walletC.address);
+      expect(incorrectSignerReceiptResponse[1]).to.be.false;
+    });
 
-    const correctSignerReceiptResponse = correctSignerReceipt.logs.find(
-      (l) => l.fragment.name === 'IsAuthorizedRaw'
-    ).args;
+    it('Should verify message signature and return TRUE using isAuthorizedRawPublic for ED25519 account', async () => {
+      const correctSignerReceipt = await (
+        await cryptoAllowanceContract.isAuthorizedRawPublic(
+          EDItems[0].signerAlias, // correct alias
+          messageHashED,
+          EDItems[0].signature, // correct signature
+          Constants.GAS_LIMIT_10_000_000
+        )
+      ).wait();
 
-    expect(correctSignerReceiptResponseCode).to.eq(22n);
-    expect(correctSignerReceiptResponse[0].toLowerCase()).to.eq(
-      signerAlias.toLowerCase()
-    );
-    expect(correctSignerReceiptResponse[1]).to.be.true;
+      const correctSignerReceiptResponseCode = correctSignerReceipt.logs.find(
+        (l) => l.fragment.name === 'ResponseCode'
+      ).args[0];
+
+      const correctSignerReceiptResponse = correctSignerReceipt.logs.find(
+        (l) => l.fragment.name === 'IsAuthorizedRaw'
+      ).args;
+
+      expect(correctSignerReceiptResponseCode).to.eq(22n);
+      expect(correctSignerReceiptResponse[0].toLowerCase()).to.eq(
+        EDItems[0].signerAlias.toLowerCase()
+      );
+      expect(correctSignerReceiptResponse[1]).to.be.true;
+    });
+
+    it('Should verify message signature and return FALSE using isAuthorizedRawPublic for ED25519 account', async () => {
+      const incorrectSignerReceipt = await (
+        await cryptoAllowanceContract.isAuthorizedRawPublic(
+          EDItems[0].signerAlias, // incorrect signer
+          messageHashED,
+          EDItems[1].signature, // different signature
+          Constants.GAS_LIMIT_10_000_000
+        )
+      ).wait();
+
+      const incorrectSignerReceiptResponseCode =
+        incorrectSignerReceipt.logs.find(
+          (l) => l.fragment.name === 'ResponseCode'
+        ).args[0];
+
+      const incorrectSignerReceiptResponse = incorrectSignerReceipt.logs.find(
+        (l) => l.fragment.name === 'IsAuthorizedRaw'
+      ).args;
+
+      expect(incorrectSignerReceiptResponseCode).to.eq(22n);
+      expect(incorrectSignerReceiptResponse[0].toLowerCase()).to.eq(
+        EDItems[0].signerAlias.toLowerCase()
+      );
+      expect(incorrectSignerReceiptResponse[0].toLowerCase()).to.not.eq(
+        EDItems[1].signerAlias.toLowerCase()
+      );
+      expect(incorrectSignerReceiptResponse[1]).to.be.false;
+    });
   });
 });


### PR DESCRIPTION
**Description**:
This PR adds e2e test coverage for isAuthorizedRaw() in HIP-632

**Related issue(s)**:

Fixes #844

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
