### PR TITLE
docs: added a design document outlining the ERC contract indexer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,8 +46,6 @@ out/
 /broadcast/*/31337/
 /broadcast/**/dry-run/
 
-# Docs
-docs/
 
 # Coverage
 lcov.info

--- a/tools/erc-repository-indexer/docs/registry_design.md
+++ b/tools/erc-repository-indexer/docs/registry_design.md
@@ -27,17 +27,15 @@ The **ERC Contract Indexer** will:
 
 ### Architecture
 
-The indexer will consist of the following components:
-
 #### 1. **ERC Interface Signature Matcher**
 
 - **Objective**: Leverage Hedera Mirror Node APIs to retrieve and analyze all smart contracts on the Hedera network. Validate the bytecode of each contract through signature matching to determine compliance with the ERC-20 or ERC-721 standard.
-
+- **Limitations**: While effective, this method may fail to detect some contracts, such as those that implement ERC standards in unconventional ways. For this reason, Step 2 (Validator) is optionally included to increase confidence and accuracy.
 - **Output**: A comprehensive list of verified ERC-20 and ERC-721 compliant contracts.
 
 #### 2. **Validator** (Optional)
 
-- **Purpose**: Increase confidence in token identification.
+- **Purpose**: To increase confidence and catch contracts that might have been missed in Step 1.
 - **Output**: Filtered and validated list of ERC tokens.
 
 #### 3. **Registry Generator**
@@ -53,7 +51,7 @@ The indexer will consist of the following components:
 - **Parameters**:
   - `HEDERA_NETWORK`: Network environment (e.g., testnet, mainnet).
   - `MIRROR_NODE_URL`: API URL for the Hedera mirror node.
-  - `STARTING_POINT`: a starting contract ID or a potential `next` pointer included in mirror node REST response (TBD).
+  - `STARTING_POINT`: Starting contract ID or contract EVM address (or a `next` pointer from a previous run).
 
 ### Implementation Workflow
 
@@ -63,13 +61,12 @@ The indexer will consist of the following components:
 
 2. **Identifying ERCs**:
 
-   a. **Retrieve Contract Batches**
+   a. **Retrieve Contract Batches**:
 
    - Use the Hedera Mirror Node API to index the entire network, retrieving contracts in ascending order (from oldest to newest):
-
      - `https://{{network}}.mirrornode.hedera.com/api/v1/contracts?order=asc`
 
-   b. **Fetch Contract Details and Parse Bytecode**
+   b. **Fetch Contract Details and Parse Bytecode**:
 
    - For each contract:
      - Retrieve contract details:
@@ -77,37 +74,15 @@ The indexer will consist of the following components:
      - Extract and parse the bytecode from the contract detail object.
        _Note: Utilize concurrent requests to optimize execution efficiency._
 
-   c. **Perform Interface Signature Matching**
+   c. **Perform Interface Signature Matching**:
 
