### PR TITLE
ci: replace release notes generator action with one maintained by stepsecurity

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Create Release Notes
         if: ${{ steps.milestone.outputs.milestone_id != '' }}
-        uses: Decathlon/release-notes-generator-action@98423db7024696a339f3988ac8a2b051c5860741 # v3.1.6
+        uses: step-security/release-notes-generator-action@d7cdbb310d4aab8d98f273f4ae20fdd7cb055799 # v3.1.6
         env:
           FILENAME: ${{ env.RELEASE_NOTES_FILENAME }}
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
**Description**:
The release-automation.yml workflow uses a release notes generator action that has an equivalent maintained by StepSecurity.
This PR replaces it with the StepSecurity variant.

**Related issue(s)**:

Fixes #1018 

**Notes for reviewer**:
N/A
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
