### PR TITLE
feat: added an option for resolveStartingPoint() to fetch next pointer from disk

### DIFF
--- a/tools/erc-repository-indexer/erc-contract-indexer/src/utils/constants.ts
+++ b/tools/erc-repository-indexer/erc-contract-indexer/src/utils/constants.ts
@@ -23,6 +23,7 @@ export default {
   GET_CONTRACT_ENDPOINT: '/api/v1/contracts',
   ERC_20_JSON_FILE_NAME: 'erc-20.json',
   ERC_721_JSON_FILE_NAME: 'erc-721.json',
+  GET_CONTRACTS_LIST_NEXT_POINTER_JSON_FILE_NAME: 'next-pointer.json',
   NETWORK_REGEX: /^(localnet|previewnet|testnet|mainnet)$/,
   MIRROR_NODE_URL_REGEX:
     /^https:\/\/(previewnet|testnet|mainnet)\.mirrornode\.hedera\.com$/,


### PR DESCRIPTION
**Description**:
This PR enhances `resolveStartingPoint()` by adding the ability to fetch the `next` pointer from disk. To support this, `RegistryGenerator()` has been updated with two new methods: `updateNextPointer()` and `retrieveNextPointer()`. 

The `resolveStartingPoint()` method now determines the starting point for indexing based on configuration settings. It prioritizes the `STARTING_POINT` defined in the configuration; if unavailable, it checks for a stored `next` pointer on disk and uses it if found. If neither is present, indexing defaults to starting from the genesis block.

**Related issue(s)**:

Fixes #1056

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