-   - Analyze the bytecode for compliance with ERC-20 or ERC-721 standards using the [Contract.isErc()](https://github.com/acuarica/evm/blob/402028ca8c3a33dbb8498f0200d9af2efbf4f792/src/index.ts#L153-L158) method from the [SEVM library](https://www.npmjs.com/package/sevm). This method analyzes the contract bytecode and matches function signatures to confirm compliance with the ERC-20 and ERC-721 standards.
+   - Analyze the bytecode for compliance with ERC-20 or ERC-721 standards using the [Contract.isErc()](https://github.com/acuarica/evm/blob/402028ca8c3a33dbb8498f0200d9af2efbf4f792/src/index.ts#L153-L158) method from the [SEVM library](https://www.npmjs.com/package/sevm). This method matches function signatures to confirm compliance with the ERC-20 and ERC-721 standards.
+   - **Limitations**: The tool may fail to identify contracts that were not compiled using Solidity or Vyper. This limitation should be considered when interpreting the results.
 
-   - Identify the following function selectors in the bytecode:
+   d. **Handle Pagination**:
 
-     - **ERC-20 Selectors**:
-
-       - `0x18160ddd`: `totalSupply()`
-       - `0x70a08231`: `balanceOf(address)`
-       - `0xa9059cbb`: `transfer(address,uint256)`
-       - `0x23b872dd`: `transferFrom(address,address,uint256)`
-       - `0x095ea7b3`: `approve(address,uint256)`
-       - `0xdd62ed3e`: `allowance(address,address)`
-
-     - **ERC-721 Selectors**:
-       - `0x6352211e`: `ownerOf(uint256)`
-       - `0x42842e0e`: `safeTransferFrom(address,address,uint256)`
-       - `0xb88d4fde`: `safeTransferFrom(address,address,uint256,bytes)`
-       - `0x095ea7b3`: `approve(address,uint256)`
-       - `0x081812fc`: `getApproved(uint256)`
-       - `0xa22cb465`: `setApprovalForAll(address,bool)`
-       - `0x70a08231`: `balanceOf(address)`
-       - `0xe985e9c5`: `isApprovedForAll(address,address)`
-       - `0x01ffc9a7`: `supportsInterface(bytes4)`
-       - `0x23b872dd`: `transferFrom(address,address,uint256)`
-
-d. **Handle Pagination**
-
-- Since the `/contracts` endpoint has a limit of 100 records per request, use the `next` pointer provided in the response to recursively fetch subsequent batches and comprehensively index the network.
-- Write the `next` pointer to disk for persistence, allowing the indexing process to resume from the last recorded point if interrupted or to accommodate future runs when additional contracts are deployed on the network.
+   - Since the `/contracts` endpoint has a limit of 100 records per request, use the `next` pointer provided in the response to recursively fetch subsequent batches and comprehensively index the network.
+   - Write the `next` pointer to disk for persistence, allowing the indexing process to resume from the last recorded point if interrupted or to accommodate future runs when additional contracts are deployed on the network.
 
 3. **Validation (Optional)**:
 
@@ -147,3 +122,23 @@ d. **Handle Pagination**
        ```
    - Sort entries in ascending order of `contractId`.
    - Save output files to `tools/erc-repository-indexer/registry`.
+
+---
+
+## Future Features
+
+1. **Bytecode Storage**:
+
+   - Option to save bytecode to disk for analysis or debugging.
+   - Include file size considerations and storage optimizations.
+
+2. **Manual Contract Addition**:
+   - Allow users to manually add a contract to the registry if the tool fails to identify it but subsequent investigation proves it is ERC-compliant.
+
+---
+
+## Roadmap
+
+- **Phase 1**: Develop and test the indexer tool with function signature matching.
+- **Phase 2**: Integrate optional validation using `eth_call` and handle edge cases for improved accuracy.
+- **Phase 3**: Add features for bytecode storage and manual contract addition based on user feedback.

--- a/tools/erc-repository-indexer/docs/registry_design.md
+++ b/tools/erc-repository-indexer/docs/registry_design.md
@@ -1,0 +1,184 @@
+# ERC Token Indexer
+
+## Abstract
+
+This document outlines the design and implementation of the **ERC Token Indexer**, a standalone tool for identifying and cataloging ERC20 and ERC721 token contracts on the Hedera network. The indexer will index the Hedera network and scan contracts, verify their adherence to ERC standards, and produce structured output files for downstream applications. The goal is to provide developers and users with a reliable registry of tokens to enhance network insight and application usability.
+
+## Motivation
+
+Hedera supports ERC tokens alongside its native HTS tokens. However, there is no built-in mechanism to identify and list ERC20 and ERC721 tokens on the network. This lack of visibility impacts the usability of tools like the Mirror Node Explorer and limits the ability of developers to interact with these tokens.
+
+The ERC Token Indexer addresses this gap by:
+
+1. **Providing Discoverability**: Enabling tools to display and interact with ERC tokens effectively.
+2. **Automating Identification**: Streamlining the process of detecting and validating token contracts.
+3. **Serving as a Foundation**: Establishing a structured dataset for broader ecosystem enhancements.
+
+## Design
+
+### Tool Overview
+
+The ERC Token Indexer will:
+
+- Fetch smart contract data from the Hedera Mirror Node API.
+- Detect ERC20 and ERC721 token contracts using function signature matching.
+- Optionally validate contracts via `eth_call` for additional confidence.
+- Generate two JSON files: one for ERC20 tokens and another for ERC721 tokens.
+
+### Key Features
+
+1. **Network-Agnostic Configuration**:
+
+   - The tool will support flexible configurations for different environments (`testnet`, `mainnet`, etc.) and mirror node endpoints.
+
+2. **Interface Signature Matching**:
+
+   - Identify token contracts by analyzing bytecode for ERC20 or ERC721 function signatures.
+
+3. **Validation**:
+
+   - Include an optional mechanism to validate contracts by calling key functions (`name`, `symbol`, `totalSupply`, etc.).
+
+4. **Registry Generation**:
+   - Create structured, sorted JSON files for ERC20 and ERC721 tokens.
+
+### Architecture
+
+The indexer will consist of the following components:
+
+#### 1. **Contract Scanner**
+
+- **Purpose**: Retrieve and analyze smart contracts from the Hedera Mirror Node API.
+- **Workflow**:
+  - Fetch contracts starting from a configurable `startingContractId`.
+  - Retrieve and parse bytecode for each contract.
+  - Match bytecode against known ERC20 and ERC721 function signatures.
+- **Output**: A list of candidate ERC20 and ERC721 contracts.
+
+#### 2. **Validator** (Optional)
+
+- **Purpose**: Increase confidence in token identification.
+- **Workflow**:
+  - Use `eth_call` to invoke key methods and confirm their behavior.
+  - Validate token metadata such as `name`, `symbol`, and `decimals` for ERC20 tokens.
+  - Validate `name` and `symbol` for ERC721 tokens.
+- **Output**: Filtered and validated list of ERC tokens.
+
+#### 3. **Registry Generator**
+
+- **Purpose**: Generate output files in the required format.
+- **Workflow**:
+  - Aggregate data for identified ERC tokens.
+  - Generate two JSON files:
+    - `ERC20_registry.json`
+    - `ERC721_registry.json`
+  - Sort entries by `contractId` in ascending order (from oldest to newest).
+  - Ensure compliance with the schema for each token type.
+
+#### 4. **Configuration Manager**
+
+- **Purpose**: Enable flexible and environment-specific configurations.
+- **Parameters**:
+  - `env`: Network environment (e.g., testnet, mainnet).
+  - `mirrorNodeUrl`: API URL for the Hedera mirror node.
+  - `startingContractId`: Optional starting contract ID for scanning.
+
+### Workflow
+
+1. **Initialization**:
+
+   - Load environment variables and configuration parameters.
+   - Establish a connection with the Mirror Node API.
+
+2. **Scanning Contracts**:
+
+   - Retrieve contract details sequentially starting from the specified `startingContractId`.
+   - Parse contract bytecode and identify function selectors corresponding to ERC20 and ERC721 standards:
+     - **ERC20 Selectors**:
+       - `0x18160ddd`: `totalSupply()`
+       - `0x70a08231`: `balanceOf(address)`
+       - `0xa9059cbb`: `transfer(address,uint256)`
+       - `0x095ea7b3`: `approve(address,uint256)`
+       - `0xdd62ed3e`: `allowance(address,address)`
+     - **ERC721 Selectors**:
+       - `0x6352211e`: `ownerOf(uint256)`
+       - `0x42842e0e`: `safeTransferFrom(address,address,uint256)`
+       - `0x095ea7b3`: `approve(address,uint256)`
+       - `0x081812fc`: `getApproved(uint256)`
+
+3. **Validation (Optional)**:
+
+   - Perform `eth_call` on detected contracts to confirm:
+     - ERC20:
+       - `name`, `symbol`, `decimals`, `totalSupply`.
+     - ERC721:
+       - `name`, `symbol`.
+   - Filter out contracts that fail validation.
+
+4. **Registry Generation**:
+   - Aggregate validated contracts into two separate registries:
+     - **ERC20**:
+       ```json
+       [
+         {
+           "address": "0x....",
+           "contractId": "0.0.x",
+           "name": "...",
+           "symbol": "...",
+           "decimals": x,
+           "totalSupply": "..."
+         }
+       ]
+       ```
+     - **ERC721**:
+       ```json
+       [
+         {
+           "address": "0x....",
+           "contractId": "0.0.x",
+           "name": "...",
+           "symbol": "..."
+         }
+       ]
+       ```
+   - Sort entries in ascending order of `contractId`.
+   - Save output files to `tools/erc-repository-indexer/registry`.
+
+### Output Examples
+
+#### ERC20 Registry
+
+```json
+[
+  {
+    "address": "0x123456...",
+    "contractId": "0.0.12345",
+    "name": "Test Token",
+    "symbol": "TEST",
+    "decimals": 18,
+    "totalSupply": "1000000000000000000"
+  }
+]
+```
+
+#### ERC721 Registry
+
+```json
+[
+  {
+    "address": "0xabcdef...",
+    "contractId": "0.0.67890",
+    "name": "NFT Token",
+    "symbol": "NFT"
+  }
+]
+```
+
+### Future Enhancements
+
+1. **SEVM Integration**:
+   - Transition to SEVM for improved contract analysis.
+2. **Extended Standards**:
+   - Add support for other token standards like ERC1155.
+
+The ERC Token Indexer will serve as a foundational tool for discovering and cataloging ERC tokens on Hedera, addressing a critical need for token visibility and usability across the network. By focusing on accuracy, scalability, and extensibility, this tool will empower developers and applications to interact seamlessly with the Hedera ecosystem.

--- a/tools/erc-repository-indexer/docs/registry_design.md
+++ b/tools/erc-repository-indexer/docs/registry_design.md
@@ -53,6 +53,39 @@ The **ERC Contract Indexer** will:
   - `MIRROR_NODE_URL`: API URL for the Hedera mirror node.
   - `STARTING_POINT`: Starting contract ID or contract EVM address (or a `next` pointer from a previous run).
 
+### Class Diagram
+
+The following class diagram illustrates the code structure and relationships between the components of the ERC Contracts Indexer tool:
+
+```mermaid
+classDiagram
+    class ContractScanner {
+        +fetchContracts(startingPoint: String): List~Contract~
+        +fetchContractDetails(contractId: String): Contract
+    }
+
+    class InterfaceMatcher {
+        +isErc20(contract: Contract): Boolean
+        +isErc721(contract: Contract): Boolean
+    }
+
+    class Validator {
+        +validateErc20(contract: Contract): Boolean
+        +validateErc721(contract: Contract): Boolean
+    }
+
+    class RegistryGenerator {
+        +generateErc20Registry(contracts: List~Contract~): void
+        +generateErc721Registry(contracts: List~Contract~): void
+    }
+
+    ContractScanner --> InterfaceMatcher : "Uses for matching"
+    InterfaceMatcher --> Validator : "Optional validation"
+    InterfaceMatcher --> RegistryGenerator : "Passes matched contracts"
+    Validator --> RegistryGenerator : "Passes validated contracts"
+
+```
+
 ### Implementation Workflow
 
 1. **Initialization**:

--- a/tools/erc-repository-indexer/docs/registry_design.md
+++ b/tools/erc-repository-indexer/docs/registry_design.md
@@ -1,14 +1,14 @@
-# ERC Token Indexer
+# ERC Contracts Indexer
 
 ## Abstract
 
-This document outlines the design and implementation of the **ERC Token Indexer**, a standalone tool for identifying and cataloging ERC20 and ERC721 token contracts on the Hedera network. The indexer will index the Hedera network and scan contracts, verify their adherence to ERC standards, and produce structured output files for downstream applications. The goal is to provide developers and users with a reliable registry of tokens to enhance network insight and application usability.
+This document outlines the design and implementation of the **ERC Contracts Indexer**, a standalone tool for identifying and cataloging ERC20 and ERC721 token contracts on the Hedera network. The indexer will index the Hedera network and scan contracts, verify their adherence to ERC standards, and produce structured output files for downstream applications. The goal is to provide developers and users with a reliable registry of tokens to enhance network insight and application usability.
 
 ## Motivation
 
 Hedera supports ERC tokens alongside its native HTS tokens. However, there is no built-in mechanism to identify and list ERC20 and ERC721 tokens on the network. This lack of visibility impacts the usability of tools like the Mirror Node Explorer and limits the ability of developers to interact with these tokens.
 
-The ERC Token Indexer addresses this gap by:
+The **ERC Contract Indexer** addresses this gap by:
 
 1. **Providing Discoverability**: Enabling tools to display and interact with ERC tokens effectively.
 2. **Automating Identification**: Streamlining the process of detecting and validating token contracts.
@@ -18,93 +18,96 @@ The ERC Token Indexer addresses this gap by:
 
 ### Tool Overview
 
-The ERC Token Indexer will:
+The **ERC Contract Indexer** will:
 
-- Fetch smart contract data from the Hedera Mirror Node API.
-- Detect ERC20 and ERC721 token contracts using function signature matching.
+- Fetch smart contracts from the Hedera network using Mirror Node APIs.
+- Detect ERC20 and ERC721 token contracts by performing function signature matching.
 - Optionally validate contracts via `eth_call` for additional confidence.
-- Generate two JSON files: one for ERC20 tokens and another for ERC721 tokens.
-
-### Key Features
-
-1. **Network-Agnostic Configuration**:
-
-   - The tool will support flexible configurations for different environments (`testnet`, `mainnet`, etc.) and mirror node endpoints.
-
-2. **Interface Signature Matching**:
-
-   - Identify token contracts by analyzing bytecode for ERC20 or ERC721 function signatures.
-
-3. **Validation**:
-
-   - Include an optional mechanism to validate contracts by calling key functions (`name`, `symbol`, `totalSupply`, etc.).
-
-4. **Registry Generation**:
-   - Create structured, sorted JSON files for ERC20 and ERC721 tokens.
+- Finally, generate two registries in the format of JSON: one for ERC20 tokens and another for ERC721 tokens.
 
 ### Architecture
 
 The indexer will consist of the following components:
 
-#### 1. **Contract Scanner**
+#### 1. **ERC Interface Signature Matcher**
 
-- **Purpose**: Retrieve and analyze smart contracts from the Hedera Mirror Node API.
-- **Workflow**:
-  - Fetch contracts starting from a configurable `startingContractId`.
-  - Retrieve and parse bytecode for each contract.
-  - Match bytecode against known ERC20 and ERC721 function signatures.
-- **Output**: A list of candidate ERC20 and ERC721 contracts.
+- **Objective**: Leverage Hedera Mirror Node APIs to retrieve and analyze all smart contracts on the Hedera network. Validate the bytecode of each contract through signature matching to determine compliance with the ERC-20 or ERC-721 standard.
+
+- **Output**: A comprehensive list of verified ERC-20 and ERC-721 compliant contracts.
 
 #### 2. **Validator** (Optional)
 
 - **Purpose**: Increase confidence in token identification.
-- **Workflow**:
-  - Use `eth_call` to invoke key methods and confirm their behavior.
-  - Validate token metadata such as `name`, `symbol`, and `decimals` for ERC20 tokens.
-  - Validate `name` and `symbol` for ERC721 tokens.
 - **Output**: Filtered and validated list of ERC tokens.
 
 #### 3. **Registry Generator**
 
 - **Purpose**: Generate output files in the required format.
-- **Workflow**:
-  - Aggregate data for identified ERC tokens.
-  - Generate two JSON files:
-    - `ERC20_registry.json`
-    - `ERC721_registry.json`
-  - Sort entries by `contractId` in ascending order (from oldest to newest).
-  - Ensure compliance with the schema for each token type.
+- **Output**: JSON files:
+  - `ERC20_registry.json`
+  - `ERC721_registry.json`
 
 #### 4. **Configuration Manager**
 
 - **Purpose**: Enable flexible and environment-specific configurations.
 - **Parameters**:
-  - `env`: Network environment (e.g., testnet, mainnet).
-  - `mirrorNodeUrl`: API URL for the Hedera mirror node.
-  - `startingContractId`: Optional starting contract ID for scanning.
+  - `HEDERA_NETWORK`: Network environment (e.g., testnet, mainnet).
+  - `MIRROR_NODE_URL`: API URL for the Hedera mirror node.
+  - `STARTING_POINT`: a starting contract ID or a potential `next` pointer included in mirror node REST response (TBD).
 
-### Workflow
+### Implementation Workflow
 
 1. **Initialization**:
 
    - Load environment variables and configuration parameters.
-   - Establish a connection with the Mirror Node API.
 
-2. **Scanning Contracts**:
+2. **Identifying ERCs**:
 
-   - Retrieve contract details sequentially starting from the specified `startingContractId`.
-   - Parse contract bytecode and identify function selectors corresponding to ERC20 and ERC721 standards:
-     - **ERC20 Selectors**:
+   a. **Retrieve Contract Batches**
+
+   - Use the Hedera Mirror Node API to index the entire network, retrieving contracts in ascending order (from oldest to newest):
+
+     - `https://{{network}}.mirrornode.hedera.com/api/v1/contracts?order=asc`
+
+   b. **Fetch Contract Details and Parse Bytecode**
+
+   - For each contract:
+     - Retrieve contract details:
+       - `https://{{network}}.mirrornode.hedera.com/api/v1/contracts/{contractIdOrEvmAddress}`
+     - Extract and parse the bytecode from the contract detail object.
+       _Note: Utilize concurrent requests to optimize execution efficiency._
+
+   c. **Perform Interface Signature Matching**
+
+   - Analyze the bytecode for compliance with ERC-20 or ERC-721 standards using the [Contract.isErc()](https://github.com/acuarica/evm/blob/402028ca8c3a33dbb8498f0200d9af2efbf4f792/src/index.ts#L153-L158) method from the [SEVM library](https://www.npmjs.com/package/sevm). This method analyzes the contract bytecode and matches function signatures to confirm compliance with the ERC-20 and ERC-721 standards.
+
+   - Identify the following function selectors in the bytecode:
+
+     - **ERC-20 Selectors**:
+
        - `0x18160ddd`: `totalSupply()`
        - `0x70a08231`: `balanceOf(address)`
        - `0xa9059cbb`: `transfer(address,uint256)`
+       - `0x23b872dd`: `transferFrom(address,address,uint256)`
        - `0x095ea7b3`: `approve(address,uint256)`
        - `0xdd62ed3e`: `allowance(address,address)`
-     - **ERC721 Selectors**:
+
+     - **ERC-721 Selectors**:
        - `0x6352211e`: `ownerOf(uint256)`
        - `0x42842e0e`: `safeTransferFrom(address,address,uint256)`
+       - `0xb88d4fde`: `safeTransferFrom(address,address,uint256,bytes)`
        - `0x095ea7b3`: `approve(address,uint256)`
        - `0x081812fc`: `getApproved(uint256)`
+       - `0xa22cb465`: `setApprovalForAll(address,bool)`
+       - `0x70a08231`: `balanceOf(address)`
+       - `0xe985e9c5`: `isApprovedForAll(address,address)`
+       - `0x01ffc9a7`: `supportsInterface(bytes4)`
+       - `0x23b872dd`: `transferFrom(address,address,uint256)`
+
+d. **Handle Pagination**
+
+- Since the `/contracts` endpoint has a limit of 100 records per request, use the `next` pointer provided in the response to recursively fetch subsequent batches and comprehensively index the network.
+- Write the `next` pointer to disk for persistence, allowing the indexing process to resume from the last recorded point if interrupted or to accommodate future runs when additional contracts are deployed on the network.
 
 3. **Validation (Optional)**:
 
@@ -137,48 +140,10 @@ The indexer will consist of the following components:
            "address": "0x....",
            "contractId": "0.0.x",
            "name": "...",
-           "symbol": "..."
+           "symbol": "...",
+           "serial_id": "..."
          }
        ]
        ```
    - Sort entries in ascending order of `contractId`.
    - Save output files to `tools/erc-repository-indexer/registry`.
-
-### Output Examples
-
-#### ERC20 Registry
-
-```json
-[
-  {
-    "address": "0x123456...",
-    "contractId": "0.0.12345",
-    "name": "Test Token",
-    "symbol": "TEST",
-    "decimals": 18,
-    "totalSupply": "1000000000000000000"
-  }
-]
-```
-
-#### ERC721 Registry
-
-```json
-[
-  {
-    "address": "0xabcdef...",
-    "contractId": "0.0.67890",
-    "name": "NFT Token",
-    "symbol": "NFT"
-  }
-]
-```
-
-### Future Enhancements
-
-1. **SEVM Integration**:
-   - Transition to SEVM for improved contract analysis.
-2. **Extended Standards**:
-   - Add support for other token standards like ERC1155.
-
-The ERC Token Indexer will serve as a foundational tool for discovering and cataloging ERC tokens on Hedera, addressing a critical need for token visibility and usability across the network. By focusing on accuracy, scalability, and extensibility, this tool will empower developers and applications to interact seamlessly with the Hedera ecosystem.


### PR DESCRIPTION
**Description**:
The ERC Registry is an initiative aimed at creating a comprehensive registry of contracts that are widely recognized and believed to be standard ERC token contracts with a high degree of confidence. At this early phase of the project, it requires a design document to highlight and outline the approach.

This PR adds a new design document for the approach.

**Related issue(s)**: #1028 
Fixes #1029 
