### PR TITLE
chore: added a list of files containing token information for ERC-20 and ERC-721 tokens on the Hedera networks

### DIFF
--- a/tools/erc-repository-indexer/erc-contract-indexer/erc-registry/mainnet/erc-20.json
+++ b/tools/erc-repository-indexer/erc-contract-indexer/erc-registry/mainnet/erc-20.json
@@ -1,0 +1,3122 @@
+[
+  {
+    "contractId": "0.0.14902",
+    "address": "0x0000000000000000000000000000000000003a36",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.15701",
+    "address": "0x0000000000000000000000000000000000003d55",
+    "name": "CUSD",
+    "symbol": "CUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.15707",
+    "address": "0x0000000000000000000000000000000000003d5b",
+    "name": "CUSD",
+    "symbol": "CUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.18586",
+    "address": "0x000000000000000000000000000000000000489a",
+    "name": "CUSD",
+    "symbol": "CUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.20354",
+    "address": "0x0000000000000000000000000000000000004f82",
+    "name": "REJOLUT",
+    "symbol": "REJO",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.21261",
+    "address": "0x000000000000000000000000000000000000530d",
+    "name": "HbarToken",
+    "symbol": "HT",
+    "totalSupply": 10000000,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.27482",
+    "address": "0x0000000000000000000000000000000000006b5a",
+    "name": "TOKENWALLET",
+    "symbol": "TW",
+    "totalSupply": 1234567,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.27879",
+    "address": "0x0000000000000000000000000000000000006ce7",
+    "name": "TOKENWALLET",
+    "symbol": "TW",
+    "totalSupply": 10,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.28435",
+    "address": "0x0000000000000000000000000000000000006f13",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.47310",
+    "address": "0x000000000000000000000000000000000000b8ce",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.47764",
+    "address": "0x000000000000000000000000000000000000ba94",
+    "name": "PhiCoin Gold",
+    "symbol": "ΦAu",
+    "totalSupply": 3110347680,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.47770",
+    "address": "0x000000000000000000000000000000000000ba9a",
+    "name": "PhiCoin Gold",
+    "symbol": "ΦAU",
+    "totalSupply": 3110347680,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.47774",
+    "address": "0x000000000000000000000000000000000000ba9e",
+    "name": "PhiCoin Silver",
+    "symbol": "ΦAG",
+    "totalSupply": 31103476800,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.1015433",
+    "address": "0x00000000000000000000000000000000000f7e89",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 60554305877683,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.1100989",
+    "address": "0x000000000000000000000000000000000010ccbd",
+    "name": "ClubPenguinToken",
+    "symbol": "CPT",
+    "totalSupply": 100000000000000,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.1128603",
+    "address": "0x000000000000000000000000000000000011389b",
+    "name": "MyToken",
+    "symbol": "MTK",
+    "totalSupply": 1.222e+22,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1321086",
+    "address": "0x442af81eaad6c27d4c7e029c935603bae96c66e8",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 20687611777,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1321164",
+    "address": "0xd18f1922cffa8f4bbc47793a6d198120447ad8e4",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 6911745567811,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1321478",
+    "address": "0x189079f6bac1f07c99308faaa380ec0d14e62ee1",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1321481",
+    "address": "0x49483a71140894d2381fed43f9dd3b6462fde657",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 35614707,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1321496",
+    "address": "0xf4d8e05ce43bec2179a7bdc1313dc56b16edd96a",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1189539063,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1321517",
+    "address": "0x6b15d05f55a60341d738250f78774cb395ecf05a",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 42719902011,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1321519",
+    "address": "0x9dda110649fb2969c705e23b338f6ab093027ac9",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 111556211800,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1321521",
+    "address": "0x9a41de1112a920d491e064519d83edee4eb90703",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 160126,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1321537",
+    "address": "0x6e38ecababba37ffb94150bd53c4593f72e1f920",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1321558",
+    "address": "0x8164516ca825293c46e5eefe3cff44b38b9227ab",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 2131969,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1321564",
+    "address": "0x8cb5be7ccda89b4f1b2014a0b75d9cdf31c94e4b",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 7865590944,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1321573",
+    "address": "0x0a7a675861f1686dcb9e33dcfbe9cc2f196eb9b2",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 6544920305,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1323828",
+    "address": "0x581f8294b4a0779d723bb4e289a1f4ee4c196b6a",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 65315961067087,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1323836",
+    "address": "0x7e4e0a89ce690e6f5d4c9237a54e96dcc866065d",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 57930201,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1323911",
+    "address": "0xb62dc6e5f021dc2e1acc61f9fdd66b768f59622e",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 3279602653065,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1323915",
+    "address": "0xe001dde8f149a96b658ed8c6875a74c445927cdc",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 4288443375,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1324439",
+    "address": "0x2296620de98cb02a48dadb339bb11a1c9fa92f43",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1324858",
+    "address": "0x549b5cce7eebd38cc09f6547cb981bf3825b9d06",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1325020",
+    "address": "0x9d87dffb6b4c9d01f9545b49642ff6b0bbbfc3a4",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 3874516549,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1325027",
+    "address": "0xa06127077bc963c17160cda03aa00082e88806a0",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1326601",
+    "address": "0xb1eaf5bbb341ffb676f49ab8ba2714c398d8b164",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1327041",
+    "address": "0x2a4164f81ae882bf7a0a958622e22005e20a915a",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1331865",
+    "address": "0x0000000000000000000000000000000000145299",
+    "name": "PutinGrow",
+    "symbol": "PUTINGROW",
+    "totalSupply": 1000000000000000000,
+    "decimals": 9
+  },
+  {
+    "contractId": "0.0.1334385",
+    "address": "0x9c4f289e3365986293379a2f07a437420985bddf",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 10000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1335121",
+    "address": "0x7a6153eef8626819534e50b6a9a9b11d992ed6dd",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1344113",
+    "address": "0x5cb7f7164df83557c791374d4f474149d2117c41",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 48639481048833,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1358819",
+    "address": "0x000000000000000000000000000000000014bbe3",
+    "name": "zvsfhpSdMh",
+    "symbol": "UsPUa",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1366082",
+    "address": "0x27b3b74d3e371901cc5b579b07e89f1cc0dbf4a7",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1371155",
+    "address": "0x362606dc8ccaf2805d2e898da22156f353a2906e",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1385358",
+    "address": "0x54fa7533012b4a1373fcfbadde33a6da6653e24f",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1396001",
+    "address": "0x74c83727ed85b52b5b7f463f2425cdf1468a9205",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1409436",
+    "address": "0xd416a437f588762a1171056827925ead246da04b",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1412565",
+    "address": "0xba35d9fc4c0b422c680ee8d628c2ccf44ee65f50",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 500500,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1412832",
+    "address": "0x88e1e76f39032a936cf80185f50e335e669aca53",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1414374",
+    "address": "0xfa65dd60f176b3fb88eddfad511706796a9eb900",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 313965959,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1414441",
+    "address": "0xf68a4d27bac7e83f1867e35f46eb16a633a7d0a0",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 428735665,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1414822",
+    "address": "0xf981fa7d5db3cf311e46d5e42ef052cedb850234",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1446271",
+    "address": "0xc8d4829279f50bf982433b4c850c5c3fbf1a9bcc",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 466379723,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1450140",
+    "address": "0x31ce1372027a82171fc1b15f18871fd56d17f81a",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1450144",
+    "address": "0x6e6cdebe922662464d20e0df15636a28fb874a97",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1450817",
+    "address": "0x11c5ba23e7cfa42a999163242e86b9253284054e",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1451054",
+    "address": "0x27a5fc7d40533e53245c4793ca985447e4374d74",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1451056",
+    "address": "0xf7fbed0cabfa839faaab2676fd6d37c189593cbc",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1451061",
+    "address": "0x103e48d35781a7ce56564dbb4553d169a959c130",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1451063",
+    "address": "0xb50d35e59d06faa546b92b9fbfa667b40aa4f734",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1451428",
+    "address": "0x70fbd57ef58b8ad87046274342bf7afece7db246",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1458192",
+    "address": "0xdffdc4c3a8554fef34414a690d96053cfee42eac",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 6036886,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1459465",
+    "address": "0x0000000000000000000000000000000000164509",
+    "name": "BattleCoins",
+    "symbol": "BACO",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.1459473",
+    "address": "0x0000000000000000000000000000000000164511",
+    "name": "BattleCoins",
+    "symbol": "BACO",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.1462442",
+    "address": "0x791940f4cfe9309b9766e2c3818145caf8791e68",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 122404,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1467793",
+    "address": "0x07390065bbfef3562a97c86c9b97b494dd9c06a7",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 50000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1467869",
+    "address": "0xe6c16e3b4e86e0c5b93ae3c126fcd682ddbb30ec",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1473819",
+    "address": "0x906de1de8412924986fc3c6f6496d4daa1d2980a",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1474629",
+    "address": "0x744488530bc80275e7e6854e031c99f994991891",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1475183",
+    "address": "0xdddcd22e0da3d7982be87c0c3c5d2dae95e384e7",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1475184",
+    "address": "0x0d6515faa00808c819435d9972c79b2748281bc8",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1475187",
+    "address": "0x92393d5e469b5e3ef5ddce2eed2e002e1ebc3254",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1476053",
+    "address": "0x9a5ad85eac8f3d176750b9d25ecf0e6930de5556",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1477370",
+    "address": "0x591699db7a7112bfc0bd6d7a913b88ebc26bb220",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1477452",
+    "address": "0xe97418354e8c4c2961f186fa9824461261ad62e2",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 4472135954,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1477498",
+    "address": "0xa05c62f195d508e013a09f4fa7ce7ddcb9b1c937",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1483461",
+    "address": "0x37522f48cad2ab403e391dd0b7daa5d8ea2c0f79",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 100144145,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1485848",
+    "address": "0x069ee99943aa052a8ffa48a4d34efa0e58b923c7",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1485861",
+    "address": "0x6d0a18de90ea79c2f75ac519861e0662f15e39b1",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 6523136,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1488252",
+    "address": "0x387972aa050266bf329fff2a7e530f60377fc5dc",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1488286",
+    "address": "0x2f3e71864178a93887e11bbee849d16d288c5b60",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1488288",
+    "address": "0x5c5a02b5c059ef7a9408b24ecc070b346196b981",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1488289",
+    "address": "0xa007436df285216a4f6051b5ee116b36b806dbc5",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1488915",
+    "address": "0x9da6b937470432da0523fcaaa007d69612067f69",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1488924",
+    "address": "0xbbf0de872084501b9efcac7ab62faa21d02f6d8a",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 3322398000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1488935",
+    "address": "0x0ba07d52b1894593fa3270e88728ad2d37021be4",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 15112648436,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1489073",
+    "address": "0xc13d17ff0366be91ee802cbb2d4fce0083707a06",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1489078",
+    "address": "0x53e09a52d766ccbc11899d8c99b742945b6eb765",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1489124",
+    "address": "0x5172391fde0d6ec5789aa003be49d21aed6ceb50",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1491381",
+    "address": "0x23b8c670442d9a5efbf62a669fe8eb2ee13506d0",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1493825",
+    "address": "0xe247e7c561276ce5ea976cd2d483990498c7f5bd",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1494708",
+    "address": "0x90e948717e509e9af7ffae4996fe5cd6a4c89388",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1495929",
+    "address": "0x11e4c75c824aee0b5d5302dfb044676c7cee2561",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1495930",
+    "address": "0xa1e5428607468f2586a6442180071b9462d465dd",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1497677",
+    "address": "0x5aca0ce5d24417d0e097a20f1e12d11b069c6de9",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1497797",
+    "address": "0xe6af53332246219551f90115a7702e10986c4cb3",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1497799",
+    "address": "0x6cf5c072d71d29e7ee57be8b421a3246a408e088",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1665091",
+    "address": "0x130b90e3233b42a4d6b8084b48008bfc0ef01df3",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1671009",
+    "address": "0x47835939062bc475490add35fae5fcdec6dabf95",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1671011",
+    "address": "0x90959684abd6013ed1a2c2822d36a4ce2a740bf0",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1671012",
+    "address": "0x71e02b4f214b168798d90174d3ef7f7cbb542af1",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1671026",
+    "address": "0x72214678d1d984cd76ac8daf29ab60e9364b7e4b",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1671076",
+    "address": "0xcd8d7baf1eedca9c48bfd903141669d25e5ae617",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1671196",
+    "address": "0x9283e675003008004973461715fea181a8164e6d",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1740860",
+    "address": "0xf00b8e6c6c6372f5f63a6c875002c12ee0e4f0d0",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1778107",
+    "address": "0x961147b21d222312e2fa8c41e9bbf2126eb89fa6",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 7723880,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1886292",
+    "address": "0xcf617b80319eb859f96f197989de70c7da44e926",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1977759",
+    "address": "0x781f2a3818245043c97679690d34db2ca275d7e6",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1986078",
+    "address": "0x3904ad0e5c86c9c3ac452cd61afe1776bf92cecd",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 69762251118643,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1986162",
+    "address": "0x0aa81a482da9a402063b5e48066620f7f46ea171",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 4857369494,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1986560",
+    "address": "0x02298b30c2aa641ec2ed642125e3bf962c0637d5",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1986572",
+    "address": "0x606854f6dba29caf562d5671550987dd7e159aea",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 41690910,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1986579",
+    "address": "0x17b86812b12ff4bbaaab99c508b889b4e8ebd90a",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 28778987,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1986581",
+    "address": "0xf9eec4f1b074a2c1de32a34f9f99564985799c7a",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1986597",
+    "address": "0xfbc8df7a950556413485af86097b10fd9a8d9a1a",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1702351315,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1986618",
+    "address": "0x7f76a37b7915210ff21c039c12154f8884128a48",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 122474487,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1986641",
+    "address": "0xd36b6f37b825a22b0c4552c7807ae7663e68f810",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1996547",
+    "address": "0x9ddf6cfb825adb4458feaee71142c2e1d5d9477e",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.1997618",
+    "address": "0x40fba927aef76f5f6e6bc4263b9b98de302b883c",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2012238",
+    "address": "0x657194d752cb399cfc7ed0550fc3c23c3ac4e773",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2016872",
+    "address": "0x58b9c4815f8f3d46928e1765bd2b024b82a9c77e",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 6964827736222,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2021991",
+    "address": "0x04e10493d0a4724f1b9a11516270175321762fc4",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2022101",
+    "address": "0x42ab31dc14de6787f82e236c7b17f22c29892bad",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2022287",
+    "address": "0xec9396fd1019a6644534ce7905183f495bc86baf",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 2364864575276,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2022990",
+    "address": "0x9869ad7ee5e503b37dacdb072a1a2d96a6874e41",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2023059",
+    "address": "0xca6e6938159fa4b0f6b6c34a63e4ec6deecbbb9d",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2023065",
+    "address": "0xde7faff219bb968a09b0d4aec043d14f63925550",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2023068",
+    "address": "0xa4aaa1a2b2ca0a34d2039e970edd231b3b8d416a",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2023542",
+    "address": "0xed26482532593309b929cd484d3bc94d51a0d391",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2023554",
+    "address": "0xa07b79793e6eb105d88d82d249e5b41603f4976a",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2024508",
+    "address": "0xf81434b0924c1fe8e4558d263fc77a2c3e0c7ecd",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2024810",
+    "address": "0xf142200f5195e5802ebad1e13788ec806f57c0c8",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 40906152,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2080602",
+    "address": "0xb552a6c5d6cb3602ae34b83eed22df13e037adb0",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 24176792,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2086139",
+    "address": "0x3e294197feb7ba7c9f738d6b8020741250ab5940",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2089231",
+    "address": "0x5c93f5dbb67da372cc1790cfd450ad9d083bf166",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 13372809,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2089235",
+    "address": "0xbed14f5e8dcf9fdcfd9f487884e5a899bce48c03",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 441947503,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2105520",
+    "address": "0xa501b838ce05670a7fc59062e90b78dd0631bef7",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 624223675801,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2105529",
+    "address": "0x7ea5c6153afc2dd1b9503c02d6ea344ebb9c6d28",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1151120737,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2105535",
+    "address": "0xefbb5200f3ad0209e84be08b40127c1d8fd9ca70",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2105539",
+    "address": "0x9df76caeebda5c7f7e13769c49e7cdc809fd3ffa",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 137039139263,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2105541",
+    "address": "0x095cc0bf1e0482599dd565cb3543c307dd788e6a",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 222256387,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2106167",
+    "address": "0x0000000000000000000000000000000000202337",
+    "name": "Test",
+    "symbol": "T",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.2110967",
+    "address": "0x00000000000000000000000000000000002035f7",
+    "name": "Test",
+    "symbol": "T",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.2131436",
+    "address": "0xc332a4132c3ae48142860b7639c1f43105910b5b",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2131453",
+    "address": "0x9549d5469314061960e8b630a5b15f0f5a2c172e",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2131458",
+    "address": "0xe2223075e6fc2a438933d2a026d6162f97838696",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2131585",
+    "address": "0xf2e5868582287636fcad1f76e855dedde3ee404d",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2134348",
+    "address": "0x27bfd16619a097a8efdf3834d1f3f01892743b58",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 200000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2148458",
+    "address": "0x6e96d2d7250fb9a648f4f2ea2d10f2fdcc9d3581",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2150845",
+    "address": "0xaf811fbfc38217eb15e4d85037842fa27cfba0bb",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 2645751311,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2158402",
+    "address": "0xd0d144891f66d4fe248d2d306979a7bc0744935d",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2162031",
+    "address": "0xfee63a8a3064a2a6c1fff8de1b39b494022253de",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2172069",
+    "address": "0x9b07949e426bfbe7867a612329f21ef42bafc9f8",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2174298",
+    "address": "0x0000000000000000000000000000000000212d5a",
+    "name": "Test",
+    "symbol": "T",
+    "totalSupply": 3000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.2174328",
+    "address": "0x0000000000000000000000000000000000212d78",
+    "name": "Test",
+    "symbol": "T",
+    "totalSupply": 4000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.2179869",
+    "address": "0x000000000000000000000000000000000021431d",
+    "name": "MyToken",
+    "symbol": "TKN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2179870",
+    "address": "0x000000000000000000000000000000000021431e",
+    "name": "MyToken",
+    "symbol": "TKN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2180398",
+    "address": "0x000000000000000000000000000000000021452e",
+    "name": "MyToken",
+    "symbol": "TKN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2186200",
+    "address": "0x8c030eddfed1319303425a3c41665ba42a8138eb",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2189425",
+    "address": "0xaa9414a978f607cf2933e7ba3e717e25296db8bf",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2198249",
+    "address": "0x4c0032d1386767a95672394ba2314a3ed085a4d5",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2198479",
+    "address": "0x8d161dd3a06c46a1994f6a5cbed196a95ea26ea8",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2198513",
+    "address": "0xc4da5ca68a0499010b6696f22378a384c7044199",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2198532",
+    "address": "0xb2d8736f6a12a3e01730454687a3383d3007a499",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2198533",
+    "address": "0xa8af37a0b221156d3608326640a7a37d38177d1b",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2198573",
+    "address": "0xa833fa11d50a95b0b405867e3a4e888ea1725e3e",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 547722,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2198576",
+    "address": "0xc95289080155c08c8ff035bd94010903699e7e23",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 10594,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2198588",
+    "address": "0x97c956c53364c807cb4b60354768ae20c66b1d70",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 6407,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2234822",
+    "address": "0xaf02d687fb9eed3e77cfe61623eac7429348373b",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2260540",
+    "address": "0xab54e9d48bcd562caddc03f1da38de63ae6e96c5",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2261251",
+    "address": "0xea7c502d58374c1e4d4db0dc3349fc8818df1e30",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2483189",
+    "address": "0x3a0bbedfc2b8f910733abd606f63cd5beaab0844",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 19899,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2638512",
+    "address": "0x94b8df72b66616349f9135f96945b6e4b318ce9e",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2849202",
+    "address": "0x00000000000000000000000000000000002b79b2",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 99999700,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.2906772",
+    "address": "0x00000000000000000000000000000000002c5a94",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 10100000008,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.2918781",
+    "address": "0x00000000000000000000000000000000002c897d",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 5100000008,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.2926466",
+    "address": "0xda832d309ced5e69c6d54c5515f873303ba64a51",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2928837",
+    "address": "0x475a4c3ca4978753248a907827653388d6225750",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2934593",
+    "address": "0x00000000000000000000000000000000002cc741",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.2934623",
+    "address": "0x00000000000000000000000000000000002cc75f",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.2934659",
+    "address": "0x00000000000000000000000000000000002cc783",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.2934689",
+    "address": "0x00000000000000000000000000000000002cc7a1",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.2934740",
+    "address": "0x00000000000000000000000000000000002cc7d4",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.2934795",
+    "address": "0x00000000000000000000000000000000002cc80b",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.2934819",
+    "address": "0x00000000000000000000000000000000002cc823",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 1187612504617884,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.2935280",
+    "address": "0x53bd01dcf3dffb9dfe241793d6b79d90079e0f48",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1641428670691,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2935290",
+    "address": "0x5718f1127e025c6745835facf551283481630423",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 819560417308019,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2935295",
+    "address": "0x635fa94b5bef0de9a59b8ed7a9aee3d9d8eaba37",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 899823012252176,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2935301",
+    "address": "0xc34800c63db3dd6655783e49cadecf32d7f94e7a",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 3080453043284,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2935305",
+    "address": "0x0a0f03cbb50b0c9ae160dc5c3c87ac6074ce3a8d",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 468503813726,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2935308",
+    "address": "0x1c78852bcb1d8340baea7cc22729c38e646682b3",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 42939293,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2935344",
+    "address": "0x9a21d544829b3939b87cab8140a37827472cbbea",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2935350",
+    "address": "0x23a94e80f5390a66e6a6e14b3041f25811f91b31",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 491014311141,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2935363",
+    "address": "0x8a55d80453795ccbee2d3f3b1a63ef62b46a785c",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 2812665785,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2935967",
+    "address": "0x760cc855e7d2be294f8a4270d989987c655c54b1",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2937324",
+    "address": "0xb6098f15c0537dd69a017fb907332ebed6b69b45",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 66912540671,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2937705",
+    "address": "0xc660d5e7951c0926270e231ca9d28ef3203c2317",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1720779542905,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2937709",
+    "address": "0xca833cd33bc9f4a92171dd70b4f32086cdf08e54",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2937712",
+    "address": "0xd18f8677f4cfa455f5fdee0fa36c8a3a5cda4f23",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1324835556,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2937720",
+    "address": "0x087e68bc9cec7e329a81997cced3ef6121b7a67a",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 194853082,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2937734",
+    "address": "0xea8f005c7f2e19da7dc583757b128e41eed35e0c",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 389606980,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2946103",
+    "address": "0xd0d1e1b7ce63d8c3df19f9923705661fde0aa34b",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2962621",
+    "address": "0x0242153dc134c9a8ad0bfc0efd7fb8bd6310e7a9",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 18999143073516,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2967033",
+    "address": "0x5806fe611c6e4c40ba0ba089c08970c429539484",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2997324",
+    "address": "0x4c9af28ae82c01464f2b41124dcb310c1ccd6254",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 30374309645611,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3053291",
+    "address": "0x00000000000000000000000000000000002e96eb",
+    "name": "APU Token",
+    "symbol": "APU",
+    "totalSupply": 1e+22,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3053427",
+    "address": "0x00000000000000000000000000000000002e9773",
+    "name": "APU Token",
+    "symbol": "APU",
+    "totalSupply": 1e+22,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3053476",
+    "address": "0x00000000000000000000000000000000002e97a4",
+    "name": "APU Token",
+    "symbol": "APU",
+    "totalSupply": 1e+22,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3053731",
+    "address": "0x00000000000000000000000000000000002e98a3",
+    "name": "APU Token",
+    "symbol": "APU",
+    "totalSupply": 1e+22,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3053767",
+    "address": "0x00000000000000000000000000000000002e98c7",
+    "name": "APU Token",
+    "symbol": "APU",
+    "totalSupply": 1e+22,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3054044",
+    "address": "0x00000000000000000000000000000000002e99dc",
+    "name": "APU Token",
+    "symbol": "APU",
+    "totalSupply": 1e+22,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3071524",
+    "address": "0x11f65675482fe6b14069669b8fed2af4ea0548c8",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3071530",
+    "address": "0xd4dd9c3eddd78e8289e424304d0d821fb767d039",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3113305",
+    "address": "0x93805e37f1375e79df3e129025afad3a3ed22cb3",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 418330013,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3131347",
+    "address": "0xd0b915b2c93aae7d08487dfe77eebc0a4820a862",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3168006",
+    "address": "0xa04e1d7b414745ea5777b76e3712d229be33492c",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 227473714100,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3212120",
+    "address": "0x0d4e65163a14452a68f2771dbd34e7c0c51e5157",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 3162277660,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3240634",
+    "address": "0xbbe3b2ca378683808bcadf1df31d53c720087e52",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 10000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3242729",
+    "address": "0x92992a47ab49d85d2f05ae451cde347e8b700338",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 10000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3273617",
+    "address": "0xbc9d0b35de2b33290d61110166716f3057b35d14",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3276468",
+    "address": "0xe1ab990bcf74ac0e09561bfd5e1d4096c5577dff",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3279866",
+    "address": "0x38cd403894ee3f8ff356c203682a009f00e613ca",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3281327",
+    "address": "0x932bb3a78b35c0b101dc7369a4c19375d31ab8d9",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 333534360425027,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3282360",
+    "address": "0xe0b472448638829222ada3e45e484a38a9d0127d",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3287589",
+    "address": "0xefaf1406b18f66e50c9a88343047492ba3d4b92f",
+    "name": "Toad",
+    "symbol": "TOAD",
+    "totalSupply": 10000000000000000,
+    "decimals": 7
+  },
+  {
+    "contractId": "0.0.3295494",
+    "address": "0x0ecb6cff68c26c838bfa469a3ffb907e2aa03d18",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 420954851,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3295844",
+    "address": "0x214a75693eafe395f50edef03b6d020b90bb2db4",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 100000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3298045",
+    "address": "0xf52546582e3843727d9303a2b38f41af58d28d63",
+    "name": "Yield",
+    "symbol": "YIELD",
+    "totalSupply": 10000000000000000,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3303671",
+    "address": "0x5ae3cb0c657dc9997f16673efd6c00a1dd63d547",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3313010",
+    "address": "0x52e3482f7cf126e26cd8d4ff08210a10cec61e97",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3472673",
+    "address": "0x83aa47cb2dd6b58bc4e73d0519356d2221a2d621",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3687509",
+    "address": "0xe3b2c85a3bc3f6844a370c3e3574d2030627f7da",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3711660",
+    "address": "0x70b10485ae3d71f20f59b75854d925c4f4b24cd5",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 20000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3712595",
+    "address": "0x430b179093a6995d2e554ec8ca97254a98f42c34",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1162633,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3796821",
+    "address": "0x6aebeb423844d4c307748cc0531854bfdf3cc6d8",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3817557",
+    "address": "0x577fc0664a4e6074334452df0328147ba9c150af",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3913434",
+    "address": "0x0c259b9007b9cf47b58b397250e29e9965e839ed",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 188594662337,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3939947",
+    "address": "0x316ed99f5b191a95e3fe422461a5c1f72c831071",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3941062",
+    "address": "0xa4f3b7d93ec7b70a4daefa831b5ec56569bcb023",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 13845586,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3959615",
+    "address": "0xb30b2320457a93fb945460d305573e8c8dc1f2c6",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 60415229867,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3970846",
+    "address": "0x25bf41b690899e6adeb482a8543558950a50125d",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 19364917231,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3970969",
+    "address": "0x632c640e9d1e91ba69977d1baf19a5abac1d1fc4",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 245920326,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3970978",
+    "address": "0xfe67dbd125693ac0e2cd87d17c92429dd76d1245",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 488719489,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3970998",
+    "address": "0x025d819fd3385031e647e2ec6e7dd63973951f24",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 5291435088,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3971003",
+    "address": "0x76b49a0f386f80ba40ba3cea043857b632b698dc",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 83557367,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3971007",
+    "address": "0x91261396f347937e61c798b9c6f244195f38e2ba",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3971010",
+    "address": "0x898dc28d18779d9f6c55308dbfff5812c705b026",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 7497063,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3971014",
+    "address": "0xf6c07cdbf2e6ccb287022df7c27dbc2aa36b439f",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3971044",
+    "address": "0x86fd35da550eed4eb41e9b574eb40b6d884b72c6",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 81569228802,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3987259",
+    "address": "0x22ff5c1d396c8fdd17f040c1edeac1707465b2f1",
+    "name": "VRJAM Red",
+    "symbol": "VRJAM",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3987291",
+    "address": "0xdd9158b1d4bb7a9a1374eaad46dd1192ec740866",
+    "name": "VRJAM Red",
+    "symbol": "VRJAM",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3987315",
+    "address": "0xac43750a12fccc8287f381164890e3a58cce78aa",
+    "name": "VRJAM Red",
+    "symbol": "VRJAM",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3987355",
+    "address": "0x1355b5234c32d744ab2b3c72815b16eceedf2d28",
+    "name": "VRJAM Red",
+    "symbol": "VRJAM",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4000848",
+    "address": "0xf175cc5001a6ef48db7f6c3e54e88e41ada76dd1",
+    "name": "VRJAM Red",
+    "symbol": "VRJAM",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4002563",
+    "address": "0x67bc7e5c0957609ae9e5fd434ddb6080ea201d8e",
+    "name": "VRJAM Red",
+    "symbol": "VRJAM",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4002622",
+    "address": "0x824316ad0120be23c25fc9dc3014c5081f9ed69a",
+    "name": "VRJAM Red",
+    "symbol": "VRJAM",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4005613",
+    "address": "0xd138226fed988ea19be8dc1bfc53b8a4f3893269",
+    "name": "VRJAM Red",
+    "symbol": "VRJAM",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4093763",
+    "address": "0x26e54839f4c2e75c5d657d71ae4c2f2b648eade8",
+    "name": "HTellor Tribute",
+    "symbol": "HTRB",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4094015",
+    "address": "0xc6b647971a4233bbdf1daacd8f60c52d8ec823be",
+    "name": "HTellor Tribute",
+    "symbol": "HTRB",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4104847",
+    "address": "0x043e68836ef54fcf7a1cd16fd01716f7edc8553e",
+    "name": "HTellor Tribute",
+    "symbol": "HTRB",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4137867",
+    "address": "0x6508f76b2c3de0b06ce7e05197e9fe352cb2cc2a",
+    "name": "HTellor Tribute",
+    "symbol": "HTRB",
+    "totalSupply": 1e+56,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4144023",
+    "address": "0xb2c150f33caeb75a616c01a71142f84370eb2be4",
+    "name": "VRJAM Red",
+    "symbol": "VRJAM",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4144098",
+    "address": "0xad9d6c9cd0bc981ecdf311a12b7292c7cbcac933",
+    "name": "VRJAM Red",
+    "symbol": "VRJAM",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4144112",
+    "address": "0x082ec51b4a74e42faa42543853e4d2838d32eef4",
+    "name": "VRJAM Blue",
+    "symbol": "VRJAM",
+    "totalSupply": 1e+28,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4317709",
+    "address": "0xda59098e0e01babf826e75a3ab84e6f52e335e23",
+    "name": "VRJAM Red",
+    "symbol": "VRJAM(RED)",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4317713",
+    "address": "0x02c3b851afcdd54aa027c5aa48ee61bd10713da2",
+    "name": "VRJAM Blue",
+    "symbol": "VRJAM(BLUE)",
+    "totalSupply": 1e+28,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4342862",
+    "address": "0xa5fed32aa980daad275bcc69bdb3f0d240f96930",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4357284",
+    "address": "0x4af2ed7e4ac5e2fc5e3c1f752e584408e0637848",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4361933",
+    "address": "0x6d4c2270598ff7388782904369feb8f040310dfd",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 178885438,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4362302",
+    "address": "0x75fa212a815c1a48a2cb86e70497ab41e91f191b",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 110000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4364426",
+    "address": "0xb85014b9d0c2431ddcd5dff6f5ff8f859dba159e",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4365893",
+    "address": "0xe30b252e4bf254ace9bff851a0a99a9e51b296ea",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 89285715284,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4365944",
+    "address": "0xe3d0d244b9543d1ced4ee1f18dfa7a091ba79077",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 2449571143408,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4366214",
+    "address": "0x1c521ce32472b82b085070938f60051703acb016",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4367953",
+    "address": "0xd779ba5abe3fb62b410c98194b4542d311acf0ab",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 100000001000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4368092",
+    "address": "0x9be5b08a7ae79fed44da7a2fbca09623b7c7a9fe",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 374165738,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4369806",
+    "address": "0x1d96a14c7864a38e6eaae581d1479323565e3329",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 214366417095,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4370034",
+    "address": "0xa8e3fe82c4669b1e9b37f13ddc42547e055168fb",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 3537253666,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4373695",
+    "address": "0xbee07c5beec717bb9b3192c842033cca033c3e22",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 774377384702,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4373755",
+    "address": "0x684f2a6c641f47fae0ee3f45af27822aaed2bda5",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 42379882674073,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4382550",
+    "address": "0x9877872a57f697f00c84a62a62ffa894e163cefd",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 3290164545875,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4383953",
+    "address": "0x5ea622b3747c377bc3ff552deda8e1cd74975b11",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4433743",
+    "address": "0x5387b3ca6e2f1e21dcc16b45cc6b5eb8c098cfed",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1882185914901,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4463322",
+    "address": "0xc30bf261254f46e3277eee299e9f1a74ea900d9c",
+    "name": "VRJAM Red",
+    "symbol": "VRJAM(RED)",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4463631",
+    "address": "0x7bd495ece5f5ae65266d21ac8fd0d31a8e98cab8",
+    "name": "VRJAM Red",
+    "symbol": "VRJAM(RED)",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4464221",
+    "address": "0x7c57b1223636e417a6d9249c5a7561e77259add6",
+    "name": "VRJAM Blue",
+    "symbol": "VRJAM(BLUE)",
+    "totalSupply": 1e+28,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4498610",
+    "address": "0x88692097ca32ddd88b30cbb3f7442a403706ca70",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 11649999050323,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4525090",
+    "address": "0x9cd6ea253283cef62a72acc3e9ee4e5d29f85c69",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4525643",
+    "address": "0xe72438d6c1bcf07eb0e477231d51b1e2f54ccf5e",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 11180339887999,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4537344",
+    "address": "0xe6b478c9e7e62ccef51d2553ff70eed2ad7423b1",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4537387",
+    "address": "0x7cba09078981173193cdf53336138448dec549c5",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 100000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4539330",
+    "address": "0x76561751b7a1d295ee16b381e116328b18b6f919",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4543429",
+    "address": "0x37d20d44e5cfba414d3b862c11e51587fecc1755",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 40000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4547361",
+    "address": "0xdefc06e8433fb7b308c81ff1814f138c3835a19b",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 2564623803347717,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4550076",
+    "address": "0xfbd630dc666f11c41839af62f24403f2ee8b61fe",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4550859",
+    "address": "0xd2a2b6b2740b7782031a8b6f0de65f27b0d9710a",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4552118",
+    "address": "0xfa051a1731d290edbecbe390d0e954c397f4b57d",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 44783429469,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4554042",
+    "address": "0x16628966becaf60f956c9c41c401cf6e2566da79",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 3161675257747,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4554753",
+    "address": "0xd5552185eeed137d4d242e7ddf6780eb929011ba",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4555424",
+    "address": "0x58317ac51d61543a1e09509de48d44f7af57ddfb",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4559467",
+    "address": "0x419d00aceaf472515d19c19cf1f8460ec13f7eea",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 22360679774,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4563314",
+    "address": "0x7d59e85a3dad667c07b84971482948a90ed2848a",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4587414",
+    "address": "0x58ac2a0a904f4f8dd3b76aee4a880206a40458a0",
+    "name": "VRJAM Red",
+    "symbol": "VRJAM(RED)",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4587428",
+    "address": "0x3ed60c2c40b120bb277f341337bc1d89da4eb8dc",
+    "name": "VRJAM Blue",
+    "symbol": "VRJAM(BLUE)",
+    "totalSupply": 1e+28,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4588348",
+    "address": "0x0f58e9d1eccf94e9a895e81e4725219fcbed656f",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4590712",
+    "address": "0xfbbf5d7d5cd2e7e65a0b92b305f0f59fc06dfb09",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4593357",
+    "address": "0x30ead724aaea8c3688964f0877cd023b7bab0041",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4597531",
+    "address": "0x39ed4b267dfcfe1f84aafcc972a121a2e023b867",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4598281",
+    "address": "0x9a8f5c6a50030661d845b51d97e4dff7658cd85d",
+    "name": "Yield",
+    "symbol": "YIELD",
+    "totalSupply": 1e+29,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4605504",
+    "address": "0x20b069fa5991a00d8c17a5ba7250ec9af212313b",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4626353",
+    "address": "0x5483f05e1a742f85cbf086c1a7b02344fb6e9193",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4700956",
+    "address": "0xcdc09ca1991028a3a819575da4930bec5bb976a1",
+    "name": "HEDERAMAINNETTEST001",
+    "symbol": "HEDERAMAINNETTEST001",
+    "totalSupply": 10000000,
+    "decimals": 5
+  },
+  {
+    "contractId": "0.0.4716033",
+    "address": "0xfcc5326b3d756846612dd9cf4661ba308d920a04",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4718528",
+    "address": "0x986b08b973b7664f8d9971ad54c377c210d577cf",
+    "name": "ddjbdbe",
+    "symbol": "edjejdej",
+    "totalSupply": 20,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4723661",
+    "address": "0x81452fc30590c4ff6d754574a0b1e072927f4743",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 8644155058,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4724133",
+    "address": "0xc755b45431c6aa4973ab901bf834d11a80b6802f",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 4472135954999,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4800991",
+    "address": "0xe4502229b42119f1a8b13981258ee865a40be469",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4802731",
+    "address": "0x0472ffa7a1cdd3faa8f1c3320fc238a0d3de90e5",
+    "name": "HDR",
+    "symbol": "HDR",
+    "totalSupply": 100,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4825074",
+    "address": "0x751671987fe7d7544476088e78a5be973c53fd5f",
+    "name": "Hedera Test Token",
+    "symbol": "HEDERA.TEST",
+    "totalSupply": 100,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4850016",
+    "address": "0xd720cd0e0d292734530e6bd27ab8f2fb84c4ab58",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4850869",
+    "address": "0x7e7d0a6b011b1e83fec6903337814edee860bc87",
+    "name": "Hedera Data Owner",
+    "symbol": "Hedera Data Owner",
+    "totalSupply": 10000,
+    "decimals": 2
+  },
+  {
+    "contractId": "0.0.4905534",
+    "address": "0xbc626ae3d6ff16c79ee68d77bd4c0eb306584473",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4908234",
+    "address": "0x1b194cd9897e21e726471871666b3546b29b21c2",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4956829",
+    "address": "0xa6118b3f8061a4260a53f48a65b25e0412fbe6f1",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4967676",
+    "address": "0x83cfa41d3c45879581447ee831958ae3b390fc6a",
+    "name": "NXTDM",
+    "symbol": "NXTDM",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4977411",
+    "address": "0xf8317ba39ea302022b9424b20a71ef4bcb6fd97e",
+    "name": "MBDT",
+    "symbol": "MBDT",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4983895",
+    "address": "0xb27b174d59c73082c8b32caae803bd77a79fedb0",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 100000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5012789",
+    "address": "0xc96a3cc3b8b29cd743546e02f2d36cdc3e658359",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5012799",
+    "address": "0x6e58d68342526c94263050bd125d60f487712346",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5026332",
+    "address": "0x20abdcf9004cbae87a2459a075261d2bb4cb1339",
+    "name": "Normie Token",
+    "symbol": "NORMIE",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5026350",
+    "address": "0xdfd8627f20d87060a702797020919c1154a9b826",
+    "name": "Normie Token",
+    "symbol": "NORMIE",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5029265",
+    "address": "0xe77d0ce6de1e54f3bdc8bb5a44a43c719b523c24",
+    "name": "VERT",
+    "symbol": "V",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5029324",
+    "address": "0xd8dbfbfff2185d5a418808a24a70432158790f2f",
+    "name": "G42 Worldcoin Inveniam Transaction",
+    "symbol": "G42WITRANSACTION",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.5046212",
+    "address": "0x08a136d86ce836d04f40bacd7996fbd7559163a5",
+    "name": "test",
+    "symbol": "TESTWW",
+    "totalSupply": 10,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.5229754",
+    "address": "0x64ada5473cd34d9e313f038ae4582a8bda7260b4",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 14085448,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5232230",
+    "address": "0x2f1ac0f573d668494a5fd4fdbf3908b566be3134",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 8957601799,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5381906",
+    "address": "0xbe1efd3c10ffa257172f5a9f31d537fbcb0bce73",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5402508",
+    "address": "0xb3d4a92ef81857df82568ce6d1aa6381d1436493",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5655141",
+    "address": "0x8495ea56058ce10dac6d70e907c83e2c97d0759e",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 972784,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5655289",
+    "address": "0xc4868b4d2e1006a536d601926f57b7f3e393fc81",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 10000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5690050",
+    "address": "0xecfe32f1399967eed712a92e557d4dc07164b6ce",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1001,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5697466",
+    "address": "0x07d720523d7b084dd66dad5bbecf1e06a7a1eb1a",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 43407,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5735810",
+    "address": "0xb3e128cdfff33f63964fe87c295a1839eccc3d60",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5740447",
+    "address": "0x2d84c3bf4d2ccdcd4593d1b2d34945c240feb755",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5795965",
+    "address": "0x8f238b18187b39fb7c18c8fc72552dd31e8a5bbb",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 39113449815148,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5796450",
+    "address": "0x516f407591ce09290ba8cedd1bd69aca7fafdcd7",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.6008514",
+    "address": "0xfcde7421c9ec73b90ee63838cb3e0debebd9dfda",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.6050627",
+    "address": "0x0888cebc5cd0313169760d7a4f5ea128a2ca2ae4",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.6050757",
+    "address": "0xdac78218dfbc3089113ec2faade3dd4974a3c12c",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 447258871,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.6050868",
+    "address": "0x880151c7111a30f8cc2c82f5d9b845fc4dfe097d",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 999950989,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.6050932",
+    "address": "0x689b2ff268f38f56fe592665f1d921209c60dc18",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.6051277",
+    "address": "0xa9afd87ef961eca4f34e2d51268244076436d53f",
+    "name": "Test",
+    "symbol": "TEST",
+    "totalSupply": 1e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.6052956",
+    "address": "0xf5295c077af6b61c3f83fe794b7a830fa596aaa9",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 141421356237,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.6053247",
+    "address": "0xca9d8d749376813135ee12c27347aae4799cdfcd",
+    "name": "Test",
+    "symbol": "TEST",
+    "totalSupply": 1e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.6086934",
+    "address": "0xbdc4f8d8279601721e5a91fb4f8580891c82de52",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.6086947",
+    "address": "0x3e645b6f5b2d72bfcc134ba77c5e6bba5acdbb55",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 3363486690221,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.6266526",
+    "address": "0xd1c48b92866afc5e1c31616891c961bc371b9d60",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.6266675",
+    "address": "0x73f0c62a89794fab6fd6ced7d193aeae3ee18b3c",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.6266781",
+    "address": "0x0f40181ba1d61021395ea08b7f62251de2dcaf71",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.6266988",
+    "address": "0xe5c07622e964d71c2b36864cf6d9e3c9ed35e195",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.6267101",
+    "address": "0xc6b6bc346cd7d218bbbb8ab2be92b58e9a138855",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.6267295",
+    "address": "0xe4e9a54ea92933de1e8c080c8d200217061d63ee",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.6267367",
+    "address": "0x45c585c3a7f8a2ba91af7d95638c3c90bb878db6",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.6269877",
+    "address": "0x3b9949092469b6f6d37c1313e5d7e05917dbd1ec",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.6269952",
+    "address": "0xaa6cb8a116d03fb4d131d663385585ecd71e495c",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.6270188",
+    "address": "0xf8b3dace6657554715005daea3e0caf612d9bba2",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.6270197",
+    "address": "0xdcff6c8e94cf425adfda8af452b9eafbd2d1ca2b",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.6273452",
+    "address": "0x00000000000000000000000000000000005fb9ac",
+    "name": "Demo20",
+    "symbol": "DEMO20",
+    "totalSupply": 5.2e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.6329586",
+    "address": "0x7701ef22742357b9ea053d2f7d8632cfe0de099d",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 2236207868,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.6349827",
+    "address": "0x6233db12f694b9a870ef488d2fcb290950334aed",
+    "name": "GasSwap",
+    "symbol": "GasSwap",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.6386948",
+    "address": "0x7ce6bb2cc2d3fd45a974da6a0f29236cb9513a98",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.6439637",
+    "address": "0x48db497fa61d3991eb9e378ce388a360c549f1da",
+    "name": "vZbyte",
+    "symbol": "vZBYT",
+    "totalSupply": 78846055382820140000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.7017493",
+    "address": "0x688fd85c133f3b864962b0dd17a1b132ed0f38a8",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 54772255750,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.7205914",
+    "address": "0x75b7f3697b8ee4d56267fdde9c64d716a6243d85",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.7205939",
+    "address": "0xc8972618cd43af42da65db3b345ca28da0aeef1a",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.7205955",
+    "address": "0xbf2e2a544deae5545c57214e6627b88a0ee70ecf",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.7208851",
+    "address": "0x6319151ae5f649a57ef16ad70b78fa7e196f6c54",
+    "name": "VRJAM LP",
+    "symbol": "VRJAM(LP)",
+    "totalSupply": 17431270358,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.7212373",
+    "address": "0xab8fa03f7ecad42576c19a85fa11d905d9c345c1",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.7265040",
+    "address": "0x76cd83bc24faae816e543a2dfd015d5e7cf8feec",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.7358435",
+    "address": "0x274edff7be44301b824866895c3b0c946677aecc",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 11359951066,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.7358532",
+    "address": "0xf50996e8c4fd46f59c6dd630451c42a9cb4dfc18",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 14491376,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.7522739",
+    "address": "0x6666e76d1864d333766210b5fda0179ca0f65d53",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.7522744",
+    "address": "0x1d40fac3d55447f7b200eb861869032d2a808561",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.7522750",
+    "address": "0xbc6014f92935a452cef5ea3e0c48b57e7c235b76",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.7522757",
+    "address": "0x828e1697c1e2fa18922640e7830c3cfa3a57227e",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.7522760",
+    "address": "0x0abe58d118c0dbb81d50b4a1da7a855ec8018f27",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.7522769",
+    "address": "0x54e55795f9360d8a95bcf5adcf6b0a23bdadfc54",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.7640023",
+    "address": "0x1d65c6b1b7716da593f054f608a57bc115f51b5c",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 129016364,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.7750769",
+    "address": "0xa75ed10e635042849bded8eae15b362511072125",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 391885187071,
+    "decimals": 18
+  }
+]

--- a/tools/erc-repository-indexer/erc-contract-indexer/erc-registry/mainnet/erc-721.json
+++ b/tools/erc-repository-indexer/erc-contract-indexer/erc-registry/mainnet/erc-721.json
@@ -1,0 +1,110 @@
+[
+  {
+    "contractId": "0.0.1778110",
+    "address": "0x00000000000000000000000000000000001b21be",
+    "name": "Genesis SpheraHead",
+    "symbol": "SPH"
+  },
+  {
+    "contractId": "0.0.2015187",
+    "address": "0x00000000000000000000000000000000001ebfd3",
+    "name": "UserNftMinter",
+    "symbol": "UMT"
+  },
+  {
+    "contractId": "0.0.4153903",
+    "address": "0xb495fd2ddc7319ae5ac4249fcbf3802e22bc1dfe",
+    "name": "Miidas_Collection",
+    "symbol": "Miidas_Collection_3250"
+  },
+  {
+    "contractId": "0.0.4153915",
+    "address": "0x22b2677b2755efad609760b51b34a786e8c02455",
+    "name": "Miidas_Collection",
+    "symbol": "Miidas_Collection_5137"
+  },
+  {
+    "contractId": "0.0.4153936",
+    "address": "0x2809fb581c5e06cdcf5122ede74432a9c1850da6",
+    "name": "Miidas_Collection",
+    "symbol": "Miidas_Collection_1737"
+  },
+  {
+    "contractId": "0.0.4153998",
+    "address": "0x207d96e61a03e05c9aef4974a7771fcbb748dcfd",
+    "name": "Miidas_Collection_2",
+    "symbol": "Miidas_Collection_2_8532"
+  },
+  {
+    "contractId": "0.0.6328870",
+    "address": "0xf21c21d85658fec7a407ba99b41b8764a6c4adde",
+    "name": "StreamNFT",
+    "symbol": "StreamNFT"
+  },
+  {
+    "contractId": "0.0.6447035",
+    "address": "0xb0d4916a3ac08ec5bbfa0434648493ac562c825c",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.6984943",
+    "address": "0x809ab4666be233c491b11e98472115a70817fb5c",
+    "name": "test",
+    "symbol": "test"
+  },
+  {
+    "contractId": "0.0.7490436",
+    "address": "0x104df0a11626af3d03233ac8be1bb7ce423ac550",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.7490447",
+    "address": "0xe911ea6db87ccdc72dd1fb9a5e315f7a55565d30",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.7490768",
+    "address": "0x4ad9b5633d5c0a53fadbd72f00a6046ca6a51c17",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.7490777",
+    "address": "0x07bad17dc76f765501d5bcd2b5bd688c3e58cc49",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.7522715",
+    "address": "0xd989c8c1906120e5ab3d9e899196b095750e8348",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.7546407",
+    "address": "0x664c57d5d606fa2e96ff603927d7910144b484cf",
+    "name": "BITSAlumni",
+    "symbol": "BALT"
+  },
+  {
+    "contractId": "0.0.7802209",
+    "address": "0xb80b3c7a68fb94d45aed4758ed80c001888eb8aa",
+    "name": "FSCO | Declaration",
+    "symbol": "FSD"
+  },
+  {
+    "contractId": "0.0.7802222",
+    "address": "0x1fab9abe71e379599708b951666ae9e9e9cc0827",
+    "name": "FSCO | Proofs",
+    "symbol": "FSP"
+  },
+  {
+    "contractId": "0.0.7802229",
+    "address": "0x5f41bf318082c9fb7b9d737ed3c2c44795f283a3",
+    "name": "FSCO | Proof Links",
+    "symbol": "FSPL"
+  }
+]

--- a/tools/erc-repository-indexer/erc-contract-indexer/erc-registry/mainnet/next-pointer.json
+++ b/tools/erc-repository-indexer/erc-contract-indexer/erc-registry/mainnet/next-pointer.json
@@ -1,0 +1,1 @@
+"/api/v1/contracts?limit=100&order=asc&contract.id=gt:0.0.7812555"

--- a/tools/erc-repository-indexer/erc-contract-indexer/erc-registry/testnet/erc-20.json
+++ b/tools/erc-repository-indexer/erc-contract-indexer/erc-registry/testnet/erc-20.json
@@ -1,0 +1,39586 @@
+[
+  {
+    "contractId": "0.0.693107",
+    "address": "0x0b7fb136d0414b83997fa167702f9a17929b83c4",
+    "name": "wGCeuDIINN",
+    "symbol": "Gtpgw",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2163965",
+    "address": "0xcee8bf33fc5839785ddc59acb96797094d4cde9d",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.2247065",
+    "address": "0x4d0238d2bdfcefb7c5d269bbfbbc0add5354a947",
+    "name": "IagYcRDnxB",
+    "symbol": "jsJPJ",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2253540",
+    "address": "0x8ed4e78e0cb5d97a76cd521c31c500eaed828d4a",
+    "name": "ERC20Mock",
+    "symbol": "E20M",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2256043",
+    "address": "0x178a5de8a851536311163cce58ec0ef6dad590e5",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2263349",
+    "address": "0x3c741adba686ec6b4161c84c3dc0f4465f4ddd3b",
+    "name": "fBajJNjcEu",
+    "symbol": "EQHpb",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2271474",
+    "address": "0x2e2f7b1037a0123a38d3b5b030b6b67f1424584e",
+    "name": "OgINWMHjKl",
+    "symbol": "VSwAO",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2663038",
+    "address": "0xfce04dd232006d0da001f6d54bb5a7fc969dbc08",
+    "name": "Face Token",
+    "symbol": "FCT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2667416",
+    "address": "0x9dff5bf51ca8acc66127b4f9a2091a765df7789f",
+    "name": "pEPjwhIAyd",
+    "symbol": "Bwzsq",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2672282",
+    "address": "0x2daf7c694cc75e6ec416b675c99136d882503034",
+    "name": "dvahgchag",
+    "symbol": "MNHJU89",
+    "totalSupply": 40,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.2672615",
+    "address": "0xab88717c8108d1b10a2b1f4538c7757dc6ccce6f",
+    "name": "asdfgfcxcvb",
+    "symbol": "qwertygfcvbn",
+    "totalSupply": 121,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.2672617",
+    "address": "0x41bbf1ceef96c611bae56eace423df7f2b3aa790",
+    "name": "vghcvajshvj",
+    "symbol": "LKHJU8",
+    "totalSupply": 100,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.2673343",
+    "address": "0xb1fe25e8dd2f70cd1afb72cf156436e078f1016b",
+    "name": "hjkl",
+    "symbol": "FGJK",
+    "totalSupply": 100,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.2673737",
+    "address": "0xbd43724603dd7ab86937b8cb4f6fafe18cff90a2",
+    "name": "hcvjbk",
+    "symbol": "KJHUI8",
+    "totalSupply": 40,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.2673762",
+    "address": "0xf411ca29242de69f1f5ea5b8604ceeebc7cd1145",
+    "name": "bchjbchcah",
+    "symbol": "POUITY89",
+    "totalSupply": 30,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.2826482",
+    "address": "0x973680ce84abdc8339e52642c1d0834c3be93841",
+    "name": "saadrdrd",
+    "symbol": "ertvgvgfft",
+    "totalSupply": 12,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.2947713",
+    "address": "0xcc6e523436659196edadee128bb8ad2afe834223",
+    "name": "Hedera Test",
+    "symbol": "HEDERATEST12",
+    "totalSupply": 49,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.2947742",
+    "address": "0x7b46ff5c534846be08fbaf91b784f0ce87ef4ac1",
+    "name": "sdfghjklkjnhbv",
+    "symbol": "qwertyuijhgfc",
+    "totalSupply": 20,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.2947814",
+    "address": "0xa354fb562197ad064c83a4938c191e3aa303ccb2",
+    "name": "jhgdfsghj",
+    "symbol": "POLKI08",
+    "totalSupply": 70,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.2947856",
+    "address": "0x22333851a0d8851360478fd79f69bb4d40fe14a4",
+    "name": "fsxsdrdwrdr",
+    "symbol": "rrtftrfrfrdrdrd",
+    "totalSupply": 20,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.2947872",
+    "address": "0x30d09012fdbce6fe73e2ed31652bf3978d89cfd7",
+    "name": "wasdfrtyhjk",
+    "symbol": "wasdfgbnjkj",
+    "totalSupply": 23,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.2947888",
+    "address": "0x6feb7d944475e35c0b9976263e0bb0e5e3d90ff7",
+    "name": "bsjbdhwb",
+    "symbol": "cnjdnfjej",
+    "totalSupply": 20,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.2948048",
+    "address": "0x52831c76265e7e79f0dfcf5b50db9eca4f5ab099",
+    "name": "bahcbhc",
+    "symbol": "LKPOI89",
+    "totalSupply": 40,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.2948234",
+    "address": "0x50d1c929023b7a4500ebb8df5201a8450b5a74bb",
+    "name": "vcsahghjvscj",
+    "symbol": "ZXCDSF566",
+    "totalSupply": 40,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.2948415",
+    "address": "0xac9d8bc4cc34a874e7777064cf6ce27d5d7ea003",
+    "name": "IKJJJ",
+    "symbol": "YHGTYHG",
+    "totalSupply": 300,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.2950595",
+    "address": "0x76c677475b2f0a32f322a54b9cf323c3761317f3",
+    "name": "vvswvw",
+    "symbol": "ftfwsgvwgv",
+    "totalSupply": 20,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.2952229",
+    "address": "0xca57765947b04fc263381f5ad2524213e3f45ff1",
+    "name": "Test",
+    "symbol": "TEST",
+    "totalSupply": 100000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2952415",
+    "address": "0xbb7019f155a87e1217e3f51149a50fe06165ceb7",
+    "name": "yVPRYEXoLG",
+    "symbol": "KxQfn",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.2953884",
+    "address": "0x36f0d734a6f9cc5779e78bec49e405be92a670f1",
+    "name": "vcghvsdvdsg",
+    "symbol": "TRYU76",
+    "totalSupply": 120,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.2953958",
+    "address": "0xdbd516a639ef18dd12c49de9cb4ddd67988da879",
+    "name": "hsjdhuwhg",
+    "symbol": "djdhfueh",
+    "totalSupply": 23,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.2953986",
+    "address": "0x14dd5c9c8d095c9a50018df30e29cd9a2170add4",
+    "name": "dfsyyyg",
+    "symbol": "GHF767",
+    "totalSupply": 20,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.2954126",
+    "address": "0xaf9ea1944fc02becfd1c6de3086271df4dddb893",
+    "name": "Hedera",
+    "symbol": "DEMOOFDEMO",
+    "totalSupply": 120,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.2954280",
+    "address": "0x6c7b835a7fb10a5215be649237ed21716550162f",
+    "name": "fcfcfcccff",
+    "symbol": "CFCFXDXESSZZWWW",
+    "totalSupply": 12,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3038071",
+    "address": "0x4cedbb7e96370fbfafe560600e97fd637db24a36",
+    "name": "hsbdhwh",
+    "symbol": "bhdbhhe",
+    "totalSupply": 12,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3038074",
+    "address": "0x9a3a40893decea016c05fab0d073d3eb3a89acd6",
+    "name": "Demo of Demo 1",
+    "symbol": "DEMOOFDEMO1",
+    "totalSupply": 120,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3038248",
+    "address": "0xed9a706cdb290cdefd700ca4bc4826cf3ea3e24a",
+    "name": "Hedera",
+    "symbol": "DEMOTEST",
+    "totalSupply": 120,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3041775",
+    "address": "0x2f3af27e9afe8006fd6fca3a65a52bed5d1383e3",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3121280",
+    "address": "0x77a327ffdc50154964ddef32fa20d918cebde10e",
+    "name": "cDYDXTWkRa",
+    "symbol": "jOxZI",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3121290",
+    "address": "0xafc0613f618b1719f9d74365427a50b9a20f2ca2",
+    "name": "lqOdxJLLZy",
+    "symbol": "HRUBJ",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3129117",
+    "address": "0xf442bf63539472152313c127d0b437745b8c80ca",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3329090",
+    "address": "0xa6048ead10155ccf5fb5b405573e31d012387ecb",
+    "name": "jsbdhwbhdb",
+    "symbol": "dbbhdbehbdhb",
+    "totalSupply": 1200,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3329135",
+    "address": "0x1ddddd96b0a883a8b75c7911f7b79e62a30b6c56",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3329223",
+    "address": "0x911f30990c27c20e4fb00f3d9f021e60900fb3b6",
+    "name": "ABCD",
+    "symbol": "TEST011",
+    "totalSupply": 40,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3329771",
+    "address": "0xa79e44eedad48595ee23cfc9be15ce59540776b5",
+    "name": "jwbhdbhwb",
+    "symbol": "sxhwjdhwgj",
+    "totalSupply": 20,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3401862",
+    "address": "0x872e1bedc28363030b773249835f289f51de3c55",
+    "name": "HHG",
+    "symbol": "HHG",
+    "totalSupply": 100,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3417784",
+    "address": "0xee6a40a3854c204d2353fe46148b0f547c488fe1",
+    "name": "fgcjhvjhjh",
+    "symbol": "KLIO098",
+    "totalSupply": 50,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3418217",
+    "address": "0x09edb69406f2d43fedb481729bef2b795ba7810a",
+    "name": "vchsvcsvddghcgv",
+    "symbol": "FGHTY8989",
+    "totalSupply": 40,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3443991",
+    "address": "0xcdd29dd91bc99eec5036245c23bc1ba881f07d13",
+    "name": "IVPEIV",
+    "symbol": "IVPEIV",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3493643",
+    "address": "0x4abc91a2ce31ab94440d9deb4d3f45698734ea4d",
+    "name": "TESTING 998",
+    "symbol": "TEST",
+    "totalSupply": 100000,
+    "decimals": 2
+  },
+  {
+    "contractId": "0.0.3530078",
+    "address": "0xd89c73d23146dc64765bc8f3bb3cef4477446e01",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3530867",
+    "address": "0xc28fc19131671c3acb175d462f05d28058be2b14",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3541445",
+    "address": "0x2752b008c9f2e91ae4f4ece7cff34fdac705cae2",
+    "name": "Hedera",
+    "symbol": "HBAR",
+    "totalSupply": 1201,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3547330",
+    "address": "0x24c812319dc893ab238bf017ea3249c92c2817cd",
+    "name": "kndjejdekd",
+    "symbol": "ejjndjwejkdjeh",
+    "totalSupply": 30,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3547906",
+    "address": "0x222dad6ecb700ab3fc79a75f97714a43c8466293",
+    "name": "MyToken",
+    "symbol": "MTK",
+    "totalSupply": 411200000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3566742",
+    "address": "0x5dd42fc232126fc1bd659a4d74f487afcab0a4ae",
+    "name": "gffgfdgh",
+    "symbol": "KLIO9",
+    "totalSupply": 60,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3566752",
+    "address": "0xddd6c3c0fb5ed2f9e0b927c5d950d6af5bb56de2",
+    "name": "bsdfbhebfhb",
+    "symbol": "cdmnnbfbfbehbh",
+    "totalSupply": 20,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3568310",
+    "address": "0x40261045e76727d6cd54e774c793a0e4a1f6dea5",
+    "name": "Mad Mock Token",
+    "symbol": "MAD",
+    "totalSupply": 10,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3568312",
+    "address": "0x5b75a9245d9eb125015d0e60ae3d1bd0ef5f3a7d",
+    "name": "Mad Mock Token",
+    "symbol": "MAD",
+    "totalSupply": 10,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3568445",
+    "address": "0x7674d3079541f9ac35edbb9ebf6cf0358b159dfb",
+    "name": "Mad Mock Token",
+    "symbol": "MAD",
+    "totalSupply": 10,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3569310",
+    "address": "0x6ae6c2cd7cd797d8dd322cdd68c827c6b42806f6",
+    "name": "Mad Mock Token",
+    "symbol": "MAD",
+    "totalSupply": 10,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3569324",
+    "address": "0xfeeb88d6fb3a9025ec2c261de8a54a9a47ab8b81",
+    "name": "Mad Mock Token",
+    "symbol": "MAD",
+    "totalSupply": 10,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3569386",
+    "address": "0x8321659f78e2f97b4dfc8c49f4bb894c8ac2d7f0",
+    "name": "Mad Mock Token",
+    "symbol": "MAD",
+    "totalSupply": 10,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570643",
+    "address": "0x00860bc186ddb912f052e172163946e116a9afaf",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570644",
+    "address": "0x37b0075c1869c65ca7ae14092701ced3681f856f",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570648",
+    "address": "0xff9e5a49bc233e4b4e9eb1473bb0f9dccf0297b5",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570649",
+    "address": "0x4274cf75da44339cb357f2dda0a2f7618d2266ca",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570653",
+    "address": "0x09dbda99673d9ea4c73ddad1b975e5d557f51a4a",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570654",
+    "address": "0x2afc7a247514d9599d56403386e9d70cffce9e62",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3570658",
+    "address": "0x964bdfda8098a53a10ccd3af9e41dd2e39f189c6",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3570659",
+    "address": "0x3718b71c987aeeff9858a8bb244de75b56872984",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570664",
+    "address": "0xa3727d0de2af014e11b74ae9c06cf492b13ccd5c",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570667",
+    "address": "0xd0d48cd1d13324c709533f83ef933a3c25a5e3e9",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570668",
+    "address": "0xd66680ab583c5dc33da7993c75beb0f557377927",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3570671",
+    "address": "0xdf4b33b258249bfb7b7a089ecf55516c3f6f9c98",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570673",
+    "address": "0x06234bfec5dd39cb260053084095a92c19d7ec6e",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570676",
+    "address": "0x3b09de8e6e34da7fb080593d1110d76f5c79cdc5",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570679",
+    "address": "0x9835245b9d915fd74929c2a06516d83d696dc3ff",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570680",
+    "address": "0x1c888561ae98b83d130ba961024abc04e2c8b9d9",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570683",
+    "address": "0x718c8905595439008e9bf3edca39d40b790df4fd",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570685",
+    "address": "0xa0d57358e1bdddf3a55f8860c301cf4428bfbcea",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570688",
+    "address": "0xdb66d1894414f4eca2dfc64002a9c10cc87479dc",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570691",
+    "address": "0xd6fbc989bd362858718718fa40eca4f0fa1f60ee",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570692",
+    "address": "0xb87fcbc0a7469955401b36f0f38ba77eb0f1943b",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570786",
+    "address": "0xa73263dd447232d77784390e5894ed3b62dd6dfd",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570794",
+    "address": "0x9320b6d2adfdd955a5d80f764f80fcb5074fe402",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570798",
+    "address": "0x1abfdca9e0d896a7ccebb368cfbac1d926ce6088",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570800",
+    "address": "0xf27084897e1cabd8aa26f797dfb406437845813a",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570802",
+    "address": "0xf567dca998d5394fe5de5304509ea3369791bdc8",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570805",
+    "address": "0xa1fd650c9cf07450443ffb1758fa5aefebfe245b",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3570809",
+    "address": "0xde07000cd747f7097d5a6a4c63c0320d80136c12",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3570813",
+    "address": "0x81129c90ab7cdea8c9fc622aa69a49541e0a2235",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570815",
+    "address": "0x27a0e666aac00e0360e8e6028c8457790f0b788c",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570816",
+    "address": "0xe13d0906df48fbd46ee0e6388c714316975d4c1b",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570819",
+    "address": "0x6f9e06ab86badbedfad2821a514b0add8d101dd0",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3570824",
+    "address": "0x8eae6e1133a47eef162608274b8ff5783099c512",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570825",
+    "address": "0xdb45c8cf3cbab79705390948b5dc2e203445f7ed",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570826",
+    "address": "0xb45684f0e2ffe73a6a7a866b1f719be8ee9f1fa8",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570827",
+    "address": "0x7b2e392b56d965d0add22f79ac344579f346c89a",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570828",
+    "address": "0xa844af39de036b9f2ff260991526d89a6b6b7cb4",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570829",
+    "address": "0xb48d89c22bb9f5737681b6a2b19fda250000ebfe",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570832",
+    "address": "0x243f5ac896fbf99f91f28ef6c6884adfd0befa62",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570835",
+    "address": "0x72ac99dc9371f19e7621aba03bde8ea1755c90a2",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570839",
+    "address": "0x2405f08a0a115d70dca855c9261cad6bb488941d",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570840",
+    "address": "0x8209f65d6a982f457ccbb8b0f6df5e32af533f0e",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570971",
+    "address": "0x5bca61a99599f8b3caf9d6dff5311b518d18df0a",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570972",
+    "address": "0xef78dab9677849e9a2e5e7e71f113ceedbf7b7ad",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570973",
+    "address": "0xf84f755b2a6b3db8d395e98229f4864e9908e4a2",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570974",
+    "address": "0x7918597848c065a929bc5d7b33fd9c95cf4c19d5",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570975",
+    "address": "0xee000d056516735cf4d8be8ecfb56a4f8803ca9c",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570976",
+    "address": "0x5cb3e44e72d1264110c54ccbe7b92bd83cca50e4",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3570980",
+    "address": "0xebc923a38145002d38d66c8ac12f6c4d7053d92d",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3570983",
+    "address": "0xb8ce0b45ff4cc57e540f1202a4f84432b5867aa7",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570984",
+    "address": "0xe0d8097069446ace6028d928253d2fd4b94cd42b",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570985",
+    "address": "0xabb84a8373a323de95209c3f3acf2122060a7c8c",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570986",
+    "address": "0xad4df27ef4d198ebb39e483e64ede53e58f5cf50",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3570988",
+    "address": "0x14f44fd2eb5d67e00bc8e46f6d063f1ddad6728f",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570993",
+    "address": "0x59d6d1db33fc2d2a6db000a048e486a36417f564",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570994",
+    "address": "0xf898922ccbb493b614dcdabeecd8c6e121d92635",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570995",
+    "address": "0x9529ec314fb8d6f8fc699d68438c7f97e99269c4",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570996",
+    "address": "0x630ce04f66c91d91a605e6125aea3bd4506ce4f6",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570997",
+    "address": "0x784a292492b74813d9e4558cf9c2a43af1083cf1",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3570998",
+    "address": "0xdf2a095c8aa1af8b99e2f9c1df59310bc6405a15",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571001",
+    "address": "0x0bba8915b149346a7a32deccadf73d1a3e8a1b3e",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571006",
+    "address": "0xe6ccbf4011d19996af6871d24a9c2f5f2bc88aab",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571008",
+    "address": "0xbb28d9089745d2d812e1f11b7ac537da6bcc3f5f",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571049",
+    "address": "0xd0149a35b737e02fddec3727f6363a29cf0b7657",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571050",
+    "address": "0x4dae675adb3e43bd091ff9034191fea4b29530e5",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571051",
+    "address": "0xd81e30fdc306dce75ad48693ce3e7343698586f1",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571055",
+    "address": "0x85190d189f6810f7ac68aec89392d919c385e939",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571058",
+    "address": "0x689a7100f22bca67300b11d213f5c117cd5c8a0e",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571059",
+    "address": "0xdbb4d45dcbffda6d12296343f07244f93756cf2e",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3571060",
+    "address": "0x35f08a415810712cad715d2fc0e36701708f97fe",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3571061",
+    "address": "0x3b5e5475be72507039de19d932533f9b258fa60e",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571066",
+    "address": "0xf6fe7a8c0f0dc775cc1acc7f76bb4216e4074cbb",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571068",
+    "address": "0x1a210951d48c5059d351b3ed69c9a3ca0c47cd3a",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571069",
+    "address": "0x67f65443640df92513590ba70405db72eae62d99",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3571072",
+    "address": "0xe593eeb87d1b4f14194297651cfce26327051df3",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571075",
+    "address": "0x0be7a5ce6545311f42a42c4849e6e7649e5998ee",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571076",
+    "address": "0x2f7d3751b47c5c785614bb90b264ddaf005243c2",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571077",
+    "address": "0xc29dfbec2fb6b6cac59d437dea84073e7988f309",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571080",
+    "address": "0x442469975dbda62492e4f029cc6b5dab755a12c9",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571084",
+    "address": "0x721e0059811d800bac09dd84c82c0692e040c7e3",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571086",
+    "address": "0x5c5b3c9baac13d7cbf283ad52e854e227c7f7467",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571087",
+    "address": "0xbb29ebb8ea9b0af893abff1adf86811bd0e344be",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571091",
+    "address": "0x1065a1fe03f9e97479938bb4a06e0ba6537b821f",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571093",
+    "address": "0x12862190e46ebfa595d976be5353c38e465a61c6",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571212",
+    "address": "0x162d84f6483c2e4e1e7c7f5a245487ce20e3761b",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571213",
+    "address": "0x904fa06e8ed814f17448fda77281dee04a1ae0e2",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571218",
+    "address": "0x8cc10a58bc053b6168929674cd93ea6f7eabc1c9",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571221",
+    "address": "0xfbed5e50922dcd6fc3cbdf65f3a3219946a3cc5e",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571225",
+    "address": "0xcdced4db1b3d9db5237ad886e94a4f5e094bd5d6",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571226",
+    "address": "0xf9ba477a615b9b91d3a6ce4baf36a7a81b3d1618",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3571228",
+    "address": "0x48e6936695d98ce84945bc3406f7936c97b6d939",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3571230",
+    "address": "0xa19d21be2feaebbecfbea03241bcef8d321ffc54",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571231",
+    "address": "0x806d461f07eb991d25d2c11b8f26bf8f7f678b28",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571233",
+    "address": "0x0bcbfc78779c028de8ea9975e62ab019dab8b640",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571240",
+    "address": "0xbcde427c60bf1e55a1f9e3a1196384a7a47d64c2",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3571244",
+    "address": "0xb9bd56caf976bba5f1fdd071df92fbdd86497310",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571245",
+    "address": "0xcb74823fc2e69bcb7ee23e3b38cc32a1632ffd55",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571247",
+    "address": "0xe8513af453e676393056fee62a6286601707a08d",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571248",
+    "address": "0x0a426ce4c5fc1936b5dced926597d5bdd8dc1aba",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571249",
+    "address": "0x72f9106f92876c222d21634fd712fd886c5c0449",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571251",
+    "address": "0xf9b4d0f6050e1481ac39bf519167ea9363ac1c6b",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571253",
+    "address": "0xd933d3215d5522f6163638e316b92a9d3ff915f6",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571258",
+    "address": "0x115070bcc1cbad441e0cd60d09fc78500d3c7549",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571262",
+    "address": "0xfa098e220134988250d99dd391c75cbb8c416bcf",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571265",
+    "address": "0x05a525d181cdf2880809694e457b7540056764da",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571331",
+    "address": "0x9e530885b56952c50b0d88224d391cb46cf04a8d",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571333",
+    "address": "0xc4ece0c55e838c2a9b61f316179cfb42d2b804dd",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571335",
+    "address": "0x0da17560ff902513ac9770f302de3baa4f4d255b",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571336",
+    "address": "0x317262ebb211f963215f3319c3b753384077efb8",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571337",
+    "address": "0xe18cdaa71b76602e6899342fc15e5a64729df59d",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571338",
+    "address": "0x0bf451aa3831a92cc75462dd1c3c159a2d990f0d",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3571340",
+    "address": "0xfbb3b7fd116b7585cdccee12137ef55cd940edce",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3571345",
+    "address": "0x17c09fd4d0eafd80ff57bcc241b5d1588f1e7b4e",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571349",
+    "address": "0x042e441d2aff52a0e8e00d8b516c5fea99613216",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571351",
+    "address": "0xc176d7590fc0f97beb71f258ab838bc6ea9742e5",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571353",
+    "address": "0x5f597657f2750ff412515da71b52543e1ccdc16d",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3571354",
+    "address": "0x95d88f4f957c5a4a4640830b85b1e4a7d5d065b2",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571355",
+    "address": "0xd124de0ced720740d69248618d53821a274ad0c0",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571356",
+    "address": "0x8529350f786654b929a1fd8c57264bb054f8ba70",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571358",
+    "address": "0x40736a621838536d786e01fbca19a6b73965550b",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571362",
+    "address": "0x660e686ccb755eed3ba35ffcd8eeddb54374d26b",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571365",
+    "address": "0x439dc862d8a391fd175d8ea037ba1aa7dfc3aea9",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571369",
+    "address": "0x1f297bd312c93757a911a75a3b1bc0a82ba5255d",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571370",
+    "address": "0x07752586ed4cb7a5a43f1b23fb53b5dfc46cf223",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571372",
+    "address": "0x89d1a0dfe2a7449885b3ade1ae8c89d8d6e874b1",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571373",
+    "address": "0x562193b463261663c2ea39081126743b78c4dce9",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571404",
+    "address": "0x20a95266119fb5eca12027177acba80688d9f351",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571405",
+    "address": "0x9ab5ae6dfd1cf943ea3a14aa81692a4b3c529666",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571406",
+    "address": "0xab5c3c56ddddee2cf396b8c8b8c0b0822768e683",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571407",
+    "address": "0x91aac61fc4f36388ebe8de1010a775751c4b3ef4",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571408",
+    "address": "0xdc97a8357a5e5d04eba14026e5d65455b735a67c",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571409",
+    "address": "0xad107aa01a72470e753a3a9497d7a0a9663291fd",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571410",
+    "address": "0x1e762cc0c014c530a1d24ab68c47b01030bc3bd6",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571411",
+    "address": "0x41a7950f1a4bfb7c8b710a4c777c092d2878f279",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571412",
+    "address": "0x6d2b41e99a154d96f2a32a14afacc286ba51bb3a",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3571413",
+    "address": "0xcb18ac4b36896aa466852e161d5f4e4957d0eb14",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3571414",
+    "address": "0x55ad882cbc5c158d8283fc8c62f0c66357aed21f",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571415",
+    "address": "0x19803d0f88b14b36666770137c748dd02e3f1400",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571416",
+    "address": "0xabb2606a03eab0c54de26ea098f36a8dfcdd0a0d",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571417",
+    "address": "0x534aa386b99bb8b569348499b46bbb4fdc4f651d",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3571418",
+    "address": "0x8eed6eae536d402f9666e186562f26682219e1be",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571419",
+    "address": "0xd0633502e3d317269bc623e612545cf951173469",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571420",
+    "address": "0xd2ffb0eb0763d048a01060c685e80e5e36481e46",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571421",
+    "address": "0x6ce7b16983a6b88346e57019323afa4818c07532",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571422",
+    "address": "0x526d86d6154227e7e32b2ba7eea72e9515d06557",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571423",
+    "address": "0x22e510bee3c4544ce7d9d786c310b871e52d011f",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571424",
+    "address": "0xa0dfdb9ddf3722af74f584be6bab6c685a196e7d",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571425",
+    "address": "0x574be4cc392b72667fc9f32ede26d3d3d0b07631",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571427",
+    "address": "0x67d4bc300749558464d59e1d3953734625baa372",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571428",
+    "address": "0x52590a92d3f6162af8400747d97cea45bb108f9b",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571461",
+    "address": "0x517aec439edb9f94d03378dcf99d5d3ebcc4f3cf",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571462",
+    "address": "0xa9fbd5caedbf98371a876616d9f05c6be3e747e3",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571463",
+    "address": "0x8708bbb091839c2b28e707a830c85abbbc885e8d",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571464",
+    "address": "0xd11c4e5d08892e30611778bff1ab760603e28805",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571465",
+    "address": "0xf2ed34e3fdd8d7e2cf46861b8b6cbbc816d51f7b",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571466",
+    "address": "0x2397473737bee8e74c348d5c7e4084a981877e7b",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3571467",
+    "address": "0xd65324f32ec0c77d83b8b9ff07dd0df72363c1cd",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3571469",
+    "address": "0x80b4a8c696ccd0d7738abdef9d3bf31ee27db17a",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571470",
+    "address": "0xc4edda65770e7856d2dede600dbedb568156c3f3",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571471",
+    "address": "0x6519853f9a9d092f41a39bb5c24e9149b107d064",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571472",
+    "address": "0x50ed666af1b811e37f9e8c59c93a24aed763cb6d",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3571473",
+    "address": "0xaf2f7ea463a5adac17609a5ba675aa4c95b672d7",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571474",
+    "address": "0x758b2722fb01362f23cb86ee77cf2e77c68209ed",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571475",
+    "address": "0xcbb404f90c1a4978903bdbed5d42f2062fe3a7b5",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571476",
+    "address": "0x0ecd8fdb90ca7b20b29446d249a56db785bbc550",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571477",
+    "address": "0xd62e3e1dbf9b1e735ef11d40191bd81712c0905f",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571478",
+    "address": "0xd236d13e40a86aff8bab96b724a2f6155e74af9a",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571479",
+    "address": "0x1e1bdbabbfe0f6991108f62ed010ab2687f818fd",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571481",
+    "address": "0x8143887fcee5a50c92b953c825c2495a4a06ac83",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571482",
+    "address": "0xc18abbdae10dc5bb5042fd7723f739b821ba15b1",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571483",
+    "address": "0x5a0fba2854bcdf6e51e5edaa379687684ec59f54",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571486",
+    "address": "0x243f0051fba7bc6708308fe92c0b2c31ffb017e9",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571487",
+    "address": "0xc50946486bb7ef1780df0c7120b4476e82e0fae8",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571488",
+    "address": "0x1c3e7ec680d9ae90cd4242c3c439824f624cfb20",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571489",
+    "address": "0x2103c76b2a5440288a1781ac4b4b19f93e18dcc2",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571490",
+    "address": "0x2620ad2a817fad57d33dda9bbb4e0d64348e8b52",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571491",
+    "address": "0x437feb36758630eeeb88041bb2b709bd991bd809",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3571492",
+    "address": "0x3aaa347961d6be1536fc5505b7afbc1df72e2dde",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3571493",
+    "address": "0x6515b51fc2ea4efa961937302c43ffdf7f8af07c",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571494",
+    "address": "0xe0b96f32cb6225b6dcc932fde2678eca1075b018",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571495",
+    "address": "0x9d25766c08704b433d20abd0372820b321f03a93",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571496",
+    "address": "0xfda1e50d10a0dace4092343297a618fb9e26cdf7",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3571497",
+    "address": "0xeb675f253274482d19fc86e8d56b1881f79ec00d",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571498",
+    "address": "0xd1c290c8fbe7e2cb2b4c0eb4dfafb6a057a31277",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571499",
+    "address": "0x653abbc1d588f3ec2909aca39ab195139751878a",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571500",
+    "address": "0xc0b89b96050772ba472d2d60db4051cc56b1a160",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571501",
+    "address": "0x3695f2e5711ac19f4704b042f83090dcaecf2201",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571502",
+    "address": "0x017e1a861539bf01d202d81d018261b4d5fae9c1",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571503",
+    "address": "0xbba4546f7ada39ae926d27ecbdbd3de54d3e3e85",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571504",
+    "address": "0x0aeb71b161ea2b2b0074d9ddc687ebd77e8f5296",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571505",
+    "address": "0x3b84681a557eb3fcef20045f817b00d31a24405d",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571506",
+    "address": "0xc5651ceb43b80e7216b9f13d2434b72acdf30685",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571509",
+    "address": "0x6d777c673a254e8c4b43c991ff0a7511344bca3d",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571510",
+    "address": "0x09cc6c174880a6ec9c0e4c67ad9e1352b678a930",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571511",
+    "address": "0xd1c2ed608ac00d832f1ed04e452c9b9890b9d9cc",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571512",
+    "address": "0x5634c08083075fd1a1e7063c2598e12814d1a612",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571513",
+    "address": "0xbb118c2144ad3b13364a7b50d209bda6b53595a6",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571514",
+    "address": "0xd4c25191652d96e7db02cf70e7f90afc976ea614",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3571515",
+    "address": "0x79832055d3f6195aa2088d73f6e3ad0257ab536b",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3571516",
+    "address": "0x29fac4de2ef7e953f95d30d644be5bdb54b6aa85",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571517",
+    "address": "0x9108b62078d8dcdcf753452b18875b9e46c9ab51",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571518",
+    "address": "0x4ed2f58fbf592df131514fedc4b4d38107c0e226",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571519",
+    "address": "0xec0d6205649246ba6d61211012ec893d519aed1b",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3571520",
+    "address": "0xa5508fb408e88461d668adf26c338e256efc899b",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571521",
+    "address": "0x4a5632cf55fabd0fc1292057dcf8db24f6ef818a",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571522",
+    "address": "0x5eaa13049de639c9a2f166c02d454155a8c59851",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571523",
+    "address": "0x697358004d1b6cf7192665abc345acf177bf3da9",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571525",
+    "address": "0x4bbc28c1a588778129115bca93ebb7345b31f243",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571526",
+    "address": "0x31dde393592ffc1bc15d97ef404e92add03d1540",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571527",
+    "address": "0x762bd2de60dc860476628c6531cea0212ed0e87a",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571528",
+    "address": "0xd1a6cc5c9e0ae7b5bfeaaf2508955945310df7c8",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571529",
+    "address": "0x8b3eefe590140beb774105fb8632887feb5d2517",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571530",
+    "address": "0xfe5c3aa1585425ff8a6d3f2e9f39206560a40b59",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571537",
+    "address": "0x81b0d5dd875a4c99fc1c669530f4540b3c659c47",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571538",
+    "address": "0x05df1ead374e7e4d6fc0ed54a41212f460aaec65",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571539",
+    "address": "0xef0c6cb0187d8fb268b8b3e11453f8486cf01b63",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571540",
+    "address": "0x4969fdbde449d64c741d6b3e497cb3df139f3f80",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571541",
+    "address": "0x7d7532cee5eb84ebb5a17dbecbdea9e1089b5cca",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571542",
+    "address": "0xe7be109d14bd2a0288ca04f28c691548db537b78",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3571543",
+    "address": "0xf1162b44c09c66c2dbfe8267722c68210bf20a31",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3571544",
+    "address": "0x273a86adb2c8ebc1fd11b6c99b1fa41a6a023fcf",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571545",
+    "address": "0x0121e0c7298e876234b62ae1583fd1290dc7e28e",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571546",
+    "address": "0xa55ea9ba660b41f5969c54f028e72ad27f3292ea",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571547",
+    "address": "0x40dbf3102d9268ae43de8773c725776f851fc6ba",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3571548",
+    "address": "0x260f30ba5b2577b01281f90508d724fdc009b3c6",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571549",
+    "address": "0xfb9904c68fe1d997eecc5a135cbf124234e1966e",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571550",
+    "address": "0xe8ce3ed51d559e78bd2c82b48b2f42d01a2ea91c",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571551",
+    "address": "0xdd4534536ff80bd3764d73c9ccbf07308197deea",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571552",
+    "address": "0x54fb0508556e74565a81b8bd38374ea9d49c2b14",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571553",
+    "address": "0x2c113dd57d68404190a1d4f57d80f69b750b8411",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571554",
+    "address": "0xb79d838757be4ea8e56c2dc9e9a90fdfdf018050",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571555",
+    "address": "0x29a0ef295cf0bb365866ce2a42d1f0eac3e0d098",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571556",
+    "address": "0xc7b746672719937f4a0f7d051bcb1df07285f182",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571559",
+    "address": "0xaad16558106fa19aa2e35ec16e82fa192075b6d7",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571563",
+    "address": "0x25b00317366077bba18bd4bd26910acb1904320d",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571564",
+    "address": "0xb6a422940ef0389562a13b7d9a56918ed954cf93",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571565",
+    "address": "0x6eee778479f2e67d414fdc46d6b245ddd16375bf",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571566",
+    "address": "0x1e3a8e5e8f4c1b4450655d5cf9f2ee74686a4e3d",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571567",
+    "address": "0xb5f9cd6170f620569a04221f5936ad31d612ba5b",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571568",
+    "address": "0x1618bb9d1c5556a9984f0bc0918093b205f3ffe5",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3571569",
+    "address": "0x19237141531b39bbbd80812ba61180d188ec316d",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3571570",
+    "address": "0x21325c1946e5cee3a19e793154200afe7e88f1e8",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571571",
+    "address": "0x094c726205efa324eeaf45ccda3b0c69aecccf9c",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571572",
+    "address": "0x3d2ea5fe2814a9ed4101bce8ec2f8c311a67d570",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571573",
+    "address": "0x5924565b2a9bdc2f68597f1a0f3b911752ce22b7",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3571574",
+    "address": "0xe9342e6ff4675bfe18707bb609e2eeb15fd300cf",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571576",
+    "address": "0xb54dfef6e0a5bb4a20f30bbfc32cddd8474c6060",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571577",
+    "address": "0x711c6aada9d38c961e2843c50b5b691628720c1d",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571579",
+    "address": "0x89558336ec78b4f759ac3b286f720a25b5097e8b",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571580",
+    "address": "0x01ebf0b2f2fbbdb635c10573043a86206f5fd944",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571581",
+    "address": "0xbb3817ebfddd8d652173aebbe72ac6a53fb24da4",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571582",
+    "address": "0x76b5620cf904c2187ff27402298657c1ba6485c7",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571583",
+    "address": "0xa43ea5a61aca16544efa0118a87d216c875bcf58",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571584",
+    "address": "0x2c8a8392d2633b04f7fa50475fa275d3baa3e132",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571585",
+    "address": "0x3b27406e1e1334b9a2d52a06b4b89352fd067337",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571588",
+    "address": "0x6535b6f3a65783e9b02188f77fed2a5190ea9789",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571589",
+    "address": "0xfeb9039d58dcf62b2f8616f842ce9383e13bfc12",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571590",
+    "address": "0xdca3a9679d24e7cc27b2b60186779f7da6bbb529",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571591",
+    "address": "0x6a130d143832742958abfc11d14af53b6fc6159b",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571592",
+    "address": "0xf7a56c3131ad8371bfb56353fc54a199c6bdc05a",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571593",
+    "address": "0xeb8f98fa411cc2111a85160abca87d135494732c",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3571594",
+    "address": "0xe3472afc2126608484090846f2372c1fa6e373b5",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3571595",
+    "address": "0x4dba0d471252d7834694e64373c03e1d14778aa4",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571596",
+    "address": "0x3bd852e3b71d7c9e38d511b5a3e93bd991b4e8b0",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571597",
+    "address": "0x709ec3f9212dd98d3a9c53c8b56c66877363c906",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571598",
+    "address": "0xae92f94d95f27019b6aced98b4f041df252cb409",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3571599",
+    "address": "0xec42b28b769717727e964bf64560c9b4e90655af",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571600",
+    "address": "0xa17f08078bd5e8c1936f82b6d5c4f38eee7cc308",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571601",
+    "address": "0x66f114599fc5dd47a8d11d24dd1275b5d9761619",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571602",
+    "address": "0x24fd9e8dc459fcc8d244858fd3277fe8aacd4037",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571603",
+    "address": "0x94045c9d3400aafc90198b063ded3451ecbee7cb",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571604",
+    "address": "0x03be27f3f35bdd3dba6c106911574f892f3c4f96",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571605",
+    "address": "0x7652b0ba9a89f661c8ce4631ba95c90b65289323",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571606",
+    "address": "0x45919eaa8d5bc70d2fbf463bbfe0bb61a498130a",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571607",
+    "address": "0x79125efc8941a4d6c61ebf9a755841022f8ac7cb",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571608",
+    "address": "0xead2407300b54f9248c66541893092bc4b92ebf5",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571700",
+    "address": "0x1e50b0c73b436dca1a928626ac1baf47b212ecf6",
+    "name": "Mad Mock Token",
+    "symbol": "MAD",
+    "totalSupply": 10,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3571707",
+    "address": "0xf460fdec387c2d68d8e6fa0bbcb082f53cfead28",
+    "name": "Mad Mock Token",
+    "symbol": "MAD",
+    "totalSupply": 10,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3572907",
+    "address": "0x7cc100691adadb694e696299725978319cc31458",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 5000000000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3572908",
+    "address": "0x5fe44db4445faee4d167d6bebcbf6536a5cf314a",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 3000000000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3572909",
+    "address": "0x190d0e402c265708c601eb68932764c67d630f0d",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 3000000000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3575105",
+    "address": "0x598f9f5da9b10521f3594e79820882c8e02ed8a0",
+    "name": "Token",
+    "symbol": "TKN",
+    "totalSupply": 1e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3575127",
+    "address": "0x7825a11ef235298e76f042bf872721bb933434d0",
+    "name": "Token",
+    "symbol": "TKN",
+    "totalSupply": 1e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3575136",
+    "address": "0xa0acd5d1281c2b2fa1a1334b0455c8250964e26b",
+    "name": "Token",
+    "symbol": "TKN",
+    "totalSupply": 2e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3575199",
+    "address": "0x637f1392b71fdac399bcf5690b0582b2fc641d1b",
+    "name": "Token",
+    "symbol": "TKN",
+    "totalSupply": 2.3e+22,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3577999",
+    "address": "0x526033a4d969eb8066a78066b5ce434e200431b9",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578000",
+    "address": "0x163fb4a55031032ed66447728bf3ddc2f456cbf7",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578001",
+    "address": "0xcef9c4da020460e45afbec67a9c1356cfcea8b03",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578003",
+    "address": "0xbe52053b4d88bd3a6d8a6fa578ed78cd36a30df4",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578004",
+    "address": "0x9960da9f467201a752f2efbbe1e67ce843b8ffa5",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578005",
+    "address": "0x9adf88d61063fec0a63c2c6e334224a35cbd779a",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3578006",
+    "address": "0x8ebf690afe944ed82ffa69e3bb703b6ce1864614",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3578007",
+    "address": "0x5ab9c8d5529eca14040f609d15998c37b8e4fd8e",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578008",
+    "address": "0xb9b160adefb6bbedc96d61e4adcd501db614bdf2",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578009",
+    "address": "0xf319d1d7fb615af8f2f3b748257cfb450c0f6232",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578010",
+    "address": "0x341a883badc7b72ccb140dd3b812994d8108f1a1",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3578011",
+    "address": "0xc3e5c9d3ed99f22830e1e1de9094ad0dcc75b474",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578012",
+    "address": "0x297724505c20ee2fafccd42a5f2d5c1c95d74621",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578013",
+    "address": "0xf65c9294882c8627cd144af62abc69ce0dca1d38",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578014",
+    "address": "0xf854c9e3b346086404186e33a2c6e83d1739a4ad",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578015",
+    "address": "0x795659a40c3e9c9a9503221273802fe9d982bb0f",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578016",
+    "address": "0x1d780d313de691ffc0cb558c6eda3c0273e4b887",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578017",
+    "address": "0x6025812a8208d897d33773001ea7632c30c9f78b",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578018",
+    "address": "0x6d3ff23276f49541efe1a5fef09cfa3f61227363",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578019",
+    "address": "0x2906d84dfac0c1225f55ce104e16d3cf75b989b6",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578020",
+    "address": "0x363612307a7f54a563bf19609db078c1ade73247",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578023",
+    "address": "0x9079dc8eb71d9fad73bea91adb4ee395b33292ee",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578024",
+    "address": "0xf84427f6cc4d39f8e17d8304a28daa33a09255f1",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578025",
+    "address": "0x77e2ff19217f476e25df5b718d66b9a9e51076b6",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578026",
+    "address": "0xeedf8e73112ce2bbfb38135eee768c8e2e5a03c9",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578027",
+    "address": "0x6104aacaf4291e4f7a81b2c6b72bf01c03aefd38",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578028",
+    "address": "0x7093365401b7e0454eef19ff4b0617b9007cceed",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3578029",
+    "address": "0xb7766ff8d3c09590b7b406597b3383daaf1d2737",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3578030",
+    "address": "0xa22a3dbda532723356506f5162e5a0dafbb75142",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578031",
+    "address": "0xee14599b62f6476b4ec597326249b16ee4657890",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578032",
+    "address": "0x2de4502109db496c54be93fac5d77421fdfc3eda",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578033",
+    "address": "0x47a9dd2aaf8ffc20b7ec066d1454ad074468b3db",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3578034",
+    "address": "0x77344f0c8cc4c6a612d901dc90f5012ddb8b8b80",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578035",
+    "address": "0x72dd4c4649ee09f04bab8ecdd7b7bb1dc38f8f65",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578036",
+    "address": "0xcbad57f53811e9af110e4a778acb2b04a554898d",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578037",
+    "address": "0x28a7373700bbd639a57876fc8ca5006c7765a389",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578038",
+    "address": "0xc0c76ab213f5ab33ffb567342cad593055f51899",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578039",
+    "address": "0x70eab2e16a07c443cf45a3eefc779370183fd590",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578040",
+    "address": "0x855334a3aff6d56ba6ce0aaba775425f5ea83bf3",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578041",
+    "address": "0x5bffb2550e7526374859968724923f8f25a2300d",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578042",
+    "address": "0x52491b69cf78089cd95d5d73d5e99a316823560d",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578043",
+    "address": "0xe661a41a368b6804d53dd417b124da0ddf16527a",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578048",
+    "address": "0xb47f2cbb7c275e924e735b590e7152b5ff268584",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578049",
+    "address": "0xdc4b1b626662625baea1940c7e832ca487ad16bb",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578050",
+    "address": "0x87c001e1a6571be08e3c72fa3e54afe6c18c5cb7",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578051",
+    "address": "0x7262dc66b609e43c1a626df6b622a4217ba33c51",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578052",
+    "address": "0x82094ed45de8a6b3666e06117385b29e25569754",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578053",
+    "address": "0x1e0917e39d9fb2aadc239e3ab48182afef906bbc",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3578054",
+    "address": "0xe130849d777f7c89cc8bc2d9341a976e917f7093",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3578055",
+    "address": "0xe670fe6669efa81daf6d23d73f74da4fc58b0449",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578056",
+    "address": "0x41a4672ef1ab8c51ce9e54ef7c8c7f902745cb26",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578057",
+    "address": "0x627fe335b833478f02c037321190c0839167195c",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578058",
+    "address": "0x388e58150299056ca95e56c5097a8d1e116a8b15",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3578059",
+    "address": "0xd5c8fdc039d4490bc85b50f256b6f7e15432b1a0",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578060",
+    "address": "0xee438b423e1a3d9204529e96838119d4d4adb1c6",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578061",
+    "address": "0x9b6fe2352ea1fa581ad42dc6445149df55e515d8",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578062",
+    "address": "0x346bdaae0f39d18775c765f48a4c866186d395ba",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578063",
+    "address": "0x22c20f7c476e13df4e7bee7573e4c4da03905b5c",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578064",
+    "address": "0xc424b2a7f61d842d7a8ecfaf3dac0050544aeea4",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578065",
+    "address": "0x5e53fd8a6f30cbe873d9497325f23c93754421d4",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578066",
+    "address": "0x891dfd43e24d6c6b72029e0ec4b96efa0b968240",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578067",
+    "address": "0x83e078d23a4bd7137aceb05f2ea5c99094016179",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578068",
+    "address": "0x1d16ed913facd1dc9301ddafcc3e5f0d57157161",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578071",
+    "address": "0x034cfd69fef72ac5a865b6613129a747e3f962f9",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578072",
+    "address": "0x997ac2bf5abb6b468a68f7f061d55c07d4b41b5e",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578073",
+    "address": "0x36a200df9aaae92c808cd270174f39ff5b811c32",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578075",
+    "address": "0xf4c848bde893e72ccd23100807c68f238ed7bcb2",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578076",
+    "address": "0xe7a0e713b4bc91c71c14737587fbed7567933462",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578077",
+    "address": "0x2900d2a43edcba9fd8422f437697697736b01894",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3578078",
+    "address": "0x17bec8cf9789186892795b17e250e9cc29b7609b",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3578079",
+    "address": "0x2a2ce6e1342a9b3ae84f83e8b1bfbd8d1e0e7d99",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578080",
+    "address": "0xf21cd23afb1b24d3ca4e5cdb7c42b3fa576e551c",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578081",
+    "address": "0xad08e6d195fc2cc8b0c513aa652f3980f9ec4b3a",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578082",
+    "address": "0xd4c5841a62f47cd287da82d5256c6bcff81c3b7e",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3578083",
+    "address": "0x1157933f27a8c7cdf325e1ccac5b3116df8f4b57",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578084",
+    "address": "0x01fe0d8eafdebfa937d1bf6dce73276f02cd5d47",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578085",
+    "address": "0x829835c5485623a6cd427149b9c9bfdd8fe967a1",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578086",
+    "address": "0x9b74d66945053e3df30bffc6202b3862fc03afe1",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578087",
+    "address": "0x5d1c35a2f7303523cd7a169233aeb4a8e979abfb",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578088",
+    "address": "0x7ebeae34516a0121fa5022e155e9af2e77ee518b",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578089",
+    "address": "0x2432267e440fc7f1931efefa4367488d7321505e",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578091",
+    "address": "0xf82b420707ed757370e7d4cfad71e8e66bdd8729",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578092",
+    "address": "0x1021bed2d268e4d931f126bbf5baefe147450b97",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578093",
+    "address": "0x8cd745a73ff218a3026ae81ca2bdf2c227446931",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578100",
+    "address": "0x4b84415cb9a93bd99d1d77970ba8e3c6bb2eca1c",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578101",
+    "address": "0xc43e544e959d4a8a7badfc0b8c9c67665e7db881",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578102",
+    "address": "0x00e554ab33d38fb0f816b1a848d57968c3e45ce9",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578103",
+    "address": "0xfcfe33f4d8978744970c9ab084ca1e8d78bbf2d0",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578104",
+    "address": "0x2a9c833104bb1aca32e085a219098012a25a1f90",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578105",
+    "address": "0xac8bff77cf0453163e5c4b6529527a36f9bf3948",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3578106",
+    "address": "0x74f4ff3e25e56d80efcbfff118b38f9ff9f6ccb7",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3578108",
+    "address": "0x24c9e865b53fa1a79099a168d4351350bb1714e7",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578109",
+    "address": "0x41fedc8a5ebedd9cbe7ffd600bd15650ca5b84a4",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578110",
+    "address": "0x5ec8bddb3f768032dcac3be82426bfa37c8ee56d",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578111",
+    "address": "0x2fa23ed96b6a916d25835de5606cfeb76e87b3c6",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3578112",
+    "address": "0x0a2f31fff60814a89b0c0bf02d9fe1673d2297a3",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578113",
+    "address": "0xc229124764cc48e1cccb74aaa80a23d5b525b45e",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578114",
+    "address": "0xf4366211999e5549ea8d6f2809dcca6ada27de1e",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578115",
+    "address": "0x20ade1706acfde19b21fe82c152955838a337640",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578116",
+    "address": "0x549f42c87433fe2311020bf6e407332dbf2cfd7a",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578117",
+    "address": "0xbfc01d1c4dbf4adef7f0a59dcd5dc0fb6f66477a",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578118",
+    "address": "0xb7cf0fc14f1f64e3e2a96651960e90676a912ba5",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578119",
+    "address": "0x76a3f9b01ae9f0cc378d2b318f10616f899d7d5f",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578120",
+    "address": "0x56dabef6d88f1933a094c3880d1b3d8ce6d41a03",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578121",
+    "address": "0xab600a2e6967ce2488bb5b1cfb06bb781ea7673d",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578132",
+    "address": "0x65c65bd0ce9c937dcf477f741de563e38016760b",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578133",
+    "address": "0x28dc28cf3f964aa255f391f935d6e9b1b231dae5",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578134",
+    "address": "0x40f321cf403839762b3571462b64e35524a01837",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578135",
+    "address": "0x3589d459e63c74e3799350a231e54aad8ac9990b",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578136",
+    "address": "0xc88ad54b2ee85238ec90a4d6f4690f47998e69e2",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578137",
+    "address": "0xb915a76d2c13f306f6d636ffdbfdf15b84f61584",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3578138",
+    "address": "0x4127fb3affd253fc9ff7f0e9765357781b2ba40a",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3578139",
+    "address": "0x263cd5134c0c31a2dc4a48f683f44bcc0b015914",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578140",
+    "address": "0x46350e2ed9a17baee4096be55456ec4c39dd9d7d",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578141",
+    "address": "0xa8647918f6e2cd8ce6dad6b0ac399b2d50ab0ea3",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578142",
+    "address": "0x461a54592e4284c1d95944f32ac6d76d1d26217b",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3578143",
+    "address": "0x920d412c9c52dd605ed51fa2493eb35d88195bd0",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578144",
+    "address": "0x632d0d0d2efeeb0a3bc2bc5ed2ddad7f61349476",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578145",
+    "address": "0xcc54dca2bfe8edeb0ac8e3419f777edf6d3ac89d",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578146",
+    "address": "0xe55269109ff2188662347b1ef3a2d8ad8898baf9",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578147",
+    "address": "0x92898dce26404e17677107da76c89e66dd63ff3a",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578148",
+    "address": "0x988be2ff1adf4d92cb78b0929731f8aff309e2c8",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578149",
+    "address": "0x16abe1561aa13011b1460823ee158beffeb0f908",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578150",
+    "address": "0xdb5f53823d6aed93b44006fc87be8405336e1bc3",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578151",
+    "address": "0x40d2c9c598f72ea1ccc533f1ebe5531241a5eae5",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578152",
+    "address": "0x63e3823a63a53eaec0dcc8dc0b55e60ff8a7593c",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578163",
+    "address": "0x9e976ff9729eb75fa8e800d9fbed001a791dc730",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578164",
+    "address": "0x9a9568e8524227fb8f0d265300fb894d100e10d0",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578165",
+    "address": "0x4212ae72a274f6b569a8fa021d4e2c877bd043a4",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578166",
+    "address": "0x3d26fcaaae911e646520ee4a434075ead60186d8",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578167",
+    "address": "0x1c62df8c29ee598c9424fb5f83ecb9b49d80a365",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578168",
+    "address": "0x7e25454b37df56e90e86644b6c24c0104f29fff0",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3578169",
+    "address": "0x7532001a064dc1e485452f9a73fb50c21f4ea1f0",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3578170",
+    "address": "0x95d6903e1a79745a7d29b47ba6139148986c34c0",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578171",
+    "address": "0x48482a68d7461885afd9dc5a46660c6a04b7bf74",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578172",
+    "address": "0xfa4160d2568ee04ec3bad048925ea5d667b5ce88",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578174",
+    "address": "0x0427e088697b8463db3f54fa55953bf25a0ac06a",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3578175",
+    "address": "0x8cf07f0856e382ec2b03c0ebabb2fb3cdb3e068a",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578176",
+    "address": "0x69db322b3dc0f39ab13e152277b5875b32c6cc21",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578177",
+    "address": "0x8aa72d92e4e3019712723de63840cb148eb5ee6b",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578178",
+    "address": "0x0c2dbdcb45151e51415e3fe6d98d70f0ca68c0b8",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578179",
+    "address": "0x29304087f075d4e7f63f03c7370b244a8644a34d",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578180",
+    "address": "0xef1e28245e2332d19d231d44fceca633e0b52a77",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578181",
+    "address": "0xfdd7dcae73f72e49abe8cdd00fd61a44cc81f79f",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578182",
+    "address": "0x45000e6783c30ee2b435957c5282294d52634172",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578183",
+    "address": "0x8a98fea5e906b4803a67e168f8168d5f0b08e3f6",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578184",
+    "address": "0x46a8fb7f54e5635bd8cbe9e59ca6add9b838e46c",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578195",
+    "address": "0xc98b8b90ea51932fe03bd5e5f55d7c1e813ab22a",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578196",
+    "address": "0xe3df6e5e85f839571920846076cf5500a8b5b8b8",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578197",
+    "address": "0xaeda2ddd974a4ab689dba218d83ef5c519fd3884",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578198",
+    "address": "0x996412696a0b9d5720da23ef4ee3b5ef61ce5ceb",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578199",
+    "address": "0xa60610a7c0c88121a5a92ff86fa9563ac6e441d3",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578200",
+    "address": "0xdec5272fe9f15e4da8edc44808e62e434d537e4f",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3578201",
+    "address": "0x9e96e389c97ea2f77461af2fba17a19edf61ed1d",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3578202",
+    "address": "0xc382b54517d3070d0265bccce1faf818e217c2da",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578203",
+    "address": "0x68dfcf16959de0f5f86928187b68ca78bc43985c",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578204",
+    "address": "0x2434205927d9c5e1d2da6f293c95a765d1177795",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578205",
+    "address": "0xe525b2df8699f538bf5b8809198f9ee9b0a0375f",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3578206",
+    "address": "0xa7f629ca7e393e173f285a4d14cdc2e9019f2bd8",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578207",
+    "address": "0xbd68d5d02df9fe009e797ca1a42f503b9e32095e",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578208",
+    "address": "0x126ab0d14907e92fc685474ed9faa05084bb4b3c",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578209",
+    "address": "0xe260efd6c28860f5d7e49e99b437be69be527d84",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578210",
+    "address": "0xddfe6186958f7c2eecbde4bec9f45718e25877c1",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578211",
+    "address": "0x4a04559a09bff553fce73c1ac87f08cd55212bf0",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578212",
+    "address": "0xf64e6eaa4170395039e1b3968206004b94d164e4",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578213",
+    "address": "0xbc8783a88fc84b363aaec18b8e74498a74ced7dd",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578214",
+    "address": "0xd0ad90624f0897c17c122e04b3ddee57443ad210",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578215",
+    "address": "0x87c7cbb8d3c604cff3a0cc0d5865c5ebc4fd5431",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578226",
+    "address": "0x23b562c781e479f812c020013580e1d6d71f6a37",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578227",
+    "address": "0x52bafc08f44ace9c6c3f63da27ec7d141a3ec36a",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578228",
+    "address": "0x7d1dfce53a4a9601b6ccdec234aecd00864df06b",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578229",
+    "address": "0x732b7cd979683efd4bbed8f3776e6a837d28b911",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578230",
+    "address": "0xd60f511ca63e3f4e86815b0d4ac6e4f2459be048",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578231",
+    "address": "0x4a0a50b1cb58ea7b1c95b17164863347a7a34201",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3578232",
+    "address": "0xb1fa8a909305a25b2bbc913542cc612d5c371523",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3578234",
+    "address": "0x5de12b62627e011300c06226af79df85cd6b9894",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578235",
+    "address": "0x42ae33f7295d35c78f6ff5075314bf8647eb6258",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578237",
+    "address": "0x8832a288bf9efd3d63a3430353b08fc1dcaab442",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578241",
+    "address": "0x9d5006be973e54ede0856bba52f7ceae498eb136",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3578242",
+    "address": "0x82deb5600b03a54ae5ba148dca3a48ba5d298c3d",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578243",
+    "address": "0x5796010ca0b24afcb99e3c6ab2fc37cc50e5781c",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578244",
+    "address": "0x91f17e038ad77211b0d907ef38ef7e600e115abd",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578245",
+    "address": "0x7138b9691a9317b964b3fdda47cfdbd015bc716c",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578246",
+    "address": "0x9e3355142b2e86cfb2809f3bba7c7ce3f1c9d222",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578247",
+    "address": "0xcee3fb4c1deb4f5e7aad1c8f349d63ccd787eade",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578248",
+    "address": "0x56055e3b21a3295b965225f623f0fe5060c38197",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578249",
+    "address": "0x7bd6a4c63a58f2ff7ab9a3411b683363bdb4333e",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578250",
+    "address": "0xa1c59dde78db2d0ccff975c98ab50b656fb15938",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578251",
+    "address": "0x7644ba39b97eaa273eeb91f1149447ffb7c3800e",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578256",
+    "address": "0x366d6d7331cb00a55f3c8e9fd34ccd8aa194c99b",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578257",
+    "address": "0x6ee811173cf1a5a37681bffb71185d1370d5ca7a",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578258",
+    "address": "0x3eb224bb73f37ff612fbeca85ae2c20a4d0090bf",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578259",
+    "address": "0xfad858765c6d34906dc88b881e965228d7fd1923",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578260",
+    "address": "0x1de446708d42e046ded76998ab837d66fb84d56b",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578261",
+    "address": "0xf18097aa884bfb07f2660597d59b2d6523584df2",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3578262",
+    "address": "0x8091ab1a6c2f27d19e94da093d567173d487461d",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3578263",
+    "address": "0x0188f40fc9cd85e9b3b8cc2f4fe3e4e4900568cd",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578264",
+    "address": "0x3345cebc67df1a4e00e94b164f20480821446989",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578265",
+    "address": "0xa8f5ebc5c56dc5f2e0f8f785c02465acee1d4bea",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578266",
+    "address": "0xbddf108926e671f191a4706d7ff34edd08a96b7b",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3578267",
+    "address": "0xebde68a03eb771fbcabee78344d30ce238735490",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578268",
+    "address": "0x4e2452f56b234bedbf7a8cbfa93de3ac9ecd11d6",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578269",
+    "address": "0x0ad46d7e09f68a36cd3815fcc5c08f0f26571c5e",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578270",
+    "address": "0xc649cdafe848a93dbe3f56ebdfeafd603e3041d6",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578271",
+    "address": "0x85f72e687bacd5af339445f4d7cd76c5108fab03",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578272",
+    "address": "0xd1786f26390c5e353e2b23bb6233e5233aed33af",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578273",
+    "address": "0x0d1cfff85906e4e44a6eeae3042a61012980a0df",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578274",
+    "address": "0x072fb02ea11bf6565e5ba9247d62ca0bd35a6707",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578275",
+    "address": "0xd2002f21ac9589d513a34d10c19f786d24779c68",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578276",
+    "address": "0x4e63f5c9401e948ac7b7ad481f23ffb02c84bca5",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578334",
+    "address": "0x93a3a13de5cd9b8e5e23a8473c1fa51d8e7bc62d",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578335",
+    "address": "0x192323ed224074e7087a427f73b4909d864be924",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578336",
+    "address": "0x08be6b6f3a0cfb9095dc48c4d44e8d70620b7c94",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578337",
+    "address": "0x4e74d0f626b645ca78e0aebd05fd6c8518e8ebba",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578338",
+    "address": "0xc64da4b940cd79451383b58a1467def1c0b833c2",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578339",
+    "address": "0x4505b0185c4c5e7b9d5748b813a41bceed49ff9f",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3578340",
+    "address": "0xe4af0c511a368e9b68c04c1d948051330ca92c43",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3578341",
+    "address": "0xa36a2e1ae84728dad13de149ede484b43f861b77",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578342",
+    "address": "0xdb660b5b9317a45efb7baba065cbef89e7d7e69d",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578343",
+    "address": "0xe48a4ebab9cb7e2cdfbdc35f141eb2c5fafd7cad",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578344",
+    "address": "0x1481b19619bc2d38aa2e052ee028e22bb9bb3050",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3578345",
+    "address": "0x2982a3d95a125525fbea27f7f6fd0990e4bf3e79",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578346",
+    "address": "0xe808f7f70c3431fbcdb1499494f929dac6a502c6",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578347",
+    "address": "0x0b6acb64345ac401e41bcb9e35d899f57333ce43",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578348",
+    "address": "0x39ee5091e3fadc86d08c18020581915a2a409e26",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578349",
+    "address": "0xd455c15e8c9cfb29a1604ddc4c0fe49e67014677",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578350",
+    "address": "0x131c6ad9b8c97bdf582238ca0498b49bcf0d0047",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578351",
+    "address": "0x3361f162d892b15ccbe3598620c07a2f057b9c43",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578352",
+    "address": "0xe1a083b50f7dc23d52b505ba801933f23d5e34c1",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578353",
+    "address": "0xd99ccaa4f846a94c241588b2ca7bdb4d88440635",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578354",
+    "address": "0x46c3dc65c23c29be4965a880620ce3857190e572",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578441",
+    "address": "0xf5592046b222621d9c95b54a1b42886e895c8dff",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578442",
+    "address": "0x9dfec8bff56feb433704bd9250fa6d1b04c1f945",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578443",
+    "address": "0xb954791faca85a8650cb933e9c841a11d08b91e9",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578444",
+    "address": "0xa77ae4a15c203e8fc281a01f0434ff29aac9a4c7",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578445",
+    "address": "0x45a83ba52dd79a686131e3f8bdd70d8d1833cc9a",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578446",
+    "address": "0x31515b5d3c053529c083020981ea5ed1dfbab17d",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3578447",
+    "address": "0xc72f5392a623df70e1f5c83e22682a508e5be3d8",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3578448",
+    "address": "0xde9a4e9c07b784e7bb40a654ef35ea613697b2ee",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578449",
+    "address": "0xe16af0a22890d37c518aade50af2ff6f7d68af6f",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578450",
+    "address": "0x861418422da5cbcb5856f0eda721d1ad3d0b6afe",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578451",
+    "address": "0x91ecc933c08587fae079eee729d4a31b979aaa17",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3578452",
+    "address": "0xcfaa4ce740755aafd27ad4cc56114b5117a3c9b0",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578453",
+    "address": "0xa1ea6535fc8a823ab6ec99070af465cf34f1c520",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578454",
+    "address": "0x65a6fb24da41e3a168e80170c8cff2908fa99caa",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578455",
+    "address": "0x10207e2406907beb3c476f11587ed3daa6f7bdbf",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578456",
+    "address": "0xba24c90a4f59ed453ff32a93da1813cad93f547f",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578457",
+    "address": "0x2e18df009e36cf2182d37a826c002448c2e5cd75",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578458",
+    "address": "0xfef92b9da678e086b118de564f977ee0d769d716",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578459",
+    "address": "0xeaa71336ae3999aca11f316fc123116b7bbfcbcd",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578460",
+    "address": "0x1d3da5a72fc94deb8abc3026fbdf5b70965e289a",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3578461",
+    "address": "0x9038f12ac8581e07806ba767376162c00a712c51",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579394",
+    "address": "0x5e53e10a0bba1c9aba51a2d0c7a1d5eea77eff27",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579395",
+    "address": "0x41bd002e47aa1431cb80da414bd12684a6a219ca",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579396",
+    "address": "0xbca5334e71b7e4e782056b76e7635723a2cc24cb",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579397",
+    "address": "0xf5c7969307f9379e96cbd89d1ea6aa0a6c208d78",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579398",
+    "address": "0x079b98a2480d8d46964f744a9ea5baa295508954",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579399",
+    "address": "0xc54d20d2a12f7df3465659c92362a3f22d8701db",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3579401",
+    "address": "0x3a8a03b4ff608e0d5f9507a487c6ba95768b7bc2",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3579402",
+    "address": "0x7407d7cb1af9aaa93e43419c6aaf2762477744d5",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579403",
+    "address": "0xba0bee11226a51eaddbab5d31caa0ff51fa09bc6",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579404",
+    "address": "0xa76c275d121868935a5df91b2e5acdcd69db1732",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579405",
+    "address": "0x3a82b6731a5fa0bb3402757d129b8ced07a3e76f",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3579406",
+    "address": "0x8868fec76417206a5e1bcc3949ef745e7e2ebcca",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579407",
+    "address": "0x6979a01b4358fd59fa4691040ced8da52bfcd18b",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579408",
+    "address": "0xad79d2a8d72fdb1919193a51703b4266655ffe6d",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579409",
+    "address": "0x2729a9edad0bcb32fbcf988bf3218058845529a4",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579410",
+    "address": "0xb1126e89275d0f918b9934e1423d9a04fe9c9355",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579411",
+    "address": "0x002a8a32e36ff6dad9e65526451ef00596a0fc77",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579412",
+    "address": "0xce92d4479b0241c2e69cd6d692c3bab17f150bab",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579413",
+    "address": "0xfe8e4819c290d96ac8f71ac934a0438289e87da8",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579414",
+    "address": "0x0eff4204ca6dbcfae1e805ed8897a47f6711b8da",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579416",
+    "address": "0x75338d20b4a74632e3d5dcf106c7318e4c707201",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579497",
+    "address": "0x7f372e87cc556c718c0908320f012644c1bc4817",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579498",
+    "address": "0xe6699c915081982d9bab1db9dc431de5c42257cf",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579501",
+    "address": "0xf7c4a67d1f97b80be9399c78c12cd929f1c86faa",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579502",
+    "address": "0xdf88dbe49a54e9ff17e8cde8b6e289986c6242cb",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579503",
+    "address": "0x0fa21d3fc3d4e907660497eca5696e0ab9133f7f",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579504",
+    "address": "0xbebf21f58d5d1bb7504ecd8581235c57080bcdf4",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3579506",
+    "address": "0xd650ca0f50d67de86aff5d0fcfe80bd4468c3e7e",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3579509",
+    "address": "0xca3af5427f2c28af05ac5ff8ca2238dfbb60a00b",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579511",
+    "address": "0xa345db89c81aedf52cfc6a09805abf1761f7e3f4",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579512",
+    "address": "0xa17f623befdb5709cd08f10d9515ec7b178b88d5",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579513",
+    "address": "0x9e43a4a076d3a835c3557265f70e1dc6917b33fd",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3579514",
+    "address": "0x0b24f3e131b9486cbd1fa623354faa0e2c839cac",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579516",
+    "address": "0xe501e1421f9da12dfb51baf1c883de6522cf3a6f",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579518",
+    "address": "0xec717f5e273740204115a884c3dbd7893d935dd8",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579519",
+    "address": "0xa4279ce6cbcbd38b9157288270577c5f67694c63",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579520",
+    "address": "0x1a3a92889ff9f60406cc018a57640da5781a244c",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579522",
+    "address": "0x2c0183262a313f630817f83a4b20dce5d161939d",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579524",
+    "address": "0xcbee958cad279e068a59ebb7e0f7dd3ddd20d987",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579526",
+    "address": "0x74b8511e995051a357d4b06a826259344872db40",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579528",
+    "address": "0xc23c8fd2d5c3e2308ca09d3aeb17bb6109985746",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579530",
+    "address": "0x3bef94926133c472c30e85726bcce1562cb43158",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579618",
+    "address": "0xe38f56d5b6b0ff0647be677c34a64ddb0d9e24d8",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579621",
+    "address": "0x1e8b44c3a2f7e1df82181a8ea485b320d96faf05",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579622",
+    "address": "0x313578205a8a44edbc75b4bfea2a0b3b81cf46fe",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579625",
+    "address": "0x67d4d9e2ca3dbf5e9fcbc4a816e096143766113a",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579626",
+    "address": "0xe03235f0a119214918b51049e67c2419312ca0a0",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579628",
+    "address": "0xca983be4d5a6dbd6f18f9581782e40956e66e505",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3579630",
+    "address": "0xeaab6e0492f1735cb32a9e003d6dceb3fb2686dd",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3579631",
+    "address": "0xda6a7f007fb4ac245218cac38def020784d3b1a0",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579633",
+    "address": "0xc21cd393fccdce06b3f973fb6b9419871bb18b97",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579636",
+    "address": "0x2774901001c40a37938f313c4599438c9cf907c4",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579639",
+    "address": "0x2d5408ef3e83f18ec68130e7d6966093c849d941",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3579640",
+    "address": "0x2917cfbffaa30376fa3d1f266d35205b3abfe0ff",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579641",
+    "address": "0xd65e316efc7a1d51046996acd7ae6c0ccf1e39a9",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579644",
+    "address": "0x442fad64dd1c38fb00af6e4b38f8e2bf0b04e259",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579646",
+    "address": "0x3ab7ca60e468ae4428e8824832da96f16a7ebdf5",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579647",
+    "address": "0x452292480492b32a0fe2c0da4e468adde15526f2",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579649",
+    "address": "0x0375e01203d0e15537772f0c8a0a6a0e4ae8476d",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579651",
+    "address": "0xe8e6a414af3496b4604c3b8e14ed5e23965dc60b",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579654",
+    "address": "0xade6a23c3cf1c4e6a35938623e4014a2d2713727",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579655",
+    "address": "0x078d7f7d51ee6d0f4397abc98ce6e9c47abb2ce8",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579657",
+    "address": "0x16ccff511479d6761ad6e52dc8daefad142fe490",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579770",
+    "address": "0x147f266a267c05f0fa2c298e987b9a84391fea30",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579771",
+    "address": "0x2a77fe26cfcbadcc6fa982da066408a8a151556a",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579774",
+    "address": "0x9103b496892e741805e9a14392e2dadf8b5e2d59",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579775",
+    "address": "0x322353170da743dfcd18c28cc726b403c4ab6615",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579776",
+    "address": "0x3b9114616c777812a11c14feaa4828a346d60800",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579777",
+    "address": "0xc44fb69fd12b23dfbec66d84c7b91cad53ff07b8",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3579781",
+    "address": "0xe929a66f45f73c8967b50e5e6b2b9ddae67cc3ea",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3579783",
+    "address": "0xc9b0c1d697efedd051df8b74c773617a488528db",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579784",
+    "address": "0xf4ac2e2bfb49a2a5b0565816381e2787fdfde888",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579786",
+    "address": "0x28b9eb82d4a9757394d1cef55af5adbb10102728",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579787",
+    "address": "0x8d7e710a6986d7c5f23a3672170141399fac1d1b",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3579788",
+    "address": "0x3fbedfefb57add7a63b2275fd559e09b61999b87",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579789",
+    "address": "0x8661b885227fb33de09b05533b163fbbfa093803",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579790",
+    "address": "0x388c2dd305d256500ef4c883c58acb96ab9a2008",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579791",
+    "address": "0xc2e8fb08b149f46678969d4df0c25f3db1b63538",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579792",
+    "address": "0x293df7e3ea74940c7d3df60a26ead696219fcf60",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579793",
+    "address": "0x9ff7a2a1bfd740eb97b141b47b64fd814469109f",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579794",
+    "address": "0xc28a96cb5552bd2c4df3272439cc3b4ad1e83610",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579797",
+    "address": "0xa54d200b5db1c775b215216e6737512b087849e5",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579798",
+    "address": "0x0c52e9728fc300156980b1bfbe214e425dcdccf1",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579801",
+    "address": "0xa9d93afbf35b6a75175c1a9e430a2a235fdc3434",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579980",
+    "address": "0x6efae7beaaa7c3515efef62643628f78f09a67ad",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579981",
+    "address": "0xb79292b4af9c020831664ac226a7319814b2f001",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579982",
+    "address": "0x12f816d3e93a19cae53b3ae82d9b7bc811671b73",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579983",
+    "address": "0x1b33a52ab4736d6135c0704f6c62ed43a1233091",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579984",
+    "address": "0xe77644b257ace609a738b02a35646c0c643059de",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579985",
+    "address": "0x9eb6e12f9167e45fd638e92d74560b9a4148285d",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3579986",
+    "address": "0x5ffdac84d6d4f435767e14a9450af95c266e9da4",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3579987",
+    "address": "0xe18d00db8512d1a7a4a95671a49a7ceaad11a2eb",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579988",
+    "address": "0x1cb99f6c6d1ba0f0c3ede60568e50242a5dd3ba7",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579989",
+    "address": "0xbd6aca82c97a5ae33da3db2a07a5bf8741538801",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579990",
+    "address": "0xf0ea3da5ba44f492a06e00034478829e037b5454",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3579991",
+    "address": "0x13e45ce47ce9a615ac9c396d4fc77ddae4c40403",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579992",
+    "address": "0x5a60cdcbba52b6f3e772e06c424aefa7bade9a1e",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579993",
+    "address": "0xfc2c838040c32374be8fe353ab794de0b56669a6",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579994",
+    "address": "0x6797c572ce22377c5f177cb30acf4a1b1eaea3d8",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579995",
+    "address": "0x97d509dc00be59f2b6be069b56d9476ade3e6664",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579996",
+    "address": "0x903a5204ad72e810666a04bc08ae2df845d61bf2",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3579997",
+    "address": "0xd399582b0c62681c6588d6d02758fd9af0d26ffc",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580001",
+    "address": "0x1025ada11dd12269106f7ae055d8e5d413c17599",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580002",
+    "address": "0x6d5a43e2ca21afc09bae14e18d4be1bf3dc49c24",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580004",
+    "address": "0xfb16f57382193a1de5b45e24776845c46a930f3d",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580123",
+    "address": "0xd431abb565a0b39e030008edac9de2cb90b8098f",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580124",
+    "address": "0x1f43c1f9f8d62bbbbb6f2d3caf261624c984cbb1",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580125",
+    "address": "0x4804738ad116c4014753118f87fc0ed9be8da082",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580127",
+    "address": "0x339ec4177e4ebd804c6ee44e6e64cb92c7cb2ea8",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580129",
+    "address": "0xeaa4d7b6d157af337b40ee0926a6bd6999c154e8",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580130",
+    "address": "0x9638afdffca6d91aa0481312cb2f0912abf99edb",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3580131",
+    "address": "0x53f7df3c53d47b4c2349ca0677aae2a4f9a41711",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3580133",
+    "address": "0x5b9a0f9e31e1a07ce0581daeb9e0bbdef4698c25",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580134",
+    "address": "0x5666e2d16d566b9122de9c462766de080257e9b5",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580137",
+    "address": "0xc905ec195fe1f8fda0e8f2f2a3575403bcd5bd62",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580138",
+    "address": "0xa1ef7e8842c710d17838540737095ec0a84f09b7",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3580140",
+    "address": "0x4b6a823a98b8a0ada1fdc901743357a38a1a7cec",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580142",
+    "address": "0x74f1e266bba90a371a50c8416c91597bd6382025",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580144",
+    "address": "0xc9e4b5bb2fc922feb8e1eab417ed82381631450f",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580145",
+    "address": "0x61873a40dc5964198e668301d2a0b86744410321",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580146",
+    "address": "0x7b10f2d688c6e310b29cf5c88840e74408c98662",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580147",
+    "address": "0xa01eaab0cbe0c72fe0d28ef2cd95fdef79b4fa6f",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580148",
+    "address": "0x78e25165d1e50705198a40b4e4db4555690f75bd",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580149",
+    "address": "0x04eb759ce4c315d2e0edcfdab539b74925feb191",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580150",
+    "address": "0xf9e6f1bb977c2f9efbf8b17fd622628f77538140",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580151",
+    "address": "0xb46445daa944787ae749ca77a93ddbe28e68c1fe",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580184",
+    "address": "0x340f2e4c0c3b3024784d2ee0c6355a93507f42a2",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580185",
+    "address": "0x019990cf50c5e1cca81af13f2175aa7e3e1d9906",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580186",
+    "address": "0x34ff8fda6bb31a4086833ac17c5e136a6e21a364",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580187",
+    "address": "0x2c2cd81705f7a278332954cc1bf12d9c52833af6",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580188",
+    "address": "0x37f9a6bd78308901a7847f369125f4cbc6794278",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580189",
+    "address": "0xa3ff55a6ef489436f156c006323ea89b82cfb8ed",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3580190",
+    "address": "0xb7a50327032560055eefedd0f1083fd51808e22c",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3580191",
+    "address": "0xe866ca9ef21785f75a3a11c05ae17ce951dcdf87",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580192",
+    "address": "0x8db3054d794d5071d00844522e499a3da6ec2d81",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580193",
+    "address": "0xc18037010fd12faf4d6b5f8c890193314daf101a",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580194",
+    "address": "0x4f3b43033bebdc80bee8678c80fa5efb704495eb",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3580195",
+    "address": "0xf59edcc0554ed26ab4ba3f8f55babec07cb926c4",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580196",
+    "address": "0x8cc0c7ea086f82f049ea6c5c952eb60ac800b5d4",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580197",
+    "address": "0xeac645d88401cba1b3e0ca57e8122505ed7e823c",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580198",
+    "address": "0xb75dfa34aa128187eb4a44fcd2a09b9fe7996c03",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580199",
+    "address": "0x1c799a4aa09feb3e99fde700f0aa62687d3e6945",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580200",
+    "address": "0x96963ad830bc1de58a7d3f4feb2d7e9807d841f8",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580201",
+    "address": "0xc44052b9f96bfbb781deaa84ee7b923a70669127",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580202",
+    "address": "0xefe9b9057779cc64278d4bcd5755dcefef8948ed",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580203",
+    "address": "0xcabcbaf6c11260906ad2d919946a71e6814fd633",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580204",
+    "address": "0xb6928316d04aa724c74a5a60ca2204d65ea4d211",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580820",
+    "address": "0x2a10a2e5c90197e8e01fa42f43ae9100419422a8",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580823",
+    "address": "0x35c6880efc12de4b9e3e5b42ad006eeb20a9f760",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580826",
+    "address": "0xccf78661659fc78f977ad0ebac4dac1f17dd2b1c",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580829",
+    "address": "0x6ad3245bd81d135e92296b633e5b1aed306535b3",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580830",
+    "address": "0x21152c55849046817b5fc170dae3d1fdaeac1d95",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580831",
+    "address": "0x2a5771791a283e4dd46980c28b7d8196f21f3ccc",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3580832",
+    "address": "0x79b31b622c383e7fa737847e3f766906220451ff",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3580833",
+    "address": "0x91a39aa87db62ec7882a1d882e61f92ada1c1eb2",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580834",
+    "address": "0x6889904e33988cd79869e0765c03a7c4b81e6993",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580835",
+    "address": "0xb10468c6c75b8ab30f4f3096d31abf49bd7de555",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580836",
+    "address": "0x4df5fbae2d099d5e7b232d9f2ab4083cba78050d",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3580847",
+    "address": "0x90e659d97151e62fbec9d29bd5d3571898707a1c",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580850",
+    "address": "0xbd9d4851e38b244a9c3f7d8a367a2b216dc167fc",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580851",
+    "address": "0xe3a56223d5e414f2fb55229d0ca2fa59f98cf9b3",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580855",
+    "address": "0xc1e7ce4c9443b50a22adcf6cdbdfa6f77ed83b50",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580861",
+    "address": "0x721eb4973e0676c8f4756e138314f1ae70ff4647",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580863",
+    "address": "0x13c510d1a0119cc5a08b205cc3dcbe33c6738480",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580864",
+    "address": "0x7185530549e302b5bbd7c2453b197b7f1b79b310",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580868",
+    "address": "0xf9c236f400605533c9bcafb82e3b7d80e547b189",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580869",
+    "address": "0x3ef69e3725f8563c99d9315064853788eb477197",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3580873",
+    "address": "0x1cb69ac79e1a751444d18c014a4d9509066e7935",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3581106",
+    "address": "0xcd27bc110aa65d72aef4a0f80cb86b732863b9a6",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3581109",
+    "address": "0xbebbd059e69816a86f7ca8de4a525aa3f3756d66",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3581113",
+    "address": "0x80cc07d04ab4b934e6ee2e10dbe05339c40d184e",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3581114",
+    "address": "0xe14d22720e108d4ce5b9e0eddd9aa5fa7c8cf0b4",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3581115",
+    "address": "0x030931fa5163ba891832a76fb3dd0aca30bf981f",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3581116",
+    "address": "0x97e707093c835824ed4d08dfc5dbe8b346117de8",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3581124",
+    "address": "0x290dcc9f0ae6fa921bf6925a20b1df8a48049d6e",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3581125",
+    "address": "0xd8fcd8bca5c2cbe2e6765df0e701acb25b712d16",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3581126",
+    "address": "0xc717eb45e44092595986e7f1c8786248ebe91b1e",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3581129",
+    "address": "0x0102cd69b4948ff032601cb92cb40ba33f9ff01f",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3581135",
+    "address": "0x533228b678f361fca62b22c988c68602fa52ba3a",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3581136",
+    "address": "0x02952aaedc5c7df40616722baf0e9b0d42f0dbc7",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3581137",
+    "address": "0x46093014f2634fd076e65a28875477552bc23368",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3581138",
+    "address": "0x371d62c296c698b62d033d8ee4a69c39f00e2683",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3581142",
+    "address": "0x40cc16dec5791349aa7cdae778b1ce1d3bb7f04c",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3581144",
+    "address": "0x27f776d94463d5668bed17737bf93f02b284e34b",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3581145",
+    "address": "0xcf1db5899a05506f6c5f6a9f9e0ae68feb5dcfb0",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3581146",
+    "address": "0xf1a41930a6831050ae91c573a288ef43819e405f",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3581151",
+    "address": "0x1b5e3aa6321671213a104d8d744a85c2a8f7fc2e",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3581156",
+    "address": "0x6739a27bdb94735fffefdaeb2e998d19368d053b",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3581157",
+    "address": "0xd687123640e02ad51aa5283ef23617ff5c98b33f",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582166",
+    "address": "0x6835d5c1383d879c28fcedfc4aa0f2de565bfe89",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582170",
+    "address": "0x412095e6f13f7f2d4bf26ad96b89d11941fd15bf",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582171",
+    "address": "0x01d3295f2a0824c2656c186e98227c4185748810",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582177",
+    "address": "0xc1c60770df7170ab4f1a230d2d87ea36b5a6dc46",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582178",
+    "address": "0x5a7b2292f6793ec8c0eff7acf4ec25105916d032",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582179",
+    "address": "0xa307788f68f1bdae747f98d42739e6a62c224924",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3582182",
+    "address": "0xc97d7d2ca33814dd8fa58c8d24147a557db53fc2",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3582185",
+    "address": "0xaab695d9d20561d5a52702a5bb0e62d774d02cae",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582186",
+    "address": "0xadf88589e10f4a7637077ba7db81c6400afcf117",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582187",
+    "address": "0x0b53067f3ed3df2b1e981656c5bc9086970b143f",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582189",
+    "address": "0x9ac9ae7719c3cc86f34c94dbb71c9ceaf0436cd9",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3582194",
+    "address": "0x90d494c67cade90e2edfa838e4422eadb32557a3",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582197",
+    "address": "0xb87327db09bf9629af068ea2417101eeb8406de9",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582198",
+    "address": "0x28a13271ee172703f0c17fcec3ca84b40c8f255a",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582199",
+    "address": "0xde8431141ba28f69181f0e4bbeedb4554019406f",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582203",
+    "address": "0xe89f8ed8fe013ec98b7daf1271ee9c964af357f7",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582207",
+    "address": "0x32df7806d60ecfdf460e62adb27c39bf7ac5b6af",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582210",
+    "address": "0x121bad7c452890851d240713e1f6bd0b813524b0",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582211",
+    "address": "0x88f8baf0097f211104c2e92871a6aae795817b7f",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582212",
+    "address": "0x8b31b2e351a95397fbffe01adcc65875194a3880",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582217",
+    "address": "0xb63c204056cb24afcaf3fd6488d01f583cfec3d8",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582910",
+    "address": "0xba4b5d04a8e5e0748ab0159871c9ddb5a83f3de7",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582913",
+    "address": "0x52372327b1f722e49d100e8bf17ed3047ffb04a6",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582917",
+    "address": "0x131c836734576aac6c402776b563feedab779c12",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582920",
+    "address": "0xe2f1f0233fc9f23c3a65cc0b5055d038d78a1236",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582923",
+    "address": "0xa63332d252d6fe54773b1b0e38ab33405e612585",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582926",
+    "address": "0xb4052c3c4eb44fbbc2ab29fc2b36946675de767e",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3582930",
+    "address": "0x070c257e031e462d46905b5d0e3e290ede753650",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3582932",
+    "address": "0x53c4fce98ed2e035756a2a4d4a7a76545048f48f",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582935",
+    "address": "0x025c24140150b26026693718ddf5eea011f9dad3",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582939",
+    "address": "0xb5504cd43aad551f380919b31361668f2897bee8",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582944",
+    "address": "0xbd595f2b09574a905d2c1687630dacdf6efe19aa",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3582947",
+    "address": "0xaa78e2dc8ce9302a2074e7845bba22d5dd90455d",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582950",
+    "address": "0x74acdb553daff750b069e1e36470854da9a073be",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582953",
+    "address": "0xa5dd422f4bb18171cac525ea2c2df9a49548741e",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582957",
+    "address": "0xbd9f8f6a04bbdf237efa310805b4bc23980f0a82",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582960",
+    "address": "0xc1743c48a8b6807662eeb3957c395851b0e2166c",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582963",
+    "address": "0x04e90e5cfe520428ebd4a4871d46b472f0a5ef1c",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582966",
+    "address": "0xe55a3cad8c4928ec4dcf23adb4520fb940c8c962",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582969",
+    "address": "0x6b53436c412b275cbe69efca78fa29eb82ad40d5",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582973",
+    "address": "0xec41e4fc90aca285a63a157d37870adeb3696fcd",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3582976",
+    "address": "0xf9db51e395b68544c42a7a72ecb78e4c8dea2439",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583333",
+    "address": "0x569dac3f35c2a4622a716a79f295d0e47591fd2a",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583336",
+    "address": "0xd7058929420d76e0e1ddf2967132a8e54d9724ff",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583337",
+    "address": "0x647b700333db73e14b16f023592f9d6e67080763",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583338",
+    "address": "0x2854f2fe4babcbbb3de4af1ebd9f1448e5b10090",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583341",
+    "address": "0xebcc75661525e41905b4541b1e35c851ddda4eea",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583344",
+    "address": "0x68cf9a24bd68461927ad57be9b14112b381d9d0e",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3583345",
+    "address": "0xc3ce19182bc2afe59b80bdfee56185884cc0adb3",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3583346",
+    "address": "0xab21aee32235fbfefbfa61011d13bdd5c95fe776",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583348",
+    "address": "0xbe6630c5b8ef9d5e78cfa0f64d4aa25da9141086",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583352",
+    "address": "0x2e5871f2e5773fc26fcb104cf734bb426926edc8",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583353",
+    "address": "0x121dbbd5c7d9eb16039fff54c29cfc10ee1421cb",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3583354",
+    "address": "0xa56d8af378388f0194181556697a208e4377da0d",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583358",
+    "address": "0x3f0bc5deec3742484a29551f3031d1d33672237c",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583360",
+    "address": "0x9a433c013e4066b337460ed662865617442dcb99",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583361",
+    "address": "0x3d17424c3d30e6bc828370910cf4f6893a6f9f22",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583362",
+    "address": "0x4ea1e986f1c3bf6c0d976bdd48c57a1e373e92c6",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583363",
+    "address": "0xb78f784ec91ac0a86a26d3e3b0a644bd511cbd88",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583367",
+    "address": "0xe578f703331461b598f3c5f00e144a7167fbc32b",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583369",
+    "address": "0xb3c1969c1df64d8e511dfb435c30e10ab6db7a96",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583370",
+    "address": "0xe0738b91c12af82f48c46699ce5172b698e052bc",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583371",
+    "address": "0xf99d81964252f15718fb38eb64b926cbc717e52a",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583697",
+    "address": "0xea9a5ce9fde5a4c064d8c1f4e72a21544cf4c282",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583699",
+    "address": "0x538625d0182a1b77404b27e4cae7a2c5f0fccc21",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583700",
+    "address": "0x58c36e8448fbdf3a9c86e6b217460cbce9db9b2d",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583702",
+    "address": "0x87e21c25a0bf01b3db2063883e957af5996e4e88",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583706",
+    "address": "0xff828941266b6d4786be77dbdcb0ac04951c6874",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583707",
+    "address": "0xd38e71469a96716213f6b7c72dd8b5f3232d3ad5",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3583708",
+    "address": "0x824b9838a3d2d913c790bf2b0b617b752d5baaed",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3583709",
+    "address": "0x3ee2611bbb2d6032220f2a855e65e0d16aee6690",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583710",
+    "address": "0xaf8d086d4a1817c9dfd4b290880a95803cb3e438",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583713",
+    "address": "0x7aa38d674ff03734a73ec1187264347bc710d1dd",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583716",
+    "address": "0xc7717089f8aa94eb1271c5eee5fd2d8b20a0489c",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3583717",
+    "address": "0x2e967ce34ef7d7acd8401dfcf967e736ca790692",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583722",
+    "address": "0x2b226d2d8aa2f4f2c2d633afc3f1e8acf7a23e97",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583723",
+    "address": "0xbe31ecd4b6185e7f73463d3376dc96adb17e01f9",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583724",
+    "address": "0xa40dc8af3e444eb5a92fad133102bb6a64d10bf9",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583725",
+    "address": "0x9a65c6d1535421ff34ad15aef9a1686822d341e8",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583727",
+    "address": "0xd6bc09a385ad727731c61b8423b0019e8ec8122e",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583730",
+    "address": "0xd74325ac2959fc9840f35227b9e280e3fba4efb8",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583734",
+    "address": "0x85bd57b5374b591ed67aab1131a5a1abb1ac5543",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583736",
+    "address": "0x2957f252ae3e495e43a165417e2d39be81563925",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3583738",
+    "address": "0x3d4b0c11f54366788671896504fda582a7f9c315",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584344",
+    "address": "0xe9319236d3684eed5d00baf1ca05f4f7716935c9",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584346",
+    "address": "0x83a63006c828ff4e0f89ca1f96403681da809ae8",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584349",
+    "address": "0xabb0d4b6609d6e730f88212a7bc0e2993624cdeb",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584351",
+    "address": "0x84d60d97db5e4f57503bc03b122bf08d738b0d25",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584356",
+    "address": "0xeec2e021235a3c6609b17a09fa9aa3a3ec77c6e2",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584359",
+    "address": "0x04a0a4d2edce3d4842ba1adbc3b25698ca1615f8",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3584363",
+    "address": "0x10057bd9120d23a90bae0fc6658ef425ee4fde1c",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3584366",
+    "address": "0x69274e87b6a9307a442d8c2993a31b157fdfd8fe",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584369",
+    "address": "0xd7e6ed8ae238cee5e85b1b4f5b72e74df3e0b4c2",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584370",
+    "address": "0x9099be5a86a7048d3534b744c3611d639d336f66",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584374",
+    "address": "0x3a2ea557eb981bf9d04dee19d36626b8b1930764",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3584379",
+    "address": "0x2bc7100686023af7967a68958e78a8172ba3aa75",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584380",
+    "address": "0xcf25c39d7fca1fddde74130724edc02c18592fae",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584383",
+    "address": "0x81cd09a1c4251e8f6b0591e79d79d4fae53c6a41",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584385",
+    "address": "0x6a548ed5eca72a922ef9e445c4aab8ec65135116",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584390",
+    "address": "0x29dac2c32e344eebac2159271134ac9ec251133e",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584394",
+    "address": "0xb3b5a2877bfd6501d5be292994c80b5bbd32d365",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584395",
+    "address": "0xd13db6a75d606e27c88793776be89b4f82df5308",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584398",
+    "address": "0xf7b07c2d69fce5fd7af5c0716bcf4b2164edc8f4",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584401",
+    "address": "0xf0afd5c883a10c53ddb9843652ba3ba08866d280",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584404",
+    "address": "0x0fe812c6c91e8e041673f73dfe74c2a03b08c081",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584676",
+    "address": "0xc1671c6ae7c2f07237b559f3a29fe1e8ab86dac9",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 5.0257e+22,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584677",
+    "address": "0x3de5742be866aa330e98a99dbd7ca69eb3721cd5",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 650000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584681",
+    "address": "0xf3b57cf9e2a996a241f9b4e7e93186e6465a77cb",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584686",
+    "address": "0xbad7eeb8edb1faad502f5571e742bc241b4b1614",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584691",
+    "address": "0x7b95e5183829f498263e62db2a8d91e7305d35ad",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 1500000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584692",
+    "address": "0xd18d9169bb9d0bce1340174bc84163315266600d",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 9011450000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3584693",
+    "address": "0x7adf0e863f3e04f8637b587273b16a1d9c8c7e92",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3584695",
+    "address": "0x819d4f361e725ccdb595a9a31cf71c2fe951e0d1",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584698",
+    "address": "0x90df118f7d1a9596406732f1e83c87c246f9674d",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584704",
+    "address": "0xb3239dfb18a89bbf966bc73238a913ad7faa3f6d",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584710",
+    "address": "0xfff99214abf25dbef04961a2195ea80948938874",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3584713",
+    "address": "0x1bf786f1842bcf32fa6bd1dfc1b61da437d7c7b9",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584714",
+    "address": "0xf65a8312b3d537cc601445684463fde7c0f196e0",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584716",
+    "address": "0x441afdb59604a5d8d86a3e813fdf33bfd7ce978e",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584719",
+    "address": "0x9c2200ae2b1f2d3e1d55fd96547ade3b485f6cdc",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584721",
+    "address": "0x685c9216d79ab13cd0ff956f74fce039ecb37068",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584723",
+    "address": "0xc9b33c3ec4e0f54d39ae9d407f58b35b65c2a737",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584726",
+    "address": "0x192830e987b4c362cb93fd4445776e822a091a59",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584727",
+    "address": "0xd3cd8cad5b7b68cdb41923a467246e48e88b762f",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584728",
+    "address": "0x95e97d91f3772c0f498d2e7b053ab6ead0243503",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3584733",
+    "address": "0x186ee4ec2f02f1b6bea8e833f654d2db0f5fc4dc",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3585141",
+    "address": "0x5e3b0ab1fa80fc252980c0e58566415e40e7a07b",
+    "name": "DEL",
+    "symbol": "DEL",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3585400",
+    "address": "0xee355b66d4429eaefa1edea26cf8c53ce993f4a7",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 5.1257e+22,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3585401",
+    "address": "0x852deac69e188f5d2477ef36a6152f8a5c667236",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 660000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3585402",
+    "address": "0x2a75a0fb910953c9d299c6f11491605f11c0d74a",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3585403",
+    "address": "0xc54804a0369a38f84f28f77903371a11e4886bcb",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3585404",
+    "address": "0x4f558f28ecf88ba41578abf419dc868405d87528",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 1500000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3585405",
+    "address": "0x188e76dd4c9eb1f42ef5e54996b15f34f49e2db3",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 13011450000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3585406",
+    "address": "0x6454f0110b7439aa7e2f8f41a1f38008cb7470c9",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3585407",
+    "address": "0x4076277a89bf0313d7636706ad9ba519503d41da",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3585408",
+    "address": "0xb899f10e61eb9c1b78914ad966b4665f4249197b",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3585409",
+    "address": "0xddfccc3776c0e5d7bcf83aa73b1610e17c6af781",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3585410",
+    "address": "0xdb1616c18b969fe0e6e02ea74d79caf455041837",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3585411",
+    "address": "0xd1640556be9072674ff1497c921844c0a6e90e0e",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3585413",
+    "address": "0xc84f0d92df962c5a464aea3193afa1eb4bf0fb92",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3585414",
+    "address": "0x9c0153849914511bcfaca4e0b467fd06d26e606e",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3585415",
+    "address": "0xc9f98e52fe6af08e0c1cecc13b69660288a0d4fa",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3585416",
+    "address": "0xaf43d68e8edc887a252367053f64418595a1b310",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3585417",
+    "address": "0xdbaa37d59dd3335f1f29be0bdaf9c794baaa5002",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3585418",
+    "address": "0x4b2b703ebc859bb04d080767f0b6be7c544a84a0",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3585419",
+    "address": "0x9820f371a9e9265dae9629e1592f4cd9e863510d",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3585420",
+    "address": "0x560321126d73f268eabf995e0723708ef2f5a0e3",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3585421",
+    "address": "0xade41d6df6fcb2965e20a5c63964dd2a2de990bd",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3585620",
+    "address": "0x44d8b53176875c471b504b92627563c8149ad872",
+    "name": "DEL",
+    "symbol": "DEL",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3586562",
+    "address": "0xc3c8cd6729e51a8f08d260b3255005dbf63708dd",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 3.9156e+22,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3586563",
+    "address": "0x32cd96f5b55fafac84e24fe05cdbd7a9e6b8ac57",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 10000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3586565",
+    "address": "0x5bbd48d9420b685ddf31a3834c46750b68a81f61",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3586566",
+    "address": "0x93078e3d9ec54e71f229a87cc0d269d6ae3fae10",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3586567",
+    "address": "0x6de68adb6041659ae6b2ed6090f3679b7f076731",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3586569",
+    "address": "0x45564f4101c316d630cf2d6a7293ab778a56a459",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 8001450000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3586571",
+    "address": "0xbacc1dae541ed8efd524f88ae7746e08951cda3d",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3586572",
+    "address": "0x29fc9d01a3d66a38d1ce4fdcb15baa6d61fe59c0",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3586574",
+    "address": "0xdcd9c077d3f6aac0bbcecc60279fdff9f2a654f7",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3586575",
+    "address": "0xfa34709487c72eff42ebdb770f7bc44f2ce62d65",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3586576",
+    "address": "0x37dd87e1d4b772e6140e3e4afc7d7569f40e34d0",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3586578",
+    "address": "0x20ff226a041d4984b281567dc1da16390bc6bd07",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3586579",
+    "address": "0x3fc0fbeeaae4aa959e883f84dac1166293eecf4f",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3586581",
+    "address": "0xa2c3bd3e87fc08daa131558b31cdd3eba7738216",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3586582",
+    "address": "0x5d4f797e94ea51faf7a107d06293199d042c9485",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3586583",
+    "address": "0xf393909e1d61ba6e476cbabaa2fc11d79427a3f6",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3586584",
+    "address": "0x4b2bed652020fbd2fc63b09605940b8c0e8e5f85",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3586586",
+    "address": "0x80bc3401899106be2b8cf67b01fc78734808f7d8",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3586587",
+    "address": "0x4e97faee28961f54f1f07d4ff78b46e976a462d3",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3586588",
+    "address": "0x530aa388b6698e197cea30039d125ee3e55348aa",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3586589",
+    "address": "0x3534ca10821219c1d2e42d85bb9c9c1dbb712645",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3586859",
+    "address": "0x6eb9cf07b5c135e2a30d6d82c0a9589899dccdd4",
+    "name": "DEL",
+    "symbol": "DEL",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3592183",
+    "address": "0xc1c9840bb3bfc2b5bc5ee865111ae44a9620ee9c",
+    "name": "GGWPbOdftC",
+    "symbol": "SlFDK",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3592311",
+    "address": "0xb293a07f507227663916a210e6949cb97a8a8cb2",
+    "name": "ysLoFAofXa",
+    "symbol": "uCxwi",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3592442",
+    "address": "0x22421f2128cc5c7a05517cdfe31c4b1c31b82236",
+    "name": "VwIyrkYRhI",
+    "symbol": "SeTpd",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599195",
+    "address": "0x6d61258102d6c074274f3642ded50319bad5db8a",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599196",
+    "address": "0xf88c0c3a1db61dfa4a1022535c833c1bdfe573c0",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599197",
+    "address": "0x00c4601184ec3e5acd243bb7f23ffc700702f294",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599198",
+    "address": "0xf64b1b9f31b5a468f96958455a048debdb972d8a",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599199",
+    "address": "0x86bceaa287aa3d1c61a60996f97ecdf1e7bc4f7f",
+    "name": "WETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599200",
+    "address": "0x14c4b495c72e931da411a140e6debd0c5a88360a",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3599201",
+    "address": "0x2ae7df1094a5d5f3b443621f80b63f83b85c3fbd",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3599202",
+    "address": "0xec122eb6b8c19ece9f35fdcf1e0fc7095704adfe",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599203",
+    "address": "0x3c12c566dd825c854854d5a21847c978c45613d4",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599204",
+    "address": "0xc63a68abd41324d150b6ca5355042ed146db913d",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599205",
+    "address": "0x1c6c58761f3d89423bca95327cb38833737ae693",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3599206",
+    "address": "0xfb08870a998e805c917ba520ec5d98e125b62fc2",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599207",
+    "address": "0xce814f253642abae7469592db7c8ea129f7038fd",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599208",
+    "address": "0xe3544830a5c89ddd34ffbc80a746ff50d958b6dd",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599209",
+    "address": "0x9c487d18abb0bd211945085744f1758af1d4d031",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599210",
+    "address": "0x0a03b59ae07fff9f3d5d4063b57a0bc2246f4686",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599211",
+    "address": "0x4c80bdeb53a3e41aa52b0c719038f0ff6f65bbcc",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599212",
+    "address": "0x93da5c30ef90bdb0dbaa9915d120279abb363bbf",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599213",
+    "address": "0x6fe2ef860742259626386fdf5a1aa4435a8057c7",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599214",
+    "address": "0x504c52ecd404c61753c6725414f1051693ff405d",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599215",
+    "address": "0x9fbc91626c5929a7d283b9652e6c4315faa89c3d",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599235",
+    "address": "0xeb5f765df35379fe7cc0158e1d7f851c8f0df05f",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599236",
+    "address": "0x6481b750a4518beb4273082c52b759c1baa6a7d9",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599237",
+    "address": "0xc5a176fd1778ef30f0407fe6407b6e48478d8aa7",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599238",
+    "address": "0x5128eaf4b007f59c468a0d6f3d2074757152f023",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599239",
+    "address": "0x78076cec8e62e89738ce1264051d09153fe1b485",
+    "name": "WETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599240",
+    "address": "0xba067016ee04a74e4e5f2eac794c83ba2750cb3f",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3599241",
+    "address": "0xb3fc47ac5969d9234ea6f0c8f9835f2bee5e5fca",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3599242",
+    "address": "0xcbd7457fd7a1565a67bc806df8080ca54f01d259",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599243",
+    "address": "0x958cc764fe20e03e913ed55e0cf73025ffa10618",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599244",
+    "address": "0x870eba7da0197f62c94696d37f66d8cd6c762c75",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599245",
+    "address": "0x612f1bf68c812176c48d2e9da14f13879793dee4",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3599246",
+    "address": "0xbd380a3a5fb2c69414681eca397fee46746fe5d2",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599247",
+    "address": "0xec29f9cb3ecaf14b8d8c6bf3ccd9b8a356d0fdee",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599248",
+    "address": "0xd315462b59f642fd9e9bc9a69ff903769230a069",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599249",
+    "address": "0x63606a5cae5b35ff20940e283de7e442ef5514de",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599250",
+    "address": "0x4a11960ab073cb9a814657a689e2bb269c279bbf",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599251",
+    "address": "0x0360de36e115020acd529e8dfa505e28171bacd2",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599252",
+    "address": "0xf25421e0dd7403dd8fa52dd6219a1cfbf3d593ce",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599253",
+    "address": "0x14b1536284e6ae9c64a0e6add692d9de49ae7ddc",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599254",
+    "address": "0x39fd1474c1c4dbecc6a5be841e8de0fd16394a29",
+    "name": "WETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599255",
+    "address": "0x8731436940d2722e3b6e5177d50273588f082fcc",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3599256",
+    "address": "0x51b436fff7fe5010daf837b34c7185d6b853a017",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3599257",
+    "address": "0x536c4abe8ae8e4d6e7be9120e7780da73870f642",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599258",
+    "address": "0x2680448552eed6a1970ccfbd354858158461a835",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599259",
+    "address": "0x1e88221c3ee539c1ac13280417d901814aa3a933",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599260",
+    "address": "0x4b78358d63c896736e11e2a42a4fdefcb5c021e8",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3599261",
+    "address": "0xa2a4fbb484be620af4695db23153e4ca2e91fde2",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599262",
+    "address": "0xe2fcfb8c2f6e5eb6d58d27e0ea60d1dcb377fa0a",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599263",
+    "address": "0x15221456341738d827b9e20ae86b54af5248ff1f",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599264",
+    "address": "0x1ebd740d590ad6115357c012492856b987e8ec50",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599265",
+    "address": "0xf4b3852995775a171197bae010a3f483a24e8507",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599266",
+    "address": "0x6dbe87d7f7812f8401da9c40c1a7b5e3f5ed86b2",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599267",
+    "address": "0xf5b17c8a79ce40d0a72e6fca4cb01c307de10e8a",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599268",
+    "address": "0xce5b7923db8bcbfd8b5dc09e13165a18e60694b0",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599269",
+    "address": "0xb0801e1f135cb5cee1ec419380bff33e0a5e1fae",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599270",
+    "address": "0x9cde672e6e12032e237161cd0024d0c9a03e9269",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599283",
+    "address": "0x22dfd5979ef031dcf667ae8e4b3b5982ff8dde7f",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599284",
+    "address": "0x230f5848d0d57925b2dde754ff2f3ba55167f3aa",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599286",
+    "address": "0x08632c71227a1fda2f0196409c968122fcae1b3f",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599287",
+    "address": "0xace07268676159019a0bf0d20b2a8c1d2031f3e9",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599288",
+    "address": "0x0bfe6ae1acb22a09d69e7978fa6a1c106ba59c9e",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599289",
+    "address": "0x86248a2300b377a53d059373d6dac4730dc8c571",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599290",
+    "address": "0x7e8c60bc3f04badc88c249dc63e4da7faddf16e1",
+    "name": "WETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599291",
+    "address": "0x293df0295834812dc4ee14fb70d0c407d89e0318",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3599292",
+    "address": "0x3544c2b419547b57db763c20b51a9542251faa64",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3599293",
+    "address": "0x2bf157e3200f1082f3b3018f6201b35c1164b7f9",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599295",
+    "address": "0xd96c9cde95e4add7dc2d762ad819d0919495b585",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599296",
+    "address": "0xc90c240587a396378ada8a9ae932064ba0650fa3",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599297",
+    "address": "0xc398c13c69fc18892a7c6905807f5b6a6eb6c94d",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3599298",
+    "address": "0xaeb00c6f50d1e9bc8408f896e7daa453fe4d22b4",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599299",
+    "address": "0xe78ff05c6653c5ce9e4ad0f70aec06e241b30c8f",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599300",
+    "address": "0x9195255951f7195f69d521897cca2a5d41875489",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599301",
+    "address": "0x80a1fecdff3c8fd66e05554d961d23bf5124b74b",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599303",
+    "address": "0x723be88aa288144593952f3b95ea0b533a0d98b6",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599304",
+    "address": "0x004558c079b438f7bd70e49dc7102ac1f6cc7339",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599305",
+    "address": "0x1fbd1318085c37488cff1f0a8425b4b5142fd45e",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599306",
+    "address": "0xe426a02f17839a33e8d61c8ed9d15c99b78a54dd",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599307",
+    "address": "0x2fecea55effc9b6dead71598dc466b44b8930583",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599308",
+    "address": "0x9fc609ebed322e656a95d82e11d9cd0ad1984d6e",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599315",
+    "address": "0x44458cbaf14d4c51a30d26543da8373fbbb07e43",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599316",
+    "address": "0x685f7c3b71033f38ae6dba4aed1132f8aea3e026",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599318",
+    "address": "0x6053a9f2880293908d02e8c4f3385ca02da25e2a",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599319",
+    "address": "0x9ea878955b3b090bf4231b2188e317c02f11cd76",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599320",
+    "address": "0xe8d5e4bd55b58e915becbb74a74145361359be4b",
+    "name": "WETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599322",
+    "address": "0x3e88c6a4f1817bdae3b1f6f9d1d23ee46cd772c1",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3599323",
+    "address": "0x6db759ce610de227b9bcc912fcc97fc3d3036fd1",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3599324",
+    "address": "0xd0ead8e4cfac3dc076accdda3b4d5122bd3ae2a7",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599325",
+    "address": "0x11e60c505e33f407e7575ace761420a7802d902f",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599326",
+    "address": "0x2c6fb12a334e8171762fe3466f578b4dd082e411",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599328",
+    "address": "0x74ab61afc93a07c08eddf287bb446b571f626bb0",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3599329",
+    "address": "0x4b6f993e3b8cacbdff288e05399918b249dce111",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599330",
+    "address": "0xf469dec0b908a154d4702465af8fb53ec6371fe3",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599331",
+    "address": "0x8e123c93235976cd889dcea08a97db7bd25e203f",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599332",
+    "address": "0xd31a570ae6434f19fc9b623db2623d554dffc4d4",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599334",
+    "address": "0x6b21d73af1baf529856d7dd3d5afd8b9afa0dbd9",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599336",
+    "address": "0x9236eaece1254922b4683bd6f96b8a8bb85a2a9e",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599337",
+    "address": "0x1cf66b76adee22caaca1165684099505e88c9fac",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599338",
+    "address": "0xd25f1661387a74b1c8a910a1ae59e676b281ff75",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599340",
+    "address": "0xaf1421a4506921637b6fa6c5e79515120915178e",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599341",
+    "address": "0x4f151c49cceeba8108934e9c2777819de4eb2515",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599816",
+    "address": "0x97ba6c305903d782c0102b6c17461ed689a26841",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599820",
+    "address": "0x49dadf819488bd73c32a5d6e6b662330f6b3a382",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599821",
+    "address": "0x106a7ad5941ed12d29eaf618ccc3467ab473c208",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599822",
+    "address": "0xb9f2e24338a7dca20226280a24c40df28456a15f",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599823",
+    "address": "0xb36d522c38950cf813d7617bbeb1be9f68b1b407",
+    "name": "WETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599824",
+    "address": "0x62ce22351b53a22ae2022703cfb73688ce9413e7",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3599825",
+    "address": "0xbc09a7f1048ee2ee4f0db6998dda5236d33e3050",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3599830",
+    "address": "0x263df4efa796ac94cdabadf876fdf7d30f72ef12",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599832",
+    "address": "0xf1b74811a3a4f2b3fe14a308705dda3664a7194f",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599833",
+    "address": "0x9c841769f9f0183fbc93991d6afda51bcbd06e89",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599834",
+    "address": "0x7be503f7b3821ea8bfc90329aade3d05f5d9d0c8",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3599837",
+    "address": "0xc58a6e8cbefa7fb2dc4d599d31ec89090e7ac22c",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599841",
+    "address": "0xa613d8fb3ec7765574ae392a8232e30b3296e425",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599843",
+    "address": "0x392a4a06a6f96db07f020d7b98121864d94cfbaf",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599844",
+    "address": "0x8b3416fb5b0f1ac87d0a9ae99766d30639074e31",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599845",
+    "address": "0x250c8ce608660d144fbfe5a7baf3f6433033513b",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599846",
+    "address": "0x2f946c315e146d9f2565dfc7dc58ae94db63a70b",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599847",
+    "address": "0xe217519a0221ca5c4c3b0a26b4c0b1350d698668",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599852",
+    "address": "0xfc83b6c6a8e3d3dbe2a8da83c8d3a599626129e1",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599855",
+    "address": "0x4d95c5134d3b4fecaffca07e36f56054b24d9b69",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599859",
+    "address": "0x0e7498b97e2dc852139b362b90584e88d6f61b5a",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3599975",
+    "address": "0xc48290c798f75ae61841b6871cbbe72d8fab4a0f",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3600204",
+    "address": "0xb37d9a11afe14386d01ec79a50db1d4959e00f74",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3608728",
+    "address": "0x5265f7e1a83df812cd4ddd23d708458a7719609e",
+    "name": "TestToken",
+    "symbol": "TST",
+    "totalSupply": 30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616836",
+    "address": "0xf4d1199ac95d7739a625236640bfa2d3d06a29b2",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616837",
+    "address": "0xac276799bff910fc700c40d885913bd7a3b2dbba",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616838",
+    "address": "0x2847679501f9bad43cc74a3c3b5b1718e07ade70",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616839",
+    "address": "0x0d32782adbf421aee97261816c1eb698f53f62f5",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616840",
+    "address": "0x441592e420a6e9274ac6a8af106ceece14128a0d",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616841",
+    "address": "0x15fd168c5fb7e933ff152cff31a8b08de5915950",
+    "name": "WETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616842",
+    "address": "0xe3d2a81a8f373eee212ce5f944403a09a35bb7c4",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3616843",
+    "address": "0xf21a0fb4812246252be1f69b46e85eca5c98e39c",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3616844",
+    "address": "0x92eb0df14c667fa4e2ce441ab92a0467b053d2dc",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616845",
+    "address": "0x3ccacf4743d454f20bd8d8748a072759996771bd",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616846",
+    "address": "0x436b2cd6c03a8497284f03f753a85fcf1fc7e13e",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616847",
+    "address": "0xd8c2fe2f838c10535ce55bc069f3e6bd4715892a",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3616848",
+    "address": "0x6f67c28e7fb7ba3c70c46223bc6d108c781b6f1c",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616849",
+    "address": "0xe11321bb33064fa2b56cef5733f69ea4471a22cc",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616850",
+    "address": "0xdcd7abab16c59a0390d6e58502fb99369f773765",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616852",
+    "address": "0x0e464f26b700eb5c6412b40165faf34a00fa5428",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616853",
+    "address": "0x34599a230a711d112186b05567392898f2411804",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616854",
+    "address": "0xc8c25335976a26a505ceb64c5ac46c50a6aad0e4",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616855",
+    "address": "0xdd21e711bf9886481b805f3e88baf477a2714a50",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616856",
+    "address": "0xde5d691b849b46216fa48a4a6036e56a7145e320",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616857",
+    "address": "0x5ff26d49458266fa5510a03d2f74b2fb5f949d1d",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616858",
+    "address": "0x93d401413fc939f4f105b21444d80870b33030f7",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616860",
+    "address": "0x0f0139c54f098141a138d993967c074099bd24ac",
+    "name": "UniDAIWETH",
+    "symbol": "UniDAIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616861",
+    "address": "0xfd84a7dc83b0eed4c10377f33a97ff603e200ec9",
+    "name": "UniWBTCWETH",
+    "symbol": "UniWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616862",
+    "address": "0x40a1e13671ed6ebc4e9a6f472ceea455d446ff64",
+    "name": "UniAAVEWETH",
+    "symbol": "UniAAVEWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616863",
+    "address": "0xf6b523f1fdf9b3454dfc7421a2efed960d74a1b3",
+    "name": "UniBATWETH",
+    "symbol": "UniBATWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616864",
+    "address": "0x8e75393ad452183c5b9d645ad1e497a190605175",
+    "name": "UniDAIUSDC",
+    "symbol": "UniDAIUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616866",
+    "address": "0xe1165c5d21432a392233368d41ee932c31288c84",
+    "name": "UniCRVWETH",
+    "symbol": "UniCRVWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616867",
+    "address": "0x337e51f972a44351a4c584db8dfb188ae40a8b81",
+    "name": "UniLINKWETH",
+    "symbol": "UniLINKWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616868",
+    "address": "0x397b1bd6c0f800d7592c9e9cb70a27b26b22a67a",
+    "name": "UniMKRWETH",
+    "symbol": "UniMKRWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616869",
+    "address": "0xd7dcca75f43cd48ef4c420d039c5a53f55a32944",
+    "name": "UniRENWETH",
+    "symbol": "UniRENWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616870",
+    "address": "0x58b127ecceef3e41f09de22b961a5dd7680f38fd",
+    "name": "UniSNXWETH",
+    "symbol": "UniSNXWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616871",
+    "address": "0xbe34d89964e30e6130d1a2102936ee9bb30b2551",
+    "name": "UniUNIWETH",
+    "symbol": "UniUNIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616872",
+    "address": "0xdb6db435525c88e1185ff508415ce2e78309508e",
+    "name": "UniUSDCWETH",
+    "symbol": "UniUSDCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616873",
+    "address": "0x9d28dfc2c42b64edfff60086d06c5012367ff221",
+    "name": "UniWBTCUSDC",
+    "symbol": "UniWBTCUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616874",
+    "address": "0x64b71541933a5f48e4d00ccc97f3983d93b6291c",
+    "name": "UniYFIWETH",
+    "symbol": "UniYFIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616875",
+    "address": "0x46149ebda5c1f623b4a656ed61c06d87a4d203d3",
+    "name": "BptWBTCWETH",
+    "symbol": "BptWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616877",
+    "address": "0xfbe6c983e35db50f75c88d33ce0a864225f12f76",
+    "name": "BptBALWETH",
+    "symbol": "BptBALWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616878",
+    "address": "0xef087743f321f35d343f6ebeebcbb9d860c2369c",
+    "name": "WMATIC",
+    "symbol": "WMATIC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616879",
+    "address": "0xfaf54619d9acf5382e08522f92eefb2a6431d8a2",
+    "name": "STAKE",
+    "symbol": "STAKE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616880",
+    "address": "0xd1bb46ccbc54c78c38e4bb5380da1733b1c478e8",
+    "name": "xSUSHI",
+    "symbol": "xSUSHI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616881",
+    "address": "0xc430aed58daecc4a1583ae2784e5295137671bdc",
+    "name": "WAVAX",
+    "symbol": "WAVAX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616955",
+    "address": "0xd82c5421d931b5a61965c9d954228b5d0cda5b73",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616959",
+    "address": "0xa3020a077f3a5fd33fc04a05d4df5b31901447e8",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616960",
+    "address": "0x68f4e157471c84d97517a595dc29c80553ed9bdd",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616964",
+    "address": "0x124b79cecba34d20790bd5b2a6e7c6ea285a9bc8",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616965",
+    "address": "0x7ef21dddb1338aecf05b466cf2d1943e5f6ec2be",
+    "name": "WETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616968",
+    "address": "0xfb2b2dccc6ca8169a0af8cd579b7b9ec27bae892",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3616969",
+    "address": "0x88ba9a465af6161a520c97f08d035e28d7f3dfbf",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3616971",
+    "address": "0xb066320466f377633fb853d1ed66355a0585e174",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616973",
+    "address": "0xa993382136a671aa3478caaa48eb1a92a91f0b46",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616974",
+    "address": "0x1325b2e816eba94e770f5a25670c9e76884df352",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616975",
+    "address": "0xfa5908efbf3e17e92b23a37bde55d434559149e2",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3616976",
+    "address": "0x5419fd268c62edf416bdb432333b9035be9ede93",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616977",
+    "address": "0x321b25b8e3d858bb62de2250aff6e89f8ebcd088",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616978",
+    "address": "0xa2953b5abb8f36d13a91771e968f8d01c5bda856",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616979",
+    "address": "0xe77a7a3d8ea5d79ca8e9295d9ef51d0f83c5032c",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616980",
+    "address": "0xebe7f236ef968e31b22d15a0bef4ba406ed35490",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616981",
+    "address": "0x801d2a3cf1c8cc55cfe5e41777a5c05c1e3bc6ea",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616982",
+    "address": "0x351924563f23655df8dfa50f935edd3d40dc090b",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616984",
+    "address": "0x44ae4d35f96dc2eae475cebce61358d2fee5ca30",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616985",
+    "address": "0x705a17b332498b9b512d8d858700714697fb8b0a",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616986",
+    "address": "0x9319f78c4c97adde59ace7f72e4421a1449d97e2",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616987",
+    "address": "0x98990fcc3a454102d465f95bc349676da4610b66",
+    "name": "UniDAIWETH",
+    "symbol": "UniDAIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616988",
+    "address": "0xa7133a9209e4980f311acb9ff91253995a3163ab",
+    "name": "UniWBTCWETH",
+    "symbol": "UniWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616989",
+    "address": "0x5c1ddc4d69787899d7ff1f91e5a3732f33aaae0c",
+    "name": "UniAAVEWETH",
+    "symbol": "UniAAVEWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616991",
+    "address": "0xa6ad77a5557d15675ca27d68f3c08d38aec68d22",
+    "name": "UniBATWETH",
+    "symbol": "UniBATWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616993",
+    "address": "0x716fdfc4dc768ce13c8088dd56f1fa5fe38c1407",
+    "name": "UniDAIUSDC",
+    "symbol": "UniDAIUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616995",
+    "address": "0xb787f3674bb2d84966251f6a02ecf4a8858871e7",
+    "name": "UniCRVWETH",
+    "symbol": "UniCRVWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616997",
+    "address": "0xf270745498bee4680df9b25aa6594e0ee7bc717b",
+    "name": "UniLINKWETH",
+    "symbol": "UniLINKWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3616999",
+    "address": "0xfd85ec0fc0f0f81053694dee868733f10d0b9216",
+    "name": "UniMKRWETH",
+    "symbol": "UniMKRWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617000",
+    "address": "0xb8d434527ad07c7af76df7f87e1f1c094d4ef0b1",
+    "name": "UniRENWETH",
+    "symbol": "UniRENWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617001",
+    "address": "0x8bc1ce37d0e0f0bf6fb991ff92e5abebde5e17e2",
+    "name": "UniSNXWETH",
+    "symbol": "UniSNXWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617002",
+    "address": "0x32cc3873b126cc1610e9b6af5eb93f08295d62e9",
+    "name": "UniUNIWETH",
+    "symbol": "UniUNIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617004",
+    "address": "0x0beee4cc35045ce9e93e75f548291bdf70beb3ba",
+    "name": "UniUSDCWETH",
+    "symbol": "UniUSDCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617006",
+    "address": "0xfc09320714b106a57d4af8cf73c1a39ae00941d3",
+    "name": "UniWBTCUSDC",
+    "symbol": "UniWBTCUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617008",
+    "address": "0x0e79aebf3c50f64cead547de47c247d78e497c2e",
+    "name": "UniYFIWETH",
+    "symbol": "UniYFIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617010",
+    "address": "0x7d6869704abea2bad43effc66e4bfa18bcc2f294",
+    "name": "BptWBTCWETH",
+    "symbol": "BptWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617012",
+    "address": "0x7e2f4fbc59adadfd6659bf14f3f3ef209c8cf811",
+    "name": "BptBALWETH",
+    "symbol": "BptBALWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617014",
+    "address": "0x1d44c13f7e119f09f8d2554a7af518e19c2887ae",
+    "name": "WMATIC",
+    "symbol": "WMATIC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617016",
+    "address": "0xeaebd4ceb45691931171fbc87b0f83e7a3f94e11",
+    "name": "STAKE",
+    "symbol": "STAKE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617018",
+    "address": "0x93fccd41d2a177d42a364c58383643fc859ddee8",
+    "name": "xSUSHI",
+    "symbol": "xSUSHI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617020",
+    "address": "0xb39b951931c4821d6799e1a962e2a6bb26688d7b",
+    "name": "WAVAX",
+    "symbol": "WAVAX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617141",
+    "address": "0xbe7d69f8f1c79dfb092f4537ff16b34ce312ab9a",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617142",
+    "address": "0x1202fdce534e9f91408faa9d942f0ae97d052bb4",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617143",
+    "address": "0x81cd153f40c662468d758e928b0d289aca710f24",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617144",
+    "address": "0x3bce3f4db5b2e017f54bcd7aa6263b2bd4f75970",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617145",
+    "address": "0xdde1a823f61d43074fb0ca73ca352c2fb0535eef",
+    "name": "WETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617148",
+    "address": "0xbefd5ff24f345b4f1546d5c228d1e0f5db58f466",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3617149",
+    "address": "0xad3969fee833e4ce9b6c3440c6ee000b07fe9d6b",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3617151",
+    "address": "0x4a00f07be611bdfa66011701f5ee6ac2c9e67421",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617152",
+    "address": "0xafa39018e803d9103c4173b5f47ce2c2ea66f4b4",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617153",
+    "address": "0x5957aed5fbb78e786ce4fad6e69dc8792776ba1f",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617154",
+    "address": "0xa953ccb8cc80339656fea3dcc4fb99585f036b13",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3617155",
+    "address": "0x14e825efcde70364211070bd7c951a775e0095d5",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617156",
+    "address": "0xed477b3ba3ba0ff4de295112a071d0724eb89757",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617157",
+    "address": "0xc0598aa19621ce77927d1849680b05b8940eb158",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617158",
+    "address": "0x1b789cee8b52142b6af01c7a1a25bda567f43d0e",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617159",
+    "address": "0x65d9bfb7e7f2d01d7fe92861a9865fb280605047",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617160",
+    "address": "0xcdb0410155b4187425f46ac73893d2377f1b3bb4",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617161",
+    "address": "0x1c7bb63bdb5dfe4e13c85aa1c6391ce8bb16458c",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617162",
+    "address": "0x2420de152062f7e42bf6b53bf1c3ba48951015d5",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617163",
+    "address": "0xc0c0dac787191987a6690a2df40c088d48711955",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617164",
+    "address": "0x7e97fe79230d19bec4cd07f805a9d7bdb1bc8999",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617165",
+    "address": "0x5dd3fe21d193d5c8c06eead64d8f7c6d7c07f775",
+    "name": "UniDAIWETH",
+    "symbol": "UniDAIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617166",
+    "address": "0xdba14ec17388c64d1e4f35ea813c27b72284f9ac",
+    "name": "UniWBTCWETH",
+    "symbol": "UniWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617167",
+    "address": "0x4011a914fd3146bf97a5bd9f008fb965813fd404",
+    "name": "UniAAVEWETH",
+    "symbol": "UniAAVEWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617168",
+    "address": "0x88c4f5c9014b2f2c5689c8d27c6e5bf87688a7c6",
+    "name": "UniBATWETH",
+    "symbol": "UniBATWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617169",
+    "address": "0x9e9400a38e8d21ab6f3f6171a05a358cd58ad050",
+    "name": "UniDAIUSDC",
+    "symbol": "UniDAIUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617170",
+    "address": "0x1e0bb90115bffc649a6bd7f45473b53ca3c9f2b3",
+    "name": "UniCRVWETH",
+    "symbol": "UniCRVWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617171",
+    "address": "0x3c1175e02cb62528c1951a4436d240cae64c2817",
+    "name": "UniLINKWETH",
+    "symbol": "UniLINKWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617172",
+    "address": "0x2deda86924f41ce3492358d3c6811980b4030661",
+    "name": "UniMKRWETH",
+    "symbol": "UniMKRWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617173",
+    "address": "0x39c2df5f7384a4f8634f0613c386f9f76e79fccb",
+    "name": "UniRENWETH",
+    "symbol": "UniRENWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617174",
+    "address": "0x5543907d31a56230db938cf0842363c6d75508e5",
+    "name": "UniSNXWETH",
+    "symbol": "UniSNXWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617175",
+    "address": "0xeba236a41181eee9876e3705cbf7ed3435613002",
+    "name": "UniUNIWETH",
+    "symbol": "UniUNIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617176",
+    "address": "0x38287610b3e2bdba2274e570bab9188c1f2361d9",
+    "name": "UniUSDCWETH",
+    "symbol": "UniUSDCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617177",
+    "address": "0x8a31f7059e0f02f77ed6696dd77750829b4b2af7",
+    "name": "UniWBTCUSDC",
+    "symbol": "UniWBTCUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617178",
+    "address": "0x8ceba1245c69bd7fa8552157b543040ca028caa3",
+    "name": "UniYFIWETH",
+    "symbol": "UniYFIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617179",
+    "address": "0x55dc18f74b54f827812f10c94a079c92a1e5e957",
+    "name": "BptWBTCWETH",
+    "symbol": "BptWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617180",
+    "address": "0x30c60512f681b48e467fb68b694c22e59e36d20c",
+    "name": "BptBALWETH",
+    "symbol": "BptBALWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617181",
+    "address": "0x1792191a3d895cfb7532790c3c6b8adcc890d234",
+    "name": "WMATIC",
+    "symbol": "WMATIC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617182",
+    "address": "0x504915c15bc0637302e1bb2d1b6a86f1f84382b2",
+    "name": "STAKE",
+    "symbol": "STAKE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617183",
+    "address": "0x66a8a221e5001b459f424b49a0407fdf6cdc2d56",
+    "name": "xSUSHI",
+    "symbol": "xSUSHI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617184",
+    "address": "0xdbccf5284385fee197d3f0e1f7a44b5899f09156",
+    "name": "WAVAX",
+    "symbol": "WAVAX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617231",
+    "address": "0xe11e45b52b129b9d0f9566968d710d609d548386",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617233",
+    "address": "0x1d4ed7e6c179e70ac8618c98db1b3bb2a247633c",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617234",
+    "address": "0x9bd345683a38cbd84691259e46793c226ee4888d",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617235",
+    "address": "0x59bedfa24be92c6550bff3d5756f4fe301982bee",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617236",
+    "address": "0x8c3ec0d6cfdb56d143e50743068e2d99903ffaf0",
+    "name": "WETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617237",
+    "address": "0xb4e4b5b3e96ec491373a6a8a4b6864a13eb47f9f",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3617238",
+    "address": "0xb50e79c8e5a81923e65411ced777e52cc4b8aed1",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3617239",
+    "address": "0xde514b4a5d70bb459e091d0b6a26a85a392ebc92",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617240",
+    "address": "0xa0f754801b457a7093eaac2340a9bd31898c2fcd",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617241",
+    "address": "0x7029e3ec3620d45e3dc6e84d195e694260121183",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617242",
+    "address": "0xada0a97ea03edc62b769e659272eceeed4ada2ce",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3617243",
+    "address": "0xece77a631a4cae84fa5f35b66129776bdb924ea4",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617244",
+    "address": "0x4d912005c36d822311faaefcb47ea61835440100",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617245",
+    "address": "0x561b295c67f4e5491305fad3b783bfdf81bcce2c",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617246",
+    "address": "0xe7fdc486114b70c55160d3462d76c61f3a1f4806",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617247",
+    "address": "0x2ed6818389bbca92a96e79d41b1d95a18f5972e6",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617248",
+    "address": "0x7eb1dc29c52e81f153407e86fd9d880a2659db14",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617249",
+    "address": "0x91038affc16983d77a0d5e661cdd033583f5ca3f",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617251",
+    "address": "0x998c734aea50ce7e7fe9d7d8572449fcc52fc22c",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617252",
+    "address": "0xeea8fbc157d4d3c15fd1cb853dcfb5f0bf76aefb",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617253",
+    "address": "0x27b75ab6969357f168e5584a45adfe1b2a57a577",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617254",
+    "address": "0x31ca89e1968a96cf2c027b74caeea61288d706a1",
+    "name": "UniDAIWETH",
+    "symbol": "UniDAIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617256",
+    "address": "0x9747828bb26c60ae04cc6082906cc22f2885ad6b",
+    "name": "UniWBTCWETH",
+    "symbol": "UniWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617258",
+    "address": "0xc9e23448144f2d8ae7ceb352bcda6337da72be3d",
+    "name": "UniAAVEWETH",
+    "symbol": "UniAAVEWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617259",
+    "address": "0x6e9c699e0857c23e5973d5d676fbd178e812bbc1",
+    "name": "UniBATWETH",
+    "symbol": "UniBATWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617260",
+    "address": "0x8611c019714ce26b5f7bdd0f13f07075cb029a60",
+    "name": "UniDAIUSDC",
+    "symbol": "UniDAIUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617261",
+    "address": "0xb64cebf11ed5fa36ad23b43d5f970843e99c5a44",
+    "name": "UniCRVWETH",
+    "symbol": "UniCRVWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617262",
+    "address": "0x661708cb01ad84ab68ea868ff19bc810a13d10b5",
+    "name": "UniLINKWETH",
+    "symbol": "UniLINKWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617263",
+    "address": "0xd28db287d4b4b4b5c9d5d269240df5f462c0d00d",
+    "name": "UniMKRWETH",
+    "symbol": "UniMKRWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617264",
+    "address": "0x7ccad13b97197ea07f3ed0cb1cc5dd99a325633f",
+    "name": "UniRENWETH",
+    "symbol": "UniRENWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617265",
+    "address": "0xe95f284d9b19b9c8ba6257841706b6361e9d7edf",
+    "name": "UniSNXWETH",
+    "symbol": "UniSNXWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617266",
+    "address": "0x7b0b4eae6b942aa32a04188e98e475f1b5c8e2be",
+    "name": "UniUNIWETH",
+    "symbol": "UniUNIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617268",
+    "address": "0x2c96e61bfd37d6eb66debcd1c277ff3f9e42b544",
+    "name": "UniUSDCWETH",
+    "symbol": "UniUSDCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617269",
+    "address": "0x6676bd08182ba69c0b8fcdcb6ca05910f0ef35d4",
+    "name": "UniWBTCUSDC",
+    "symbol": "UniWBTCUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617270",
+    "address": "0xa5f9c4ccd1571e0180af8010b2f2ae66f97fe074",
+    "name": "UniYFIWETH",
+    "symbol": "UniYFIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617271",
+    "address": "0x2a015fdd2f8269da7cda497c79a0e2e08f7c58f1",
+    "name": "BptWBTCWETH",
+    "symbol": "BptWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617272",
+    "address": "0x62513194efd1b19638864ef2d381554432ae9ef0",
+    "name": "BptBALWETH",
+    "symbol": "BptBALWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617273",
+    "address": "0x0222748cb22fb529265b71000722f085181d3e7f",
+    "name": "WMATIC",
+    "symbol": "WMATIC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617274",
+    "address": "0x290c76f4722b1b1dd418e58a41c0102424f38af8",
+    "name": "STAKE",
+    "symbol": "STAKE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617277",
+    "address": "0xb5df9d07ab20beb607e236cb4d92b1aa415e3fc8",
+    "name": "xSUSHI",
+    "symbol": "xSUSHI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3617279",
+    "address": "0xa6f1467781071484ddde1dd38c4d587a582d870d",
+    "name": "WAVAX",
+    "symbol": "WAVAX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3635475",
+    "address": "0x16e3df6af10d19145f3a8b985d89ebd90ce25063",
+    "name": "gvvvjvj",
+    "symbol": "LKIOO0875",
+    "totalSupply": 30,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3636235",
+    "address": "0x0000000000000000000000000000000000377c0b",
+    "name": "Test ERC20 Token",
+    "symbol": "ERCT",
+    "totalSupply": 100000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636591",
+    "address": "0x6753c1f1b8abd1991b084729258d6b0acd7744d2",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636592",
+    "address": "0x93af7045cd932e3c9324a1d442071f15e5923f3c",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636593",
+    "address": "0x168f3f7801595c1427d766812de5e4c807a9c2f6",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636594",
+    "address": "0x4249ac0e1a517ea8f07a5dc31e2f55c6772302d8",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636595",
+    "address": "0x6cf83edb9ed8e3802d59640a2c698e00679bc553",
+    "name": "WETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636596",
+    "address": "0x4bda6126b9c314677b7ad91266e5c8a9598febdf",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3636597",
+    "address": "0x8ba56cb4c842317912c91734bc62e0faf539751e",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3636601",
+    "address": "0x803c6d847021e989a83fd57a50a97a7c32158184",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636603",
+    "address": "0xa28986e7109ce99ecf06897ddd17dc6592600c1b",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636604",
+    "address": "0xea610fce60f822f8aba21d561dd262f1e8fd1d5a",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636605",
+    "address": "0x775c24cafff97dd7cd39fd431b357ce29e60bd39",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3636606",
+    "address": "0xc0cebeb97a57c7f2d434835e41ba17416760c441",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636607",
+    "address": "0xa2f335b3568e2407a209a0187b8ade552e348a05",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636608",
+    "address": "0x09ceede8a674caa6989e5bb21e0baec5f125ea2d",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636612",
+    "address": "0xd7fa981abe72ca68eae76aaddcfbf8b3cbc5fd2f",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636615",
+    "address": "0x9f7d7814545af6a76ba30a9a0b59b094f3763b14",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636616",
+    "address": "0x59fa0296bf9fde4662192e18ea32d07cf5ec2805",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636617",
+    "address": "0x536b71362a84e2d48715d7c3f06e457197b62901",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636618",
+    "address": "0xf0f774cc54a46ae2f63973eff866eccf75d5b340",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636619",
+    "address": "0x1331f53e16fde764007ae57e1a3b4fdbbae88da0",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636620",
+    "address": "0xb41461e4f2182da09881588904c8f1319df8bc32",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636621",
+    "address": "0x22088691fd3dc25c45b1b000930adb8bf9105fe0",
+    "name": "UniDAIWETH",
+    "symbol": "UniDAIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636623",
+    "address": "0xe7f2d6a08b07e030c46f728122c1df903f566a7a",
+    "name": "UniWBTCWETH",
+    "symbol": "UniWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636624",
+    "address": "0x1e614931e397b0d10ff5c687aadaad84601091fc",
+    "name": "UniAAVEWETH",
+    "symbol": "UniAAVEWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636625",
+    "address": "0xbf4ca9c5c6b27e205ca3802d8b5d92c471c4e739",
+    "name": "UniBATWETH",
+    "symbol": "UniBATWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636627",
+    "address": "0xdc34ed3034e00f874f93d8218620d4622c7bf660",
+    "name": "UniDAIUSDC",
+    "symbol": "UniDAIUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636628",
+    "address": "0xa397e2f037f69f0beab5fd3178202580b6e68609",
+    "name": "UniCRVWETH",
+    "symbol": "UniCRVWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636629",
+    "address": "0xc6718f6d56e75f32490a0559fd09ffdbc02fcbbe",
+    "name": "UniLINKWETH",
+    "symbol": "UniLINKWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636630",
+    "address": "0xa3065373af6ffa6163ea504a795b4bc148376355",
+    "name": "UniMKRWETH",
+    "symbol": "UniMKRWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636632",
+    "address": "0x0a28095bcbe6097d07902c8667b9fec51aaec095",
+    "name": "UniRENWETH",
+    "symbol": "UniRENWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636635",
+    "address": "0x2bae490225cc49c490683f4463767a0603b58e01",
+    "name": "UniSNXWETH",
+    "symbol": "UniSNXWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636637",
+    "address": "0x34bb30ea19936d33da63976b3f1465d215eb5c93",
+    "name": "UniUNIWETH",
+    "symbol": "UniUNIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636639",
+    "address": "0x7d80f31b35223d4b5ec57fe564a5cd88c1724ea8",
+    "name": "UniUSDCWETH",
+    "symbol": "UniUSDCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636640",
+    "address": "0x72a263943c7c38022861a12a2ece93e7793caade",
+    "name": "UniWBTCUSDC",
+    "symbol": "UniWBTCUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636641",
+    "address": "0xc6861d47cd32f7f3c2445c3a11a67606cfde5fd8",
+    "name": "UniYFIWETH",
+    "symbol": "UniYFIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636642",
+    "address": "0x37cbc27f047fe6780ff3a9c8e3178cb92ce6c08c",
+    "name": "BptWBTCWETH",
+    "symbol": "BptWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636643",
+    "address": "0xfea79125e698a6128f7063d2f0e791e01325121a",
+    "name": "BptBALWETH",
+    "symbol": "BptBALWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636644",
+    "address": "0xf192004d45648fa6b255f953307e79c16bfb5084",
+    "name": "WMATIC",
+    "symbol": "WMATIC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636645",
+    "address": "0x6d5c92a36d00fca4adf8f40e385ce599f61d1891",
+    "name": "STAKE",
+    "symbol": "STAKE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636646",
+    "address": "0xc5d01850c262380f73349f4c3b6d3c739c5965cc",
+    "name": "xSUSHI",
+    "symbol": "xSUSHI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636647",
+    "address": "0xf78bcae0c873f0e2a41612bd742784e4881f6a4b",
+    "name": "WAVAX",
+    "symbol": "WAVAX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636678",
+    "address": "0xbf31c4f51b4fd342e8364c0fb42a867fb9a738e5",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636680",
+    "address": "0x4b7706196f7d3a5c7c3928bf4b737c3b45d71b98",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636681",
+    "address": "0x8397cbc1cc586c83f2df5734490ca8ab690e42b9",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636683",
+    "address": "0xd7fb47bf21d4f2248ee7d2c1cc44e0b46f43bae4",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636685",
+    "address": "0x1bb10b8f4d56b0e8678cb59a0a4dc0d743892967",
+    "name": "WETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636687",
+    "address": "0xf3ac48da6423503e3097c2ed25b880db6e21beb2",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3636690",
+    "address": "0x85965c969b535c0a63ed5365b79460b8854d78de",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3636692",
+    "address": "0xa5001f9dade2c1d484999b8f4f759e0a0777a85a",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636696",
+    "address": "0xe283d9622fd86399cc59aba329098963c75de9cc",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636698",
+    "address": "0x898c7e376ae8863e457ed87fca9a4132ef277bca",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636701",
+    "address": "0x50272dffb53778875c49553a4f9cb72400db7150",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3636703",
+    "address": "0x06d58e7bc12b9140b451950e051ebd4de486cad4",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636705",
+    "address": "0x7e79e37020d2f2f899aeb65058f25ff16f20a1b0",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636709",
+    "address": "0x11828b235fd5db74aa8131d0a3a437b850635cba",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636711",
+    "address": "0x07e3fac92baa030c2ba3993df7ff93fd28597096",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636713",
+    "address": "0x0475bb4221abe335fddd21f824cf136cd85178ef",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636714",
+    "address": "0x96fa2b2d0021f9242c6f015fe28c0158c7035e4c",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636717",
+    "address": "0x73c6ea2efc9cec5504cb4277ba9d892d984f1e21",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636719",
+    "address": "0x667690cd164a70503167835055177ae178f8ffb1",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636721",
+    "address": "0x02764f76dcd50b6c83c3db565907200207b92d97",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636724",
+    "address": "0x8cd8a954a76273e9b0aa5f515905f6ede499d514",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636725",
+    "address": "0xb3b002af2352abc638dacc3c1d2ebb81d9e14421",
+    "name": "UniDAIWETH",
+    "symbol": "UniDAIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636728",
+    "address": "0xc998f6a5ca34ae9eeb96f1014250f59038d8c33e",
+    "name": "UniWBTCWETH",
+    "symbol": "UniWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636731",
+    "address": "0x3e1049ca07dd4b9797af3a53fc93044c9d37a4e5",
+    "name": "UniAAVEWETH",
+    "symbol": "UniAAVEWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636733",
+    "address": "0x229b8f4612c3530d57ffcffa8d64cef15f3f7768",
+    "name": "UniBATWETH",
+    "symbol": "UniBATWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636736",
+    "address": "0x27e5b05ca67fb8f4741dfecf6b67228efe339756",
+    "name": "UniDAIUSDC",
+    "symbol": "UniDAIUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636738",
+    "address": "0x011e198827f65297d31626b596683d4342708bd2",
+    "name": "UniCRVWETH",
+    "symbol": "UniCRVWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636739",
+    "address": "0x4ec9dd8037c370094c1585836e7fc2776efef212",
+    "name": "UniLINKWETH",
+    "symbol": "UniLINKWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636742",
+    "address": "0x0a62ff4c5ee36126577bd24b1bcbdada4ded50ae",
+    "name": "UniMKRWETH",
+    "symbol": "UniMKRWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636744",
+    "address": "0xe1c9008693aea99709d7ee34621ea6b0765b74e0",
+    "name": "UniRENWETH",
+    "symbol": "UniRENWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636746",
+    "address": "0x03179a7303066751aa9db3d3b736468831c94220",
+    "name": "UniSNXWETH",
+    "symbol": "UniSNXWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636748",
+    "address": "0x6198bc321b57cd3f250e0b5ad79b429374cb2fe8",
+    "name": "UniUNIWETH",
+    "symbol": "UniUNIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636750",
+    "address": "0x38f29903020884f0749606f31a01684ed8ab6a70",
+    "name": "UniUSDCWETH",
+    "symbol": "UniUSDCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636752",
+    "address": "0x77f746a5d9ea71c10c3d6dbea4a0c5d6ae89221a",
+    "name": "UniWBTCUSDC",
+    "symbol": "UniWBTCUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636754",
+    "address": "0x0231c9419cf132dc5b266c76b25e9bf3e7250640",
+    "name": "UniYFIWETH",
+    "symbol": "UniYFIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636755",
+    "address": "0x2ac0d543b81e04e6a1fb48b46e5d8de5188d749a",
+    "name": "BptWBTCWETH",
+    "symbol": "BptWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636756",
+    "address": "0x46f5b7802f664fd458e91119557777a0f9974ce2",
+    "name": "BptBALWETH",
+    "symbol": "BptBALWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636757",
+    "address": "0x87a51cf77d027c1ea979628a22dd4ae0db4749fd",
+    "name": "WMATIC",
+    "symbol": "WMATIC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636758",
+    "address": "0xbf120bf0b15eb4e06186d24c72f89d49dddf9873",
+    "name": "STAKE",
+    "symbol": "STAKE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636759",
+    "address": "0x5180e66d4d074f206fd2a714aaccba0718f6c7ac",
+    "name": "xSUSHI",
+    "symbol": "xSUSHI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636760",
+    "address": "0xbe41a48fa2aa39fb188aa3d6c45365b3d35c198b",
+    "name": "WAVAX",
+    "symbol": "WAVAX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636808",
+    "address": "0x022494647acaddeb3b6cbf8006c0ccb2924639d8",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636814",
+    "address": "0x87cd23e4a0e189afefe56abbcfacaaf8ca4f618d",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636816",
+    "address": "0x895cec924232aacdc769ad936ff0f5e40e9e2ae2",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636820",
+    "address": "0xecfbffa46d84fc926908abada9723663faef17c6",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636823",
+    "address": "0xf9f4c4affcb17f5e9db53889e436a73b520b4634",
+    "name": "WETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636826",
+    "address": "0xc0beec50568eac7f7fea414262daa53a4aa768f6",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3636828",
+    "address": "0x174aedb736d268c98bd11a586aa06f579d008a75",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3636830",
+    "address": "0xb02ed4bba0d40d16b4b52f285bd4dfb99ff0eda8",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636832",
+    "address": "0xd3250bbec564d1c8e4b79c297bed5fdac749008a",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636834",
+    "address": "0x398d7832b2205dc183f0b221f6ed05e6ca9ebd63",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636835",
+    "address": "0xc6d8a4a4c30fdd4ac68e56b35b529296c509edb1",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3636836",
+    "address": "0xa458a50f39d167d3c012dc69af5f10e47ea982cf",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636837",
+    "address": "0xa74eb0738800c789d82cf90843406fbd4988e374",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636838",
+    "address": "0x3334bbb7dd61a79a4c5d7c6e834e5172a1d16e81",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636840",
+    "address": "0x602ceefcdfcb08b5ad4fa8d8871939763cc5c735",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636842",
+    "address": "0xf11bb6a7ffeffe58e413d7112f592c4921c0e211",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636843",
+    "address": "0x5d47939cc147b0580474b117aabd170510daaf90",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636844",
+    "address": "0xa0e5647d52e1d17d9ae818399b3374a61b6cd413",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636846",
+    "address": "0xb006e292c68fa8a78682e9996869600b1cdeabac",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636847",
+    "address": "0x5fdae0fc7d2d106653f5cd1b65d96c22e8f8c4db",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636848",
+    "address": "0x3526f7b9b0ef148f760220f26293dd7c9438f3fb",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636849",
+    "address": "0x8151f6cb8a9006d8c645ea0213ad35975201c9b7",
+    "name": "UniDAIWETH",
+    "symbol": "UniDAIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636850",
+    "address": "0xbe999833dbc6dc22b45fd47c24c0dbdb9e30de28",
+    "name": "UniWBTCWETH",
+    "symbol": "UniWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636851",
+    "address": "0x76ee9474726af43923bf4fd2a745cd38c5488f08",
+    "name": "UniAAVEWETH",
+    "symbol": "UniAAVEWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636852",
+    "address": "0xee62ebd9f51697aed4ae40f6754d25e5caffa96d",
+    "name": "UniBATWETH",
+    "symbol": "UniBATWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636853",
+    "address": "0x194bcf28ee820ba523a7d710c8dbc13ead3e841f",
+    "name": "UniDAIUSDC",
+    "symbol": "UniDAIUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636854",
+    "address": "0xbc09e8172b574e07f4b09ec07da17bf40c21d2f5",
+    "name": "UniCRVWETH",
+    "symbol": "UniCRVWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636855",
+    "address": "0xb7dbe3901eeb7fa5acc4a88c0a49c010df6e9596",
+    "name": "UniLINKWETH",
+    "symbol": "UniLINKWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636856",
+    "address": "0xf671f061c3ece8ab58d5e1ada471edaf92d85341",
+    "name": "UniMKRWETH",
+    "symbol": "UniMKRWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636857",
+    "address": "0xa9101802b58ff73a764d73e12b5b355de12e8277",
+    "name": "UniRENWETH",
+    "symbol": "UniRENWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636858",
+    "address": "0xc961454567edafe6577ce8fa24817e3ae0713d0a",
+    "name": "UniSNXWETH",
+    "symbol": "UniSNXWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636859",
+    "address": "0x4590ab8b96d2d0873c02c236f92a19bb35b18a02",
+    "name": "UniUNIWETH",
+    "symbol": "UniUNIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636860",
+    "address": "0xc38ffc8ab637b7da49ae439221c47b4be74fb294",
+    "name": "UniUSDCWETH",
+    "symbol": "UniUSDCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636861",
+    "address": "0x9515733fcea804219423a0cdc9a7ac512bd1eee5",
+    "name": "UniWBTCUSDC",
+    "symbol": "UniWBTCUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636862",
+    "address": "0x4e0d16f5e119bf49297322b861682b3ca780b668",
+    "name": "UniYFIWETH",
+    "symbol": "UniYFIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636863",
+    "address": "0x0c2807ef12482f5b316dfdfa7e577a473c413f53",
+    "name": "BptWBTCWETH",
+    "symbol": "BptWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636864",
+    "address": "0xf1efd89022ea2c6b941c736e2da9fe59d6a40069",
+    "name": "BptBALWETH",
+    "symbol": "BptBALWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636865",
+    "address": "0x7a001b31a3547fd24342bbc25fe846c629da8232",
+    "name": "WMATIC",
+    "symbol": "WMATIC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636866",
+    "address": "0x5b8def286473ee3e69ebbf5d12e6532888e990df",
+    "name": "STAKE",
+    "symbol": "STAKE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636867",
+    "address": "0x614b4458164e3ef178f12793c654902ecf77b7f9",
+    "name": "xSUSHI",
+    "symbol": "xSUSHI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3636868",
+    "address": "0x9dc44873988a73841011123298b77fbec0737d7b",
+    "name": "WAVAX",
+    "symbol": "WAVAX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637003",
+    "address": "0x0a5c0c99a6f3b8215aedb075a1f39795a9ae651c",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637006",
+    "address": "0xc0e7d1c4594beb0d7ef6614350b697423a895ea0",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637009",
+    "address": "0x79c655d992eed7f9e518740b4183dfee8fd5f778",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637012",
+    "address": "0x169ed811980f3d77c19823ed422ddc507c720fab",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637013",
+    "address": "0x15dcfdc077f9f78b46446f223725cb44126a0be0",
+    "name": "WETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637014",
+    "address": "0x013e2e237ce7395ef3b9359c1353a2c27da3daa5",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3637016",
+    "address": "0x91326adec6fc7ad3993ba79279912e10f7acc555",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3637018",
+    "address": "0x879d07bd03e8802bb7808cd46ae397824fadee73",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637021",
+    "address": "0xa99aca391dff2d874149cd794399b00af9932d83",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637022",
+    "address": "0x125365be42b34bc537c76df2f8dd185d07d217b2",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637024",
+    "address": "0x7042a9ca412bd5641f114c5db4a0b51bd1fc7174",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3637027",
+    "address": "0x89b9d766695999c0fac135687e7a5aea0a92d75a",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637029",
+    "address": "0x28a972f48eacd35785522a01be1ca80e0c4ef349",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637031",
+    "address": "0xd2317afb599ff16f9b4c93c616a1a2f84be3801c",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637033",
+    "address": "0x12227f9f974e8fc2cc1ffc73a18c4fe05765b2a2",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637035",
+    "address": "0xf328ac1b53b5443951345e6cbdcac28e5a42b383",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637037",
+    "address": "0x7bb270411a3af79040fd7feb9eba9edfe502ab64",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637038",
+    "address": "0x1fb3eb33b4bb895d57b8adb14b74d129a53eca2e",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637039",
+    "address": "0x3165cf2574e4cb9c55b31b02a2bc8efe326e4933",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637040",
+    "address": "0x4e96910ee189edca276b37d2d8106d011c470bf5",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637041",
+    "address": "0x8a59e1f0f99eb8d26027ca3aed14eac0eae72bad",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637042",
+    "address": "0x9db8db5cb642be0c10826815b8ce9eb64210aea6",
+    "name": "UniDAIWETH",
+    "symbol": "UniDAIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637043",
+    "address": "0x49a4761881583f2e0dc277488469f7b1f169f7c1",
+    "name": "UniWBTCWETH",
+    "symbol": "UniWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637044",
+    "address": "0xedd3e15f674c290b12f289a7538f32154cc7e227",
+    "name": "UniAAVEWETH",
+    "symbol": "UniAAVEWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637045",
+    "address": "0x7f7bfced79dece1ddf25b937af505f06e521c53f",
+    "name": "UniBATWETH",
+    "symbol": "UniBATWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637046",
+    "address": "0xf75c81c3c540e3207d5139602c0270ac674717bc",
+    "name": "UniDAIUSDC",
+    "symbol": "UniDAIUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637048",
+    "address": "0x762165647b698e5fc92630462a7ef5c21ade7cc6",
+    "name": "UniCRVWETH",
+    "symbol": "UniCRVWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637049",
+    "address": "0xebf0e92b884b9d0353bea7c9d8d942ff3c488bc3",
+    "name": "UniLINKWETH",
+    "symbol": "UniLINKWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637050",
+    "address": "0x8e0ff43b53728848a8dbfdc2ddafea6458a5d077",
+    "name": "UniMKRWETH",
+    "symbol": "UniMKRWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637051",
+    "address": "0x7d12a1a3eb268bc380a5550256567f9aad060f5b",
+    "name": "UniRENWETH",
+    "symbol": "UniRENWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637052",
+    "address": "0x1f547c4c613b84f8beb9701afaaaaaa7d4f8de2e",
+    "name": "UniSNXWETH",
+    "symbol": "UniSNXWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637054",
+    "address": "0x6e489e6192719013b03145b7093338baaaf49bda",
+    "name": "UniUNIWETH",
+    "symbol": "UniUNIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637055",
+    "address": "0x0937ea64e6b20f13abe2eb29735885d23aa70731",
+    "name": "UniUSDCWETH",
+    "symbol": "UniUSDCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637056",
+    "address": "0x133e8958d1501b574552126dee28f476820934c9",
+    "name": "UniWBTCUSDC",
+    "symbol": "UniWBTCUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637057",
+    "address": "0x39dc3717f6cc18b6df6a9498077db5d7b797f7f5",
+    "name": "UniYFIWETH",
+    "symbol": "UniYFIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637059",
+    "address": "0xcccfd713afd62ec901df3d00d14ee0372e6122de",
+    "name": "BptWBTCWETH",
+    "symbol": "BptWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637060",
+    "address": "0xf9fe9f80b481125fb1b98fad0dd1c22bfc81ee16",
+    "name": "BptBALWETH",
+    "symbol": "BptBALWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637062",
+    "address": "0x810ff3061204c9eaa1a37e3c0412f5bf2390678c",
+    "name": "WMATIC",
+    "symbol": "WMATIC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637064",
+    "address": "0x02dfa765b0e04be5ef76d296724d57e61a0f8c2e",
+    "name": "STAKE",
+    "symbol": "STAKE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637065",
+    "address": "0x50edb93fcd49553f98be5dabb092f96dcd0e4029",
+    "name": "xSUSHI",
+    "symbol": "xSUSHI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637067",
+    "address": "0xf474b9372506d630f756562ab5ce579b47a1c9b3",
+    "name": "WAVAX",
+    "symbol": "WAVAX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637155",
+    "address": "0x42c736df4d941649edfe96e4db84e95aa6086961",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637157",
+    "address": "0x70777f07312bef7a456fb7db7b8e8f6a24bdf52f",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637158",
+    "address": "0x104d3104dab38b769e426558b35f78099e634521",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637159",
+    "address": "0x8ecefad10d74a8982cf536a3747f90fcd1ba9818",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637161",
+    "address": "0x4141dca7c0dd7c9ef0e5d4ca7c33267134ac7a09",
+    "name": "WETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637163",
+    "address": "0x2e5578f99a22078bece93f24bdf16c35a0c79b2c",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3637165",
+    "address": "0x256b82a57dbd483b679fc32210e14e175ad41fd6",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3637167",
+    "address": "0x40a5b503cc5bb0dcf4c848b5585e8cb0ed3e9510",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637169",
+    "address": "0x9db70b90a9e0e088582079c20508805e963a99d0",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637171",
+    "address": "0x1ab290c5ad9889c462af7fcc48215579b52ec282",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637172",
+    "address": "0x86f3957a13c2df2d9980809689265b6ea457fb4d",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3637173",
+    "address": "0xbfffafd9be64044d7eb6f9a57d51b7027d5fe8a3",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637177",
+    "address": "0x7571ff3af644d2918a0ada6873246f484547e69e",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637181",
+    "address": "0x2d3fcf48362b1860612d8a7cde37b1aa3fb8908d",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637184",
+    "address": "0x2eb1cdc621e41e823879b212c36e3a127d89652b",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637189",
+    "address": "0x6f51880fbef57279481e24080cc741ee57f398b7",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637192",
+    "address": "0xfefc5a616281663d4f938255f408c69e8bb72a0f",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637195",
+    "address": "0x4c2a83e28613c5b32dca517bfa917ab93ed7f4da",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637197",
+    "address": "0x36673a6456cc6e6b536ed0a16aed8c86ccafb68c",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637198",
+    "address": "0xaa259e5e2688138972592fb3c6485712d8207b27",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637201",
+    "address": "0xac6c75818de5b653761511b74c85c17737485291",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637202",
+    "address": "0xa51fa96b2b4ea469ecfc48f1d294b977278c2d03",
+    "name": "UniDAIWETH",
+    "symbol": "UniDAIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637204",
+    "address": "0xa280a0df146b3cedecd3b6a782c72e84840cadf9",
+    "name": "UniWBTCWETH",
+    "symbol": "UniWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637206",
+    "address": "0xe5e8324f4ed4795c8ab8169edf14de2038410067",
+    "name": "UniAAVEWETH",
+    "symbol": "UniAAVEWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637208",
+    "address": "0xd32dea54a6173fda5220660f02f3643239159f63",
+    "name": "UniBATWETH",
+    "symbol": "UniBATWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637210",
+    "address": "0xde0963e51579b2664a6f61bcf29c2a5cf8149aad",
+    "name": "UniDAIUSDC",
+    "symbol": "UniDAIUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637212",
+    "address": "0x9d7f8bb4aa2065114e6a41f28cda187a9bbcd31c",
+    "name": "UniCRVWETH",
+    "symbol": "UniCRVWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637213",
+    "address": "0xf179865b9baecbb63e0bb7c0d92534f9f5f46d71",
+    "name": "UniLINKWETH",
+    "symbol": "UniLINKWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637215",
+    "address": "0x8da44be3d1442717b1b241f46ace8a963aaa91f5",
+    "name": "UniMKRWETH",
+    "symbol": "UniMKRWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637217",
+    "address": "0x769aaf542e13f9fafaa654a1b7ad6eeaaebe254d",
+    "name": "UniRENWETH",
+    "symbol": "UniRENWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637219",
+    "address": "0xa6ca983675cc3479628b6d33d1c2078575aa583b",
+    "name": "UniSNXWETH",
+    "symbol": "UniSNXWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637220",
+    "address": "0xc3c26188fa354ac9b5f99541cbdd843917c57e48",
+    "name": "UniUNIWETH",
+    "symbol": "UniUNIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637224",
+    "address": "0x96f0cdd3fd3d1a70d5631a55b040a5e380192883",
+    "name": "UniUSDCWETH",
+    "symbol": "UniUSDCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637228",
+    "address": "0xaa8c84258964117db83daf39693ee05810d9cac9",
+    "name": "UniWBTCUSDC",
+    "symbol": "UniWBTCUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637233",
+    "address": "0xc371ca5af82d13a1426469761565449b5fff00cd",
+    "name": "UniYFIWETH",
+    "symbol": "UniYFIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637237",
+    "address": "0x365b33b0368b2f5fd74bb98b6390849e944f6f07",
+    "name": "BptWBTCWETH",
+    "symbol": "BptWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637241",
+    "address": "0xa806b201851448802bb49a7dad3ba9617543e99e",
+    "name": "BptBALWETH",
+    "symbol": "BptBALWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637242",
+    "address": "0xda6e3bf6f3b558f254bf74f12d1c256cf9008287",
+    "name": "WMATIC",
+    "symbol": "WMATIC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637245",
+    "address": "0x82175f77dc1aa6601f5f4a1c761370f1beb823bb",
+    "name": "STAKE",
+    "symbol": "STAKE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637247",
+    "address": "0xd777972daed8ca3899136e2b2c05e65c3c0949ca",
+    "name": "xSUSHI",
+    "symbol": "xSUSHI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637249",
+    "address": "0x2a1d1211717c45ff2b39e62b63c1289366e36939",
+    "name": "WAVAX",
+    "symbol": "WAVAX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637644",
+    "address": "0xd94ab74c67f9320740e87958e8947f37f370e485",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637646",
+    "address": "0x5b060b1c8e99d27e5f42f7d77f72d09089cbcc0f",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637647",
+    "address": "0xc8b3ef46f10d35d01e827c1c3e4497d5fd1fce97",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637648",
+    "address": "0x20e45c93e5c118b070c87c49a42ea501e8cce91d",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637649",
+    "address": "0x4d1d2bc818beacf56d9e97ad7dce90afb0eeaff8",
+    "name": "WETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637650",
+    "address": "0xce95245f036862f9747dc2cfa6123b8ed989502d",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3637651",
+    "address": "0xc2816cd3dc93c8fa5f14228fea0e4d6c7dcb94cd",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3637653",
+    "address": "0x2638b8a7d26b8dd292c171003c1f2d2ffb9ae28c",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637654",
+    "address": "0x6bd06b3705a2ca48b437e9555108024d78491a70",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637655",
+    "address": "0x0112cf0cfe7665e12561400a39f7be5db2efb307",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637656",
+    "address": "0x0f47e5378bd2ade5fa47d29a24ed28a0631f1668",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3637657",
+    "address": "0x5b51e3e429b2949707f327f1ab4668c0e3a0b66b",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637658",
+    "address": "0x7dd5fe4af3aabb7f0e6013a26dbf051f940075bd",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637660",
+    "address": "0x11870ce4d409904d8aec0f7c0897b302d5fa39c7",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637661",
+    "address": "0x1029a4cf5c90f38a30dc332c273128a6e6776220",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637662",
+    "address": "0x5c9528a4a2e4e2683dafe9895413f46707cc81f5",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637663",
+    "address": "0x8a13071ec4365f17f1146cfde1ed9fe579c0bffc",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637664",
+    "address": "0xc31524d36c91c00945a13d7e79c2a672a0820579",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637665",
+    "address": "0xedb34b7c7ee14bba3379ab437e8696a6991452b4",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637667",
+    "address": "0x244d14fe3d1d8c99b1127e5dc2575dec74af5c00",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637668",
+    "address": "0x20f1a34cde55d103b3f7d897f15b5d9818afc537",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637669",
+    "address": "0xdef36f99cbc3e7f64a569b2627a22397161f5323",
+    "name": "UniDAIWETH",
+    "symbol": "UniDAIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637670",
+    "address": "0x57be793b28f0fa9bd3f82836b782d0823e031a85",
+    "name": "UniWBTCWETH",
+    "symbol": "UniWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637671",
+    "address": "0xcdfa89925dc2010eab36d54b47d3e52d1468f47c",
+    "name": "UniAAVEWETH",
+    "symbol": "UniAAVEWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637672",
+    "address": "0x933b896521da9da830537d3b4eed194c02ffb7c0",
+    "name": "UniBATWETH",
+    "symbol": "UniBATWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637673",
+    "address": "0xdc79d6a9811f5dc189167a62512637a084c878c4",
+    "name": "UniDAIUSDC",
+    "symbol": "UniDAIUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637674",
+    "address": "0x83323354e973becacaf6746b742d45c501b0186b",
+    "name": "UniCRVWETH",
+    "symbol": "UniCRVWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637675",
+    "address": "0x537b182b4647d2aff1f31416f4bc22c34f88495a",
+    "name": "UniLINKWETH",
+    "symbol": "UniLINKWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637676",
+    "address": "0x8d3e921de3c8146614024f397bebaec5722b40bc",
+    "name": "UniMKRWETH",
+    "symbol": "UniMKRWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637677",
+    "address": "0xb36f51a5f016650f7ade0754c0bbddc505b7a42d",
+    "name": "UniRENWETH",
+    "symbol": "UniRENWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637678",
+    "address": "0x9be182e4c10a05ee80eb71cdd242f6c55334da41",
+    "name": "UniSNXWETH",
+    "symbol": "UniSNXWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637679",
+    "address": "0xcd92dd0c75d3dde1746d5037dbda671702b74ae9",
+    "name": "UniUNIWETH",
+    "symbol": "UniUNIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637680",
+    "address": "0x734e802b80d26ae71a8b6f7f41c421a1890c7964",
+    "name": "UniUSDCWETH",
+    "symbol": "UniUSDCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637681",
+    "address": "0x8f9d85bd3c513e603d9e77695eeff388202f9dba",
+    "name": "UniWBTCUSDC",
+    "symbol": "UniWBTCUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637682",
+    "address": "0x48a89ab42a4b9de1f79856b9c3ebbd2797dc6054",
+    "name": "UniYFIWETH",
+    "symbol": "UniYFIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637683",
+    "address": "0x4a122b9800cdde4282c80985615bbd17f2c7e9ba",
+    "name": "BptWBTCWETH",
+    "symbol": "BptWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637684",
+    "address": "0x8ed09181a54fe94cef55a12df6d8e5cf041ed06f",
+    "name": "BptBALWETH",
+    "symbol": "BptBALWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637685",
+    "address": "0x310a3c7f91666bf0d1c01935f86960ee13faef71",
+    "name": "WMATIC",
+    "symbol": "WMATIC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637686",
+    "address": "0xca74dfaee505c26769ff58b28e5e43c6a33d64f4",
+    "name": "STAKE",
+    "symbol": "STAKE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637687",
+    "address": "0x0330b93046c026df20512b65fd3f75c7a742956d",
+    "name": "xSUSHI",
+    "symbol": "xSUSHI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637688",
+    "address": "0x033d1385a0e2e63065d692ba270f2d88f5cb6360",
+    "name": "WAVAX",
+    "symbol": "WAVAX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637793",
+    "address": "0xb5be7d292449d49893580add05b410fb0222c03e",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637798",
+    "address": "0x8ec03e4a9880d801a42258526b3e32a3b4c67664",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637852",
+    "address": "0xc7764c5e671f04815eaf72a702463fbdff18be8d",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637853",
+    "address": "0xf52d79485761efc3bcad4b2684df5c0874096889",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637854",
+    "address": "0x33e3725c867049db6350b797b71484a41893a7d2",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637856",
+    "address": "0x429f8bfb793a671d768166060dba3d35974fc6eb",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637857",
+    "address": "0x5139b86780e17527460ab80908ae7d82933f2652",
+    "name": "WETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637858",
+    "address": "0x71d528af4d209b326f7dbef50001cf0f9de11fce",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3637859",
+    "address": "0xc90b66c61ef96eb2546ed751d8a7b3d8e06dccf8",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3637860",
+    "address": "0xafd878b4c280cc4cf7c97e702266739d8f0b643c",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637862",
+    "address": "0x4a56b23ec30158bf0bc40537ebd4c3b622cce076",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637863",
+    "address": "0xafa02da128163db28f53732bbb58e1d550430e93",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637864",
+    "address": "0x98a51bdca7c3e8b77c9e872382ade1df2d8907da",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3637865",
+    "address": "0x1e8ba3e18319df93260b53887b0d615f88b230e6",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637866",
+    "address": "0xaa957dc073df6aaa12bdb528a6f712982faf12c8",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637867",
+    "address": "0xbb846ab0622e272c06539851932d47589e573eaf",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637868",
+    "address": "0x820129256420e4aaf957ed21bec23e3c829daa04",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637869",
+    "address": "0x7ff844adcbd1a3fe759c10f1b8cf88b1036b5bdb",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637870",
+    "address": "0xe88ad67de2eeefff7be88e3d71247c415b8028ec",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637871",
+    "address": "0xe9dafb1d5308fd172df4b56ea451795297faa038",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637872",
+    "address": "0x360095c25d667ede35e783f0cbdb4d26e573a5a7",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637873",
+    "address": "0xe80578b5f6c82731eadc8125df3f1207747084b8",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637874",
+    "address": "0x49869d6d7e979f11179dc4c227f91abe1e949bd3",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637875",
+    "address": "0x6fcbc467e97814a9e83b1e9ceee2e802274acf14",
+    "name": "UniDAIWETH",
+    "symbol": "UniDAIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637876",
+    "address": "0x1fcd25ace16e06272de10dfdbe8048a7043eab3f",
+    "name": "UniWBTCWETH",
+    "symbol": "UniWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637877",
+    "address": "0xbc5ed03d02de3e3dcb1ecf880d6ddaff9a5fee51",
+    "name": "UniAAVEWETH",
+    "symbol": "UniAAVEWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637878",
+    "address": "0xc8f93cd194ab9dd3f1257a548068fe808cf4c91f",
+    "name": "UniBATWETH",
+    "symbol": "UniBATWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637879",
+    "address": "0xab5aa29d86fc037e7a6e3fb748ad40b6073e2bdf",
+    "name": "UniDAIUSDC",
+    "symbol": "UniDAIUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637880",
+    "address": "0x7ac0cbf80e48f50395d4d0a8d3307fb6a792d211",
+    "name": "UniCRVWETH",
+    "symbol": "UniCRVWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637881",
+    "address": "0x76645409273c57d3dc3853a304b1c99ef39da83b",
+    "name": "UniLINKWETH",
+    "symbol": "UniLINKWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637882",
+    "address": "0x3931c1145c0e13330c2c3b7f1be7ef92abab9cdd",
+    "name": "UniMKRWETH",
+    "symbol": "UniMKRWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637883",
+    "address": "0x8f9c17b9c2aab9cdbfdc5d79c08ef0fdf0b95e4d",
+    "name": "UniRENWETH",
+    "symbol": "UniRENWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637884",
+    "address": "0x7c79e5ff375a47b375ac546e3cede50c28fc44eb",
+    "name": "UniSNXWETH",
+    "symbol": "UniSNXWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637885",
+    "address": "0x54df4e8f552da0ced1667a1a26c9173ff9fff23a",
+    "name": "UniUNIWETH",
+    "symbol": "UniUNIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637886",
+    "address": "0x717882f7fb811478d12be9d7ad38a610172b948b",
+    "name": "UniUSDCWETH",
+    "symbol": "UniUSDCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637887",
+    "address": "0xbc7f98dbccac2bf9b1fbaf60b6c542d9f674ff85",
+    "name": "UniWBTCUSDC",
+    "symbol": "UniWBTCUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637888",
+    "address": "0x6d849d2321b603367907f4dce57a9a7ad580d4e1",
+    "name": "UniYFIWETH",
+    "symbol": "UniYFIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637889",
+    "address": "0xd118d3ceb8556c16161139268f7a6b1bb2f75144",
+    "name": "BptWBTCWETH",
+    "symbol": "BptWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637891",
+    "address": "0xdd159b5fc44a157c685a9ad9c09894c2eb961be3",
+    "name": "BptBALWETH",
+    "symbol": "BptBALWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637892",
+    "address": "0x4c3759931ce23f07dd2cd5af726203e12223ce63",
+    "name": "WMATIC",
+    "symbol": "WMATIC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637893",
+    "address": "0xffa99102fd4e6cf5877ae779e22596f2b54da82a",
+    "name": "STAKE",
+    "symbol": "STAKE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637894",
+    "address": "0xb6b582807111e33fe1ec06f0ce625cfcc9ed5282",
+    "name": "xSUSHI",
+    "symbol": "xSUSHI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637895",
+    "address": "0x8ea96071e1986509db4c2e275ada3de65550e04c",
+    "name": "WAVAX",
+    "symbol": "WAVAX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637973",
+    "address": "0x6ffa89eadd9fdc179bd8892405d803ac460fbe8b",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3637977",
+    "address": "0x29807ec448e70b3b8c4400c67e531b3506a31b35",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3638557",
+    "address": "0x7828c1477f82b50552220be962c4e10851ea0b73",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3638558",
+    "address": "0x8b74119b5beb63ef81c8de4e7a1dab7df3de80ff",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3638559",
+    "address": "0xda3810ab993e6a73dc9aa732be6eb3016d7dba07",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3638567",
+    "address": "0x68f05f5cac560006f19ada44241fd657ab3ab66f",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3638570",
+    "address": "0x8636936a34787738d3277877cba449f0f2a92b92",
+    "name": "WETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3638573",
+    "address": "0x7b277a1d0aeddb6986ab1d43586ab8956353d05f",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3638576",
+    "address": "0x0534e42a622c6ecd33af8fd7106ff1276e2915e2",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3638578",
+    "address": "0x170975edf587c942bf67a8023ee5361d87c46f87",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3638579",
+    "address": "0x06dad479b3696592dcc28b8ed1f197e8df6037de",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640251",
+    "address": "0xf0dd7b6246b947c16ffaa66fbcd11cf7c4c4c386",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640254",
+    "address": "0x718d632845d2ccf1a515db15e433656d8650e145",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640364",
+    "address": "0xc5658416f22f4e785b3d790792be34e958b46a41",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640367",
+    "address": "0x03b69352d27699d2fe48690d07653755d66a3dbe",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640368",
+    "address": "0x023e50601ce9f9775a89ee766e423e01639ddbc0",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640369",
+    "address": "0x493062118f3aca8a4d34998039c14960f60614fc",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640370",
+    "address": "0xd79af800b9c2cf812925221fb2c25e27bbf0747b",
+    "name": "WETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640371",
+    "address": "0xf88e3748a0da7c2f25edd0142ae3a6a6c665a8c2",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3640374",
+    "address": "0x00e5cbd3b7498cc9e3f90b55ef250020b681cc8b",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3640377",
+    "address": "0xa3922655d1ed024f9e4fef2fc6046eee36b01688",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640380",
+    "address": "0xa1181d27566c9fe17b0157c416dc267d110957a9",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640381",
+    "address": "0x5fc037276b9b28feb4a899b5f2eb4541fedd8a4e",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640382",
+    "address": "0x9129e8fed14c04cb6ccd70e8d939198e9254f5ee",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3640383",
+    "address": "0x85f45e35dd4001e7a26595defc75473bf01c3f48",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640386",
+    "address": "0x52654918466309f61e0ef8182b0a6be2e32afab1",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640387",
+    "address": "0x161c4c15ea8c0ba28dfc5d5149ed12935b4217ea",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640388",
+    "address": "0xddaf82e59569ee16a7214b3e310d93a0bccbf4f1",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640389",
+    "address": "0x3848b45871ed69c44f13c9b5a390006c042b6792",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640390",
+    "address": "0x93a96fd9bb1b9603937f269464903f3a1c2ec70a",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640391",
+    "address": "0xed9ee8483819f74d4aafdcc4db66d25c2c287793",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640392",
+    "address": "0x5c760fad7d49c990c40c15f9a4d05f52ffde8816",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640395",
+    "address": "0x571cf690f3be2e10e0f0e20ff9e8e2059c3df5e7",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640396",
+    "address": "0x37d59e272209c8f8bbaa2e16a342cd825dae93d3",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640397",
+    "address": "0xdc2a08a9d5235ec41c699d44d6939a035aa179f6",
+    "name": "UniDAIWETH",
+    "symbol": "UniDAIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640399",
+    "address": "0x62c4e586452cd17367ea9da07ba3669931b02c46",
+    "name": "UniWBTCWETH",
+    "symbol": "UniWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640401",
+    "address": "0xcfd636bf3abd1e6869fe3e3bcc6d85d45c84b236",
+    "name": "UniAAVEWETH",
+    "symbol": "UniAAVEWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640404",
+    "address": "0x68483df4a99d6ccf20405bf8a92332725ea8e3b1",
+    "name": "UniBATWETH",
+    "symbol": "UniBATWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640405",
+    "address": "0x5537b855591e550a305be8fdc8dc274ab3ea7bde",
+    "name": "UniDAIUSDC",
+    "symbol": "UniDAIUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640406",
+    "address": "0xb812dddb79eeafc052e0cc3f3461ab4f7331004d",
+    "name": "UniCRVWETH",
+    "symbol": "UniCRVWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640407",
+    "address": "0x6afab9d4d4ae0cc996c45609d84a3d074d1533ab",
+    "name": "UniLINKWETH",
+    "symbol": "UniLINKWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640408",
+    "address": "0xe8a035f5ffdedb8496552336175561edfc61277c",
+    "name": "UniMKRWETH",
+    "symbol": "UniMKRWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640409",
+    "address": "0x7d77188878763f390d4a55ef307762baad1c70e2",
+    "name": "UniRENWETH",
+    "symbol": "UniRENWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640411",
+    "address": "0xdaedae4d8140ead176604c577f7ea38f3bc7a621",
+    "name": "UniSNXWETH",
+    "symbol": "UniSNXWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640415",
+    "address": "0x11afd657602a2d7c2d8bf33553124c0a2a9645f7",
+    "name": "UniUNIWETH",
+    "symbol": "UniUNIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640419",
+    "address": "0x26979fa5d280aac639f30d5c8c8ec5fbe6b7575f",
+    "name": "UniUSDCWETH",
+    "symbol": "UniUSDCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640422",
+    "address": "0xd39750586d2669bbc1f10e047020b7125c3540f0",
+    "name": "UniWBTCUSDC",
+    "symbol": "UniWBTCUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640424",
+    "address": "0xcc96f488a3646fea913aed1e2c4e11852285d4c6",
+    "name": "UniYFIWETH",
+    "symbol": "UniYFIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640427",
+    "address": "0xc4bc0dcb768221025cc41efd04d8b9805cbe14a5",
+    "name": "BptWBTCWETH",
+    "symbol": "BptWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640429",
+    "address": "0xb6a1251c694466df70f446ac3ecd46bf9356a412",
+    "name": "BptBALWETH",
+    "symbol": "BptBALWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640432",
+    "address": "0xd20a54d0aeef142b6018347fce5a9804ebc324d1",
+    "name": "WMATIC",
+    "symbol": "WMATIC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640433",
+    "address": "0x2718e11ef20ef7e59b0acc33807dd42f1b016b74",
+    "name": "STAKE",
+    "symbol": "STAKE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640434",
+    "address": "0x0d80f74f0658718c4015df3ade40d19d3a74713c",
+    "name": "xSUSHI",
+    "symbol": "xSUSHI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640435",
+    "address": "0xbd27459c7bf7950d566285819d8d31328f1860f9",
+    "name": "WAVAX",
+    "symbol": "WAVAX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640650",
+    "address": "0x92435c4de0ec88dfa52c62c10c6ca567a19c2a31",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640667",
+    "address": "0x5c9dab6c9da4f0821bdac4829bcab2db24f897cf",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640855",
+    "address": "0x0bb897f919edcaa963a0957d338be88f6b6929b2",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640856",
+    "address": "0x5873227d2eda707b8841ea05ea0913f4041fb9db",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640857",
+    "address": "0x32c8fc1d4cf683456b1c9daff3095a96d2a8509d",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640858",
+    "address": "0x34e508dc79a16e997107b1f1e777b1dcc3616680",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640861",
+    "address": "0x47ea4319cfe2d3ef4be9f8bd79e60eb0c5597688",
+    "name": "WETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640864",
+    "address": "0x338db3bdf4094f7b6b12813aba747a9845061fb3",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3640866",
+    "address": "0x74556d6f4025441c0836690cd8e281a9075fea51",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3640867",
+    "address": "0x5a93248a8cce2d8b1825ab234e2f7dac53d6bc5e",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640868",
+    "address": "0x3b8084e971159c1ef2ecc650b0b778e784651b35",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640869",
+    "address": "0x066486cda75114da896a3c17232b1158d81f70a8",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640870",
+    "address": "0xabda3d18473f0b8251e7a5e951ab792eae780c11",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3640875",
+    "address": "0x187ee32f03bc240ee4b66c1c13b89663b96ede74",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640876",
+    "address": "0x220ab97e77f89d353bbbcb6ddd3771e0198cb94f",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640877",
+    "address": "0xff79c50cd97f98570373cda07e9dd43e604ae193",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640878",
+    "address": "0x5cd1e347e26581847d9f792e2a145b42d7f669da",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640879",
+    "address": "0x32d3fa031f079eb687f7003f1c040fd17b005af9",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640883",
+    "address": "0xca30d1085db4ca14f8e99a736c2de8ae04c28492",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640886",
+    "address": "0xe7598b2bf906f9d46ab957ced9d53efb58ff5310",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640887",
+    "address": "0xb7a2e479aa0711b26ed3a4ba4877297cb24ed57f",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640891",
+    "address": "0x0057e1718f733051cfe68629cc5ec0c752726c8f",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640893",
+    "address": "0x8f7f6998b4bb972c3aed37393ce4827a75bbf9a3",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640894",
+    "address": "0xe68d6af2b22702ee477883ad9eb6da7053cfe2db",
+    "name": "UniDAIWETH",
+    "symbol": "UniDAIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640895",
+    "address": "0x586711a6a1281735b2aa1710acb1e1b838befc8f",
+    "name": "UniWBTCWETH",
+    "symbol": "UniWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640897",
+    "address": "0xa44f3f7983388b3b95988a1bf7e6a631dcaf57d9",
+    "name": "UniAAVEWETH",
+    "symbol": "UniAAVEWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640901",
+    "address": "0xef0ee13d9858aeaa2b9fb3bc533dd5545986d9e2",
+    "name": "UniBATWETH",
+    "symbol": "UniBATWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640902",
+    "address": "0xc330ed364786224dfa543f0be6d93bb06069e701",
+    "name": "UniDAIUSDC",
+    "symbol": "UniDAIUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640903",
+    "address": "0xb4d9706afff6c4e22a61ebba566bdaa1a0de23d4",
+    "name": "UniCRVWETH",
+    "symbol": "UniCRVWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640904",
+    "address": "0x8a09ad68e40aff7dfeac059c1ffa972fe0bc2c3b",
+    "name": "UniLINKWETH",
+    "symbol": "UniLINKWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640905",
+    "address": "0xa45d4969d974e9f7df044206251be6493939e851",
+    "name": "UniMKRWETH",
+    "symbol": "UniMKRWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640910",
+    "address": "0x394082ded690f96610d9f69f85c90a014c428e82",
+    "name": "UniRENWETH",
+    "symbol": "UniRENWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640911",
+    "address": "0xafc41656f45172e972ddc6540e87a6bb2a26bcfd",
+    "name": "UniSNXWETH",
+    "symbol": "UniSNXWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640912",
+    "address": "0x60696aadbda1f7fd25c8d5f20be3920b578f5269",
+    "name": "UniUNIWETH",
+    "symbol": "UniUNIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640915",
+    "address": "0x85a8885c80d5ce59b66d3df0aad2ae2bd9e45508",
+    "name": "UniUSDCWETH",
+    "symbol": "UniUSDCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640918",
+    "address": "0xc561d9c3ab69e03a5ed91db976fd9ac9086feee3",
+    "name": "UniWBTCUSDC",
+    "symbol": "UniWBTCUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640919",
+    "address": "0xadca0f2e6f7ef3561da98d7c17e425251807759b",
+    "name": "UniYFIWETH",
+    "symbol": "UniYFIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640920",
+    "address": "0x9e8fdd0012a37c44df49b342ec108fe3a90a1466",
+    "name": "BptWBTCWETH",
+    "symbol": "BptWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640922",
+    "address": "0x21325bc83630f925e38f45e314ac58953473f9f5",
+    "name": "BptBALWETH",
+    "symbol": "BptBALWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640925",
+    "address": "0x982e00878ea94a2201d0ac84402a8146cea9772b",
+    "name": "WMATIC",
+    "symbol": "WMATIC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640931",
+    "address": "0x485e833ddfd467a1f301a46220799d5e846ee5ca",
+    "name": "STAKE",
+    "symbol": "STAKE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640933",
+    "address": "0x89974667eb7b54937445700a65a4ae1f4bdafbe1",
+    "name": "xSUSHI",
+    "symbol": "xSUSHI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3640935",
+    "address": "0xd54224a9ac121f9ac2807ad22d10050d41c1fe06",
+    "name": "WAVAX",
+    "symbol": "WAVAX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641005",
+    "address": "0xe5631c26911f2fd953710d3b1001c1aa6d41a5f7",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641009",
+    "address": "0x757fbcfe0f19973ec4a2f262a5f5f9e9785d0f9e",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641011",
+    "address": "0x79cb6112525839df50a18f1785ade437fac9414d",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641012",
+    "address": "0x820f97edd0e91aae728e602a39df457e9ef42844",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641016",
+    "address": "0x35e6d3e6a3b5454e89236b68bd17281d28b7d812",
+    "name": "WETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641018",
+    "address": "0x0691212af84082ab15a25f96951fbe9eb8fd51bd",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3641019",
+    "address": "0x4055a9fbfd26bd85670d49ca3d90b129791ec62f",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3641020",
+    "address": "0x0197a257eeee72249bb3f66e331f26b86f999950",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641021",
+    "address": "0xdb05eaab23cad7c0fbf71ddc7ef5f5e49dd55860",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641023",
+    "address": "0x2d48a8716a7016b4b42d9a845db8f09ee1a5f1b1",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641027",
+    "address": "0x3f5a86a38c1737109b04c93d52df347f79254473",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3641028",
+    "address": "0x06e9747df7e108162240350461fbab5eb3aec431",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641029",
+    "address": "0x9cb3fa9d8bee0c16cd2e2018c54eb213f50ab6af",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641033",
+    "address": "0x5fb62da7f8a444a2a18effda8ff4bb02f4bec257",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641035",
+    "address": "0xa901344b54b7a61d9fb3447270d3c746150dde8e",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641036",
+    "address": "0x9cbf757e019c66d45b3a6d6d7fced6d0d7562d3a",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641037",
+    "address": "0x2433b4507061670e0a7a8f36735271e735cd1bde",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641041",
+    "address": "0xbac608749f541ce02320a7333cf3c48c5d48d295",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641043",
+    "address": "0x24d3578b73c25daebcea0d098806ead6620b8697",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641047",
+    "address": "0xbc892fe45e8ca5835bd32d8e9bc8ddae25b8d86d",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641050",
+    "address": "0xd95e40129f9647f8e628c4beab4213b8ac701237",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641051",
+    "address": "0x474395c091aea5722efc4d88a8674dd56c305ef6",
+    "name": "UniDAIWETH",
+    "symbol": "UniDAIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641053",
+    "address": "0x6350b5fc3f5e53705a2404dbef98150aabc5dcd4",
+    "name": "UniWBTCWETH",
+    "symbol": "UniWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641056",
+    "address": "0xb0ca085784ddae0e4084e84913c27982bb96fe67",
+    "name": "UniAAVEWETH",
+    "symbol": "UniAAVEWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641059",
+    "address": "0x06e4dec9ae5e66ab7d502c4250d53efa27fad1f6",
+    "name": "UniBATWETH",
+    "symbol": "UniBATWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641062",
+    "address": "0x7d463b5a76f75cc70a18499edaf1673c5cd11846",
+    "name": "UniDAIUSDC",
+    "symbol": "UniDAIUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641063",
+    "address": "0xb4826ea427aa134ef493770d6ad244145bdf0289",
+    "name": "UniCRVWETH",
+    "symbol": "UniCRVWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641067",
+    "address": "0x61ae7acb79e6940ddf9b1554225a3495afbd111a",
+    "name": "UniLINKWETH",
+    "symbol": "UniLINKWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641069",
+    "address": "0x9bf8b1ecc91f24b99ab6a536da70ba39a0799768",
+    "name": "UniMKRWETH",
+    "symbol": "UniMKRWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641070",
+    "address": "0x8e3d2c54017696f05f9640a8247e88e1396dadc1",
+    "name": "UniRENWETH",
+    "symbol": "UniRENWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641075",
+    "address": "0x91cb22eff3b865b4deec159336cb96ab06febcde",
+    "name": "UniSNXWETH",
+    "symbol": "UniSNXWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641076",
+    "address": "0x2f34b4739acb73325d1b0c7178167b9721e69e15",
+    "name": "UniUNIWETH",
+    "symbol": "UniUNIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641081",
+    "address": "0x989d888ed186194686c9061e3549ae3315a676b3",
+    "name": "UniUSDCWETH",
+    "symbol": "UniUSDCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641082",
+    "address": "0x7d7970417056270e6c9ad17fe01ccadd7c0610a3",
+    "name": "UniWBTCUSDC",
+    "symbol": "UniWBTCUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641083",
+    "address": "0xed69f18f67b1221d3565e5fbca427a5d3e0e9a37",
+    "name": "UniYFIWETH",
+    "symbol": "UniYFIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641089",
+    "address": "0xd8f28a60d417d02a0fd906e0266f7e3ee1426fff",
+    "name": "BptWBTCWETH",
+    "symbol": "BptWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641091",
+    "address": "0xe7b81914bf4a285f857d8de9eff0714d835cfc7a",
+    "name": "BptBALWETH",
+    "symbol": "BptBALWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641093",
+    "address": "0xabd86d2b1b04e205fee06a0f90a903aa641c4f3f",
+    "name": "WMATIC",
+    "symbol": "WMATIC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641096",
+    "address": "0xc356e2ccbb1de9265fb43497c27d3ae7da08c8f2",
+    "name": "STAKE",
+    "symbol": "STAKE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641098",
+    "address": "0x6afbbc5bb1579f1c289cd3a741a144c71393320c",
+    "name": "xSUSHI",
+    "symbol": "xSUSHI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641101",
+    "address": "0xedee07f0954d5297a3888a88c0a0c9be7749a8b7",
+    "name": "WAVAX",
+    "symbol": "WAVAX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641348",
+    "address": "0x471ee9223dee8749e390a1450baa71cf318eca9e",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641369",
+    "address": "0x3f0f039dbe94201d3cddc4317c904801753246da",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641682",
+    "address": "0xef0fdb648d60ebee748710caaf476722e3af8634",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641683",
+    "address": "0x8006c2e153013a10539879621de5f41b4f1883e8",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641688",
+    "address": "0x3ad24a480a9858fa1d5e805e829ca644678dd199",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641690",
+    "address": "0x03a9120d73faa1b4a8acb6e3f3788adffd7322e7",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641691",
+    "address": "0x67a7a5915c00d0d9d17550e28a1b7922a7167ad4",
+    "name": "WETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641693",
+    "address": "0x04e27261cb30002c8031722bad9e65c7fef93fe0",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3641696",
+    "address": "0xe5c9dbfa3685cff03d5ef2625dcc6334b03a043d",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3641700",
+    "address": "0x67b830ebec14913a96da4d9ef98b1a5d718789f5",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641702",
+    "address": "0xf8e41874cc4d7ac9f8c5ae54dc6b2ed2bd2039b8",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641706",
+    "address": "0xbd5bfc660e60bae6b2534d206314c3cee92cd32a",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641707",
+    "address": "0xc2a70608bf616178cded26ecb3d434b5458ef555",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3641709",
+    "address": "0xbae40fc1898874de7d5fc7ddaa09539b6e62c744",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641714",
+    "address": "0x341b1cecaf9eeb4d170a8b313583b4d97a7aa69c",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641715",
+    "address": "0xd972b561d39e2435a4b57e19bca6733223bbae3d",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641716",
+    "address": "0x5e457d2d64e729ce09cdca3f1b6f9dfdced905cc",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641717",
+    "address": "0x0c5a6909923cb6edaab736fd9934882cb327793e",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641721",
+    "address": "0x3c3f15886833bbef95bde3d5fb9fbdefc1335dac",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641724",
+    "address": "0xed3d63154952044826380979169c653bde6f797b",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641727",
+    "address": "0xe6efcb36bb41482067360c49ce22cf7715ec98e3",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641728",
+    "address": "0x08d7cd1b6d1f904a2006cd5478feeb82d6f9cb60",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641729",
+    "address": "0xbcf776e3f05b39a0a2d852e2c1af103063ed5c63",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641730",
+    "address": "0xd6953a4bc8acd29fe9d69cd1b037aba59e0c9e52",
+    "name": "UniDAIWETH",
+    "symbol": "UniDAIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641735",
+    "address": "0x14dfe14ebad9c314aea5bfad028e67595a7b39f5",
+    "name": "UniWBTCWETH",
+    "symbol": "UniWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641736",
+    "address": "0xc33c35c62bdde7d253949d85b9fb3822b9683aca",
+    "name": "UniAAVEWETH",
+    "symbol": "UniAAVEWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641740",
+    "address": "0x02ee8aadbc7f66c1b03854d80b591d051d43542c",
+    "name": "UniBATWETH",
+    "symbol": "UniBATWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641744",
+    "address": "0x33acd18107fdf00ca7fee42430396abefad2a4a5",
+    "name": "UniDAIUSDC",
+    "symbol": "UniDAIUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641745",
+    "address": "0x75163b613b1b57743d4b056693d446f294cd3f82",
+    "name": "UniCRVWETH",
+    "symbol": "UniCRVWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641746",
+    "address": "0xc8c7386e3f4f9e9f32c114b5e8a403e37d93f6d4",
+    "name": "UniLINKWETH",
+    "symbol": "UniLINKWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641747",
+    "address": "0x658c8aaf356448427f20e78f79392fa788282c1f",
+    "name": "UniMKRWETH",
+    "symbol": "UniMKRWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641751",
+    "address": "0x2691ce2c6d1718777e2e03f7df08e9978ae23cd2",
+    "name": "UniRENWETH",
+    "symbol": "UniRENWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641758",
+    "address": "0xffabc896c0d4d94ff84efbcdeb430639720fa61c",
+    "name": "UniSNXWETH",
+    "symbol": "UniSNXWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641759",
+    "address": "0x18b5ba741c960ecf4b62f7cbda89cea6dd84cb8f",
+    "name": "UniUNIWETH",
+    "symbol": "UniUNIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641761",
+    "address": "0x34553ca8c19695891b03ee4fef186dbf012a6339",
+    "name": "UniUSDCWETH",
+    "symbol": "UniUSDCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641766",
+    "address": "0x170636cb686c19dbf2f7b8ca055b7d3c13f5da35",
+    "name": "UniWBTCUSDC",
+    "symbol": "UniWBTCUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641767",
+    "address": "0xa0600a0f8a68791265bea6d566d30635b5ce91c6",
+    "name": "UniYFIWETH",
+    "symbol": "UniYFIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641771",
+    "address": "0x49c81fc91754d90edba73a21367948db9bd4219c",
+    "name": "BptWBTCWETH",
+    "symbol": "BptWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641774",
+    "address": "0xd117cc848f71775d33ac540f02879f3d1b27e908",
+    "name": "BptBALWETH",
+    "symbol": "BptBALWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641776",
+    "address": "0x597b3b314d859935b1c967d3a32880d2fbd38801",
+    "name": "WMATIC",
+    "symbol": "WMATIC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641780",
+    "address": "0x559a921fdb86c8dca6fa65898efb64d283d62b0a",
+    "name": "STAKE",
+    "symbol": "STAKE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641781",
+    "address": "0x4533d51875e7cfba91e83a33260736dba29ba553",
+    "name": "xSUSHI",
+    "symbol": "xSUSHI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641782",
+    "address": "0xddcdbdb5eb8b464073ad10ef74637661da85d17e",
+    "name": "WAVAX",
+    "symbol": "WAVAX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641925",
+    "address": "0x414f940fc5e7329a4d01d19c0d10b094f855aede",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641926",
+    "address": "0x2a78802cc825e765eff8938bc8ac84e1af7d868e",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641930",
+    "address": "0x4a77540c481be9d173e2637f85fcce69fa2d7490",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641931",
+    "address": "0xa5240da125a1e5bdadaeb157ff691e7c739b2712",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641935",
+    "address": "0xe22b1047d2468a86bf6f9f6635aff21985a5d318",
+    "name": "WETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641937",
+    "address": "0xd54f368a6e98aecf30a5cd03e871a8bd92a57fc8",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3641942",
+    "address": "0xfcbb98dc1e14cdf7e22dd3c3c301d6bb2c3d593f",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3641944",
+    "address": "0x8f23cec45a82b2f50a85753ad808473c89597d32",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641945",
+    "address": "0x01fe5e2f721ed2f96d9479b78503e637ee88396e",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641947",
+    "address": "0x197b7f70b3aa08929abe13b9d7941228f7324c2a",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641951",
+    "address": "0x95314402b93d46a73acb7d1ebf16f484ed004941",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3641952",
+    "address": "0xa658e56fded37f751c69f7bdf499f4f36f47b258",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641956",
+    "address": "0x44fd8915b232479109cdf6b2df775a3d1627e572",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641960",
+    "address": "0x2f6821a9bd45605378f3d06a9bd7a7f8a45ecc71",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641961",
+    "address": "0x290f4c9c3fea1ce28a07eff74deb16b34caca916",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641964",
+    "address": "0xccb5e0d4a51083e11f343e455c6f45945069b0b1",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641966",
+    "address": "0xdca512e59860d1b22118c887281fe8296a2276e4",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641969",
+    "address": "0x5819b1abc6305f4c0073724726f01abfb761d11e",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641972",
+    "address": "0x743284a9ed5092f786f9488dd97fd8622baaa66f",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641974",
+    "address": "0x4c4bef5449cabf21e582bb47e2bf747d57bb3e09",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641977",
+    "address": "0xe15ec6e119f9259cff54bab9b36aa27444c98d40",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641978",
+    "address": "0x3fc470b51468ab4dd89ca4718a5118146595f575",
+    "name": "UniDAIWETH",
+    "symbol": "UniDAIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641983",
+    "address": "0x1f6408a66f13ad29491ed658f57efbddc8b9412a",
+    "name": "UniWBTCWETH",
+    "symbol": "UniWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641985",
+    "address": "0xfbba15e07308667ab2d7d9a5712a75086626d691",
+    "name": "UniAAVEWETH",
+    "symbol": "UniAAVEWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641988",
+    "address": "0x1c342e6cbb7f76864f79a77a3befd88b1344939c",
+    "name": "UniBATWETH",
+    "symbol": "UniBATWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641991",
+    "address": "0x16fcf38c6a5c1eb50a6379538b9b8aad95080c93",
+    "name": "UniDAIUSDC",
+    "symbol": "UniDAIUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641995",
+    "address": "0x1775927a84722aeec21a98bda8e8894746ab61ac",
+    "name": "UniCRVWETH",
+    "symbol": "UniCRVWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641997",
+    "address": "0x936537969174477056471da8f951fef889199a08",
+    "name": "UniLINKWETH",
+    "symbol": "UniLINKWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641998",
+    "address": "0x84c96f2cfe7a17b10125732ed1ae14ec5a302640",
+    "name": "UniMKRWETH",
+    "symbol": "UniMKRWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3641999",
+    "address": "0x9667d285b0eb9eb3555982700f7ac887d29041b7",
+    "name": "UniRENWETH",
+    "symbol": "UniRENWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642001",
+    "address": "0x8c24fc6af8a7fe4504d2e178ca8288646b3f8f0c",
+    "name": "UniSNXWETH",
+    "symbol": "UniSNXWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642002",
+    "address": "0xb223b906c4f8a6a642485193bb491d5035bc1923",
+    "name": "UniUNIWETH",
+    "symbol": "UniUNIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642003",
+    "address": "0x86633c12fbd8e75111e163a8a0d1f2013ab81d0f",
+    "name": "UniUSDCWETH",
+    "symbol": "UniUSDCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642004",
+    "address": "0xd65572432d3eaaeac6a1a06230541e4cc13821c1",
+    "name": "UniWBTCUSDC",
+    "symbol": "UniWBTCUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642008",
+    "address": "0x94830e0e645b2b911586002f1d9db229640a2106",
+    "name": "UniYFIWETH",
+    "symbol": "UniYFIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642010",
+    "address": "0xf67acf5ef435368e17136161ed6d859229d0002e",
+    "name": "BptWBTCWETH",
+    "symbol": "BptWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642013",
+    "address": "0x91ac3907635ff01117ae6ca2fe62deb268b730a7",
+    "name": "BptBALWETH",
+    "symbol": "BptBALWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642016",
+    "address": "0xd1cd4901c4cec4a67354f8fc4313e2828b4be675",
+    "name": "WMATIC",
+    "symbol": "WMATIC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642021",
+    "address": "0x8ef4a33542f63103c268e5fb457bdec38e4c02d1",
+    "name": "STAKE",
+    "symbol": "STAKE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642022",
+    "address": "0x6ca61ece7bcb8e298da600d1416d0deecd786297",
+    "name": "xSUSHI",
+    "symbol": "xSUSHI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642023",
+    "address": "0x3b589565e02f78ff855e6f7e131f3538e69711ba",
+    "name": "WAVAX",
+    "symbol": "WAVAX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642251",
+    "address": "0xa3dc04816a1c95012833754a9ae38b1974806bbc",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642276",
+    "address": "0x6b6d04cfd513be3b7d24555a42bfe1bf40017d14",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642558",
+    "address": "0x0f1a08592f1c02132f1a3e4756cfdaecaf4fcdc4",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642559",
+    "address": "0x954aa2dabf79960ece656a889143c9e74169e5ab",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642560",
+    "address": "0xbcc739c12c062aee179e4dda255daa819180c5f1",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642561",
+    "address": "0x10541a582d27e27ef97337d84d53af64c053c2d4",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642563",
+    "address": "0x1f76f3dbec2cf27e9878d298a8100f496277de15",
+    "name": "WETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642564",
+    "address": "0x01b27b8e59f79d6bd474336693fa50c30f0c7220",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3642565",
+    "address": "0x4e00d84722d40d3e664adce3a616b99d63c60bef",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3642566",
+    "address": "0x35f736e6ae943d16a1d2bbd50c9ead4ce57825f8",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642567",
+    "address": "0x40e4a02e47de3dbe830f1ea42c43e31988b3a571",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642570",
+    "address": "0x8b6b956d38a5b8a87ab91766601ff4a3f8918d35",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642573",
+    "address": "0x7323a2086beee03cdbaac1e7e7cccf762e150d98",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3642574",
+    "address": "0xadffe5806f53988761c4d1f45587c93bddf8312a",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642575",
+    "address": "0x4dc85303517a7481d66580c803fee15771c6b81e",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642576",
+    "address": "0x3408425ac230707a0c4bf29e24c03a16bd620ebe",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642577",
+    "address": "0xfdc4926ca9042c10fa7d80b2933754d5cd1e641b",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642579",
+    "address": "0xd8b246d2524bdee02ecf510a1a757ce6a0596d3f",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642580",
+    "address": "0x4d2aa28889e8145022380be3f44a97348d6a7abd",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642581",
+    "address": "0x238dc3baa6b3574d027486dc1f2b724700697e9a",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642582",
+    "address": "0x1320f5377c1a7b4d9ff4878e11657dd9fb25f0b8",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642583",
+    "address": "0x4d67f0cffe44cacc0ebd0a399122845a65ef8fe9",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642584",
+    "address": "0x351324f2e14e283730e3626761828ddfe3c0031c",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642585",
+    "address": "0x7edc05d6c9ad314ff0c9e88be328eb45b0c307a6",
+    "name": "UniDAIWETH",
+    "symbol": "UniDAIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642586",
+    "address": "0xa67027b7fa33321d8c1f6320d7dfce8bddfac32d",
+    "name": "UniWBTCWETH",
+    "symbol": "UniWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642588",
+    "address": "0x4c497adaa2234a1917f3e93aac56b410bb0444a9",
+    "name": "UniAAVEWETH",
+    "symbol": "UniAAVEWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642589",
+    "address": "0x9cca5e7c24e8b55565c250bac4fbf69882a42409",
+    "name": "UniBATWETH",
+    "symbol": "UniBATWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642590",
+    "address": "0x8b4ff2b98296378bdf383ca8ea3badb90d738b2a",
+    "name": "UniDAIUSDC",
+    "symbol": "UniDAIUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642591",
+    "address": "0x380135e5fd55e37ef94656aae33a5e685b7dee0f",
+    "name": "UniCRVWETH",
+    "symbol": "UniCRVWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642592",
+    "address": "0xf5d3f9e9f03cb00284653e72c93f648f3e8a6061",
+    "name": "UniLINKWETH",
+    "symbol": "UniLINKWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642593",
+    "address": "0x4f648c9abe2caabc44321a20f900a79c4d50ae1d",
+    "name": "UniMKRWETH",
+    "symbol": "UniMKRWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642594",
+    "address": "0x9f068f34b07c928f2161853d3c95139000396102",
+    "name": "UniRENWETH",
+    "symbol": "UniRENWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642595",
+    "address": "0xdec0e2d816e233ebdb07f20f30dd06154fbe3e37",
+    "name": "UniSNXWETH",
+    "symbol": "UniSNXWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642597",
+    "address": "0xfcdaedb57090732ad9f223a047b4459b3dad9a25",
+    "name": "UniUNIWETH",
+    "symbol": "UniUNIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642598",
+    "address": "0x96daf41bb928ed22ba78992351d5839cfca44b20",
+    "name": "UniUSDCWETH",
+    "symbol": "UniUSDCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642599",
+    "address": "0x6fd919f8acc5746c534857f3779c1112dd977d46",
+    "name": "UniWBTCUSDC",
+    "symbol": "UniWBTCUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642600",
+    "address": "0x876bcdac49c32a9c7cfff87e17ecebae59f7ced8",
+    "name": "UniYFIWETH",
+    "symbol": "UniYFIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642601",
+    "address": "0x15cc6ce8db3daa3349d446046c89b89c896bb440",
+    "name": "BptWBTCWETH",
+    "symbol": "BptWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642602",
+    "address": "0x2ad6f51baf8f20eccb5ad1425a9bb97031efcd73",
+    "name": "BptBALWETH",
+    "symbol": "BptBALWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642603",
+    "address": "0x30adf43c2cacdff0786576ab9df73f47a3ab9c28",
+    "name": "WMATIC",
+    "symbol": "WMATIC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642604",
+    "address": "0x87a2d7977e6a8d706547075bc5f2a6c1498a47ed",
+    "name": "STAKE",
+    "symbol": "STAKE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642606",
+    "address": "0x4e924d0ee72d14a493b349a6ac993ef987a94076",
+    "name": "xSUSHI",
+    "symbol": "xSUSHI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642607",
+    "address": "0x7d0310e63a15fae258b5556862fbb7de2e6dedc1",
+    "name": "WAVAX",
+    "symbol": "WAVAX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642685",
+    "address": "0x280c48d6e7e6ee51cf6c907c752264da945f6f36",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3642689",
+    "address": "0xbd88d0a6c7d2aa9a843ce6dae6ee86644316a3e6",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643290",
+    "address": "0x2ae0f6584eaef0be1529d96b037d68cdcadbb1d1",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643291",
+    "address": "0x182da382bcef40121d8d588aa2ed2068d211b835",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643292",
+    "address": "0x01e569da8c75a3e7c2ff90fcd869c467a69d6bef",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643293",
+    "address": "0xc7148c484919d4299c93d65836e27cb553e70e6f",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643294",
+    "address": "0x092968d5b83a8d0b728c101eefa17b19f280185d",
+    "name": "WETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643295",
+    "address": "0x0d02efb60ff8eeee1f127ab4b21422ecfff46ef0",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3643296",
+    "address": "0x4dd514c51f25b755a09f236fefedcd8e68a9140e",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3643297",
+    "address": "0x4a4916937eb39f3ebb187cf4b4b22a31764fe3a0",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643298",
+    "address": "0x38cb3381175f488897990408cfc46be901cd8d61",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643299",
+    "address": "0x8749ee8e09257ac56f5e835e1bd8b5d78b2f935e",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643300",
+    "address": "0xfa95890c15109ce0df752f63ab1fe581ca9e5fb8",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3643301",
+    "address": "0x795f3a406929afbeab19de100b466f13196c6f81",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643302",
+    "address": "0x7818b2bc2ee6bb6546ac1eec4bd0d014bedf3059",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643303",
+    "address": "0x73b76c2a751d387a5020a597cd8d26db30ccd428",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643304",
+    "address": "0x7e3cd1f96fa9d256e842ef43012629341dd5cf98",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643305",
+    "address": "0x0b630d84f0b840a806719e71ebf2d102dbd17716",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643306",
+    "address": "0xe4183a171a9835bfefbe0ac3dc13deb5b94c4309",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643307",
+    "address": "0x6da2157c23e97f4c7c3d7eb21631d879490d320d",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643308",
+    "address": "0x552bd508923153714c792e07438a107f67f878b4",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643309",
+    "address": "0x03aa8d70487210dc82019be3b84b245b12a7ff70",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643310",
+    "address": "0x62769b9376b6aa35bde5b70fc3077962b81a7b87",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643311",
+    "address": "0x556d10cab899bbb70293ba265f20cbe9994bfb29",
+    "name": "UniDAIWETH",
+    "symbol": "UniDAIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643312",
+    "address": "0x5fe0f290709cd42ba6edcb9000f5c8c4183cc1b7",
+    "name": "UniWBTCWETH",
+    "symbol": "UniWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643313",
+    "address": "0x57a2b424a0a1d662e82482bbeb69e958df2e09cb",
+    "name": "UniAAVEWETH",
+    "symbol": "UniAAVEWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643314",
+    "address": "0xb9076c3c4c39cbb1ec579335fce44142dcb55127",
+    "name": "UniBATWETH",
+    "symbol": "UniBATWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643315",
+    "address": "0xa73dc0948010e846305edb81abd0048e27998782",
+    "name": "UniDAIUSDC",
+    "symbol": "UniDAIUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643316",
+    "address": "0x52105840f180e10381c44c9953cdd899b3c87827",
+    "name": "UniCRVWETH",
+    "symbol": "UniCRVWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643317",
+    "address": "0xafaa120809c803d23460a4ad125ff9133dd4e395",
+    "name": "UniLINKWETH",
+    "symbol": "UniLINKWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643318",
+    "address": "0x1f568ba92617c7c5e51c0481b0746f792df88eb9",
+    "name": "UniMKRWETH",
+    "symbol": "UniMKRWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643319",
+    "address": "0x4191df8ddc4f3adcf645e8aa4c0402ca3a811d33",
+    "name": "UniRENWETH",
+    "symbol": "UniRENWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643320",
+    "address": "0x77cdf38f7e7b9ebbbf49f68e92ec5fddedb3ef06",
+    "name": "UniSNXWETH",
+    "symbol": "UniSNXWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643321",
+    "address": "0x0f9362e675c764d834856fd78be38ad235052fa3",
+    "name": "UniUNIWETH",
+    "symbol": "UniUNIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643322",
+    "address": "0x5dfae23a9c67f83e13bb28e9d8958a3abeba6ad6",
+    "name": "UniUSDCWETH",
+    "symbol": "UniUSDCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643323",
+    "address": "0xfc243c5bc28fb79b19ca6c30f326fec71e0d8835",
+    "name": "UniWBTCUSDC",
+    "symbol": "UniWBTCUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643324",
+    "address": "0x544ff6a2034e816dccde6495e4fd31b842eef7a5",
+    "name": "UniYFIWETH",
+    "symbol": "UniYFIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643325",
+    "address": "0xdcbe8722006a281cdd78ccf019a208ae8c7a83d2",
+    "name": "BptWBTCWETH",
+    "symbol": "BptWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643326",
+    "address": "0x2ba805353977177c27d3b15cf02abf5febd2dce7",
+    "name": "BptBALWETH",
+    "symbol": "BptBALWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643327",
+    "address": "0x2fde79c821c1a2d62d26827e9747252f059bb737",
+    "name": "WMATIC",
+    "symbol": "WMATIC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643328",
+    "address": "0x5d8a1e7bf5cac6569f98d5d44d675268db50ad5d",
+    "name": "STAKE",
+    "symbol": "STAKE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643329",
+    "address": "0x29c7dfda3be2f68dd2b9262fb46a5bef85d736d1",
+    "name": "xSUSHI",
+    "symbol": "xSUSHI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643330",
+    "address": "0x21bb91f01e3b0ce58fa300f6255e37294c9bdfdf",
+    "name": "WAVAX",
+    "symbol": "WAVAX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643416",
+    "address": "0x15821f7d408b161bdabb436d87a391c107c840fa",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3643425",
+    "address": "0xdf08b396bbff34a8c86026fa9e87a7e183b12bef",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644685",
+    "address": "0xfc24a3a3ef42ec196a818a55014b1ff774709fc0",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644700",
+    "address": "0xb39e74e05fb52d1a43f0dd50b9fb50785e8d4e36",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644701",
+    "address": "0x1ecf32d447ce4f2d0d12a7106f924418d6fbfe65",
+    "name": "AAVE",
+    "symbol": "AAVE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644702",
+    "address": "0x60db88fbb63b9797eda35cb3b307cd1fb9178bd5",
+    "name": "TUSD",
+    "symbol": "TUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644703",
+    "address": "0x4cbd7298502efa64630d20e576c14b79c5be8feb",
+    "name": "BAT",
+    "symbol": "BAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644704",
+    "address": "0xf5503c8a091952ae689af6ffc2b748cb9cc347e5",
+    "name": "WETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644706",
+    "address": "0xa2e28a44c1778e20a4be9f6ea693bf17c7e43e24",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3644707",
+    "address": "0x59f8343308d5b7cba1742bb99bc3eb7ba9b1b7a6",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644708",
+    "address": "0xbe792f0bed2d79fda62782f4d7873ff3eb1d513f",
+    "name": "SUSD",
+    "symbol": "SUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644709",
+    "address": "0xaa208f06652ff4fbf0d5e087dedb4f8e37eb2c23",
+    "name": "ZRX",
+    "symbol": "ZRX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644710",
+    "address": "0xeb7ca9381f12923ade9793b4a71befb90468dfac",
+    "name": "MKR",
+    "symbol": "MKR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644711",
+    "address": "0x37877d87d4d54191c32f1eb51e10308d7bc92bef",
+    "name": "WBTC",
+    "symbol": "WBTC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644712",
+    "address": "0x3a119aa4ef2a51d28d947e92e15938730de1bd39",
+    "name": "LINK",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644713",
+    "address": "0xe54ad4a68af557dd5a88b98921a0b677bf9c56cb",
+    "name": "KNC",
+    "symbol": "KNC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644714",
+    "address": "0xfba1d9023d259f1bfd8ed01f0504db75f73de6fd",
+    "name": "MANA",
+    "symbol": "MANA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644715",
+    "address": "0xbadd433d270e8d22f9192a9a77870da02ff6b07f",
+    "name": "REN",
+    "symbol": "REN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644716",
+    "address": "0xcf706ce3e9e44ea70a338898fced608f80b052c6",
+    "name": "SNX",
+    "symbol": "SNX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644718",
+    "address": "0xdfb7ae1aafdfd1b6793d235ddadcb766c28bb4e6",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644719",
+    "address": "0x76ca6bf7d7665eeda2a6c5e54f28f5b2589f92df",
+    "name": "USD",
+    "symbol": "USD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644720",
+    "address": "0x489c91721d41cb47468827aa0b3127a5240b7101",
+    "name": "YFI",
+    "symbol": "YFI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644721",
+    "address": "0xb20893d6592661ade6413550f6606cae4deb2a36",
+    "name": "UNI",
+    "symbol": "UNI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644722",
+    "address": "0x433fa528dc1b97e30480b5f25e5b80c4742a967b",
+    "name": "ENJ",
+    "symbol": "ENJ",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644723",
+    "address": "0xa3c43617e575521d5b45a16c1b512c8c417cd145",
+    "name": "CLXY",
+    "symbol": "CLXY",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644724",
+    "address": "0x6aa5fc2a60f4dcd38cdeb1ddb80f0978468d66e1",
+    "name": "HBARX",
+    "symbol": "HBARX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644725",
+    "address": "0x63e3326767f5a2abd5eac09fed347a4151285f1b",
+    "name": "SAUCE",
+    "symbol": "SAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644726",
+    "address": "0x2243a1b64fef837319ef28cd403a67348c716d97",
+    "name": "UniDAIWETH",
+    "symbol": "UniDAIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644727",
+    "address": "0xa8aec9d24b204404336bd6d6bdac1d9cde7b46d7",
+    "name": "UniWBTCWETH",
+    "symbol": "UniWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644728",
+    "address": "0x2d9b4cc4dbc1be4c8e232b207873a9e54cce42eb",
+    "name": "UniAAVEWETH",
+    "symbol": "UniAAVEWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644729",
+    "address": "0x3d57dbc8ec12b2935b0dd67c155ee4a7263902da",
+    "name": "UniBATWETH",
+    "symbol": "UniBATWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644730",
+    "address": "0xe5e2ec3c549264d9dbc1e86030cff8dc4539346d",
+    "name": "UniDAIUSDC",
+    "symbol": "UniDAIUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644731",
+    "address": "0xb9abce1e05306c43bea88534622e40c417c2cd16",
+    "name": "UniCRVWETH",
+    "symbol": "UniCRVWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644732",
+    "address": "0xfe78665dbe81a39b47e1ab516255f935f8c0aef7",
+    "name": "UniLINKWETH",
+    "symbol": "UniLINKWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644733",
+    "address": "0x8a4d614db4ce60b81ec9458c6f83242247af34cb",
+    "name": "UniMKRWETH",
+    "symbol": "UniMKRWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644734",
+    "address": "0x300c210c9e5c50543b48e6934fd70f8c99ba9667",
+    "name": "UniRENWETH",
+    "symbol": "UniRENWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644735",
+    "address": "0xedbf72f15b0e1774746b11549c540b9075820d47",
+    "name": "UniSNXWETH",
+    "symbol": "UniSNXWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644736",
+    "address": "0x5a5473c5fdeea92eb55a66a02331bc7e6eb4350d",
+    "name": "UniUNIWETH",
+    "symbol": "UniUNIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644737",
+    "address": "0xdd32d14acaf7cc49c34fdb92202d6b256c27001b",
+    "name": "UniUSDCWETH",
+    "symbol": "UniUSDCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644738",
+    "address": "0xfb6db11fd3244d3919e6e5b36e45d4fc5aa05c12",
+    "name": "UniWBTCUSDC",
+    "symbol": "UniWBTCUSDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644739",
+    "address": "0x429c64e2b416e45d05bbab7cd8bb44d050e1189b",
+    "name": "UniYFIWETH",
+    "symbol": "UniYFIWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644740",
+    "address": "0xdd05cf7f82894c1b3d3c1245b7b9c458c6f367a0",
+    "name": "BptWBTCWETH",
+    "symbol": "BptWBTCWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644741",
+    "address": "0x0fd3bcc72f1e99f00a32a34e25c27da7ebdfa3db",
+    "name": "BptBALWETH",
+    "symbol": "BptBALWETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644742",
+    "address": "0xa89b4353c9c2429f392648ad0a0e0a3980bf3d92",
+    "name": "WMATIC",
+    "symbol": "WMATIC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644744",
+    "address": "0x9e021a2892bda79a9bf0a7cef8dc21210738e9c0",
+    "name": "STAKE",
+    "symbol": "STAKE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644745",
+    "address": "0x40b90131326fd838de3094b303510b25424908f4",
+    "name": "xSUSHI",
+    "symbol": "xSUSHI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644746",
+    "address": "0x3a5fd618a028ebef16f6a356acbc3a166085baa7",
+    "name": "WAVAX",
+    "symbol": "WAVAX",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644887",
+    "address": "0x36dc6586bb26bebcdcc4dd2305d6bc702fb81180",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3644893",
+    "address": "0xd2eb5c959fbc7ad9705ae092f42a3110d10ac99e",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3647077",
+    "address": "0x51227547388178b104751622e9454175f4671a9a",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3647079",
+    "address": "0x6d614a6e161bf32ef2bc20ff06062300f3afe2a6",
+    "name": "WETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3647081",
+    "address": "0x96c482922ca8eb46ea0ae15c3e6be42fa14bb57e",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3650417",
+    "address": "0xf9485a45f14bd6dd2f33f8e95379dea8993c7742",
+    "name": "Test ERC-20",
+    "symbol": "TEST",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3650429",
+    "address": "0x73cf946dec81917dda88da96ceac842879f12c09",
+    "name": "Test ERC-20",
+    "symbol": "TEST",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3651385",
+    "address": "0x8e9b250f7e74176e76b981bcc06b025685521cea",
+    "name": "Tether USD",
+    "symbol": "Tether USD",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3651386",
+    "address": "0x93e1a0be92af1699f0d8595d3b8a34c70145efed",
+    "name": "BNB",
+    "symbol": "BNB",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3651387",
+    "address": "0x70b0559062c65044e3a67e50ca50a3f9b6c69e1e",
+    "name": "TRON",
+    "symbol": "TRON",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3651388",
+    "address": "0x6459cb67db3d56a9ff94a55aeef098a28ffbd341",
+    "name": "MATIC Token",
+    "symbol": "MATIC Token",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3651389",
+    "address": "0xebb60a7a3550ba23ecce2e075880428fc0800d6e",
+    "name": "Uniswap",
+    "symbol": "Uniswap",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3652872",
+    "address": "0xa71634a4dcc8f55aa60e35454ee186d9cd196871",
+    "name": "vgvhvhs",
+    "symbol": "FGTYU87766",
+    "totalSupply": 60,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3657968",
+    "address": "0x5856533dc569b14901cb1307df56bf6384a88c64",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 7925100000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3665632",
+    "address": "0x89a1db845de809901f4e73336a752e3982492316",
+    "name": "cdc",
+    "symbol": "jnxjsx",
+    "totalSupply": 2,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3670590",
+    "address": "0xd159249dd87ecb0cb57b5f95412d4103773ca1f4",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 7925100000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3671350",
+    "address": "0xc382fe0be63e33f3bfc87a48e786eda984c3aebb",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 7925100000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3671489",
+    "address": "0x75f3256d9909d3cfe34fb73676cc64cb788291f3",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 7925100000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3671490",
+    "address": "0xf64de215935e11be709c2cc58fa3ff75958bfb5e",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 7925100000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3671492",
+    "address": "0xc5ceeb1d4a7a41199cc3839a0d2ce39ce257b4be",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 7925100000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3671498",
+    "address": "0x5e7c835af25323fd9755820c3b1cafa7951f7f63",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 7925100000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3671571",
+    "address": "0x8d6df263c6776ed5fb27ce7a828d5c3346e099a0",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 7925100000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.3671584",
+    "address": "0x4854ae3f10b8c495f90b7e498a4907a59d6a5b02",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 7925100000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3671594",
+    "address": "0x9fdefbcb79b10b0fb0ee1b8c7ca11741b8ed5415",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 7925100000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3671704",
+    "address": "0x65b245172f5e5237e6e50a6a3ed0d0151b300115",
+    "name": "blnTNCILVl",
+    "symbol": "Tlbdp",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3671710",
+    "address": "0xd69f538b67d107b7d1dd7d01db030338c34ca9b9",
+    "name": "ZdilwohKGU",
+    "symbol": "NCNcz",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3696985",
+    "address": "0x33fa43e9c7b5cbfb436b0bcfe01c1a81fc710b9d",
+    "name": "abiw fungible token",
+    "symbol": "ABIW",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3696993",
+    "address": "0x6731630d19bf0b0ae3cdc692445667a680b5701c",
+    "name": "abiw fungible token",
+    "symbol": "ABIW",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3697014",
+    "address": "0xdb3266ab366999a8b2ffed66c5bbc6d2cbda2aa4",
+    "name": "abiw fungible token",
+    "symbol": "ABIW",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3697016",
+    "address": "0xed7c51fd41f45bd36eb086ed47dd1ab5887351a0",
+    "name": "abiw fungible token",
+    "symbol": "ABIW",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3700950",
+    "address": "0x00000000000000000000000000000000003878d6",
+    "name": "MintableToken",
+    "symbol": "MT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3700971",
+    "address": "0x00000000000000000000000000000000003878eb",
+    "name": "MintableToken",
+    "symbol": "MT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706329",
+    "address": "0x07a8f81d7e8a89d1027e5e8c44f3993d72a907b1",
+    "name": "Tether USD",
+    "symbol": "Tether USD",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706330",
+    "address": "0x7e648bc744c4e99ad3fb347d5cd960f72410f1c3",
+    "name": "BNB",
+    "symbol": "BNB",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706331",
+    "address": "0x57e51b57063ae0177ddd2e2af8f75a2f733af7f9",
+    "name": "TRON",
+    "symbol": "TRON",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706332",
+    "address": "0x93014a5275239315c74d6de4a48bc85a4b0c1742",
+    "name": "MATIC Token",
+    "symbol": "MATIC Token",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706333",
+    "address": "0x56c7c3a3208d65cc3b82a11fa868b50f081cba1b",
+    "name": "Uniswap",
+    "symbol": "Uniswap",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706336",
+    "address": "0xf4fd4089c0d25f4eb88b4d379b28615b32a0e730",
+    "name": "Tether USD",
+    "symbol": "Tether USD",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706337",
+    "address": "0xba2930f0b9a2781ed956d2a17f006195cab6b617",
+    "name": "BNB",
+    "symbol": "BNB",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706338",
+    "address": "0x1cba8b07aa0e2875ad8b8b914b473921b52bd438",
+    "name": "TRON",
+    "symbol": "TRON",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706339",
+    "address": "0xb34f6ef29a2d08dd2ba76e0e800e68ce16fbf5c9",
+    "name": "MATIC Token",
+    "symbol": "MATIC Token",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706340",
+    "address": "0xb0b79e7a90b6824eecaa855083a3ba69ac42591a",
+    "name": "Uniswap",
+    "symbol": "Uniswap",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706346",
+    "address": "0x080d93c39d5d54bbda2dafaec508cfb1207e9f82",
+    "name": "Tether USD",
+    "symbol": "Tether USD",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706347",
+    "address": "0x1c982f2f30a9f6ab552ea4ef9a41a4ae9e42cdd4",
+    "name": "BNB",
+    "symbol": "BNB",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706348",
+    "address": "0x9926194540caa40115972ef57781c166b1e99b19",
+    "name": "TRON",
+    "symbol": "TRON",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706349",
+    "address": "0x6254a3e146261c8a785c75f250adbe5e33ecd7db",
+    "name": "MATIC Token",
+    "symbol": "MATIC Token",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706350",
+    "address": "0x2b0a07d288b3b4fc1d25168a101d2360f36b41b8",
+    "name": "Uniswap",
+    "symbol": "Uniswap",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706360",
+    "address": "0xecb92bb9b0bb294d4e4d0e48e2b5b25e09b81c32",
+    "name": "Tether USD",
+    "symbol": "Tether USD",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706361",
+    "address": "0x6d8ff9176a9bc649caf4a65dc821baf3cbca6282",
+    "name": "BNB",
+    "symbol": "BNB",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706362",
+    "address": "0x98776e73d86d4ef78833c8af50944660e2ca9e00",
+    "name": "TRON",
+    "symbol": "TRON",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706363",
+    "address": "0x2b40ffb04c56de44ddd56918d024b77267e9fe3e",
+    "name": "MATIC Token",
+    "symbol": "MATIC Token",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706364",
+    "address": "0x9f2d48ff5cb42fbbf4a416ad59ca9ca3480ee908",
+    "name": "Uniswap",
+    "symbol": "Uniswap",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706369",
+    "address": "0xde2f034c8603b711db3dc77cbfcd232c22770e92",
+    "name": "Tether USD",
+    "symbol": "Tether USD",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706370",
+    "address": "0x4b6909db4ad007912419fd19e6138bcfa6871ade",
+    "name": "BNB",
+    "symbol": "BNB",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706371",
+    "address": "0xae66a29b2b0ca09bec5f45ae112df4f4ef2b3f73",
+    "name": "TRON",
+    "symbol": "TRON",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706372",
+    "address": "0x332fef4063dfe9be0a9738b660fdda8c15c064e4",
+    "name": "MATIC Token",
+    "symbol": "MATIC Token",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706373",
+    "address": "0x1c7166ffe8ba191f894cd4b7fab32ceebaaf6b4c",
+    "name": "Uniswap",
+    "symbol": "Uniswap",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706417",
+    "address": "0xca5ff3189d3e1966eb30e11aba8a2cf611c08abd",
+    "name": "Tether USD",
+    "symbol": "Tether USD",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706418",
+    "address": "0x6da0f910ead67ea5a8f9d99dcaab074d8dda66d4",
+    "name": "BNB",
+    "symbol": "BNB",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706419",
+    "address": "0xc6ab808c194f27da512fe81725f4cef5766ed71d",
+    "name": "TRON",
+    "symbol": "TRON",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706420",
+    "address": "0x0bb80a40aea0e4a4aeab1a20bc147aa5a2c4e827",
+    "name": "MATIC Token",
+    "symbol": "MATIC Token",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706421",
+    "address": "0xe4ba12d211ecdeee86a8854a3d31b1aec45fe12a",
+    "name": "Uniswap",
+    "symbol": "Uniswap",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706427",
+    "address": "0xf03dfed8e6aef215fd4ef48d9814d4ba7faaa21e",
+    "name": "Tether USD",
+    "symbol": "Tether USD",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706428",
+    "address": "0xc17585873c32c6790e04895044e1391075552a53",
+    "name": "BNB",
+    "symbol": "BNB",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706429",
+    "address": "0x5a98844cd635612d232e3f16ea144a280dbf4d99",
+    "name": "TRON",
+    "symbol": "TRON",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706430",
+    "address": "0xb5544333450ab03f99e8ef617ecdccdc00742069",
+    "name": "MATIC Token",
+    "symbol": "MATIC Token",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706431",
+    "address": "0x0648b7f737b237da8ff129ee0a13c5b4c121512c",
+    "name": "Uniswap",
+    "symbol": "Uniswap",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706443",
+    "address": "0x162aa9dfc14ea7064394cdd447bc710650b2d752",
+    "name": "Tether USD",
+    "symbol": "Tether USD",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706444",
+    "address": "0x1edba6c15a758595f135dc62d42a91c6370b031a",
+    "name": "BNB",
+    "symbol": "BNB",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706445",
+    "address": "0x5de2da5903e88a5836a6449fa6107d73b733231a",
+    "name": "TRON",
+    "symbol": "TRON",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706446",
+    "address": "0x6f0074f3d37733e475b68cd092af3ef0635b73a6",
+    "name": "MATIC Token",
+    "symbol": "MATIC Token",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706447",
+    "address": "0x3dde2a610d54eb17955fa90328392bc2f14ca703",
+    "name": "Uniswap",
+    "symbol": "Uniswap",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706738",
+    "address": "0x50d8f2e1b6cb3d35b8cf51dafb7e35072a1b0224",
+    "name": "Tether USD",
+    "symbol": "Tether USD",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706739",
+    "address": "0x8b8611eeb869f6a559f99cccd347c04fd782af7a",
+    "name": "BNB",
+    "symbol": "BNB",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706740",
+    "address": "0x831ddcdf234fde37954e0e55b87e804a353d6368",
+    "name": "TRON",
+    "symbol": "TRON",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706741",
+    "address": "0xc3dcb61d3860563c3271dd0e4cfff7b876c02c3c",
+    "name": "MATIC Token",
+    "symbol": "MATIC Token",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706742",
+    "address": "0x27a961d57e1ac290403cccecdde50dfb04f5e959",
+    "name": "Uniswap",
+    "symbol": "Uniswap",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706874",
+    "address": "0x5cd9f467d0b4fa5067d90fc945d796dc48fe9e5c",
+    "name": "Tether USD",
+    "symbol": "Tether USD",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706875",
+    "address": "0x63d536b32e77bd35972f609b30f1c314dbb71ab1",
+    "name": "BNB",
+    "symbol": "BNB",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706876",
+    "address": "0x08d6d08ad98c78bc61db21d0b0ffd381ff358407",
+    "name": "TRON",
+    "symbol": "TRON",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706877",
+    "address": "0xd1f0b94e5f3ad3ffa4cde0af6a95b5e2c172905f",
+    "name": "MATIC Token",
+    "symbol": "MATIC Token",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706878",
+    "address": "0xa7f0f9bb2274eeb073e1c4bdc8d03637f07c1b23",
+    "name": "Uniswap",
+    "symbol": "Uniswap",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706909",
+    "address": "0xd373274c927b63fb74e112119f996de999215eaa",
+    "name": "Tether USD",
+    "symbol": "Tether USD",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706910",
+    "address": "0xa443c4b9a2639e1ed619a2361e0233752b628d82",
+    "name": "BNB",
+    "symbol": "BNB",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706911",
+    "address": "0xe93b42784e45ee1a170494b359ab4e291d3bed2d",
+    "name": "TRON",
+    "symbol": "TRON",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706912",
+    "address": "0x05ed114a906227171b26be88af91c596b7e14ab6",
+    "name": "MATIC Token",
+    "symbol": "MATIC Token",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706913",
+    "address": "0x226578a34c494f0353aca3d26d4ae490cafaedfa",
+    "name": "Uniswap",
+    "symbol": "Uniswap",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706917",
+    "address": "0x95a846e9ed7db45c44231e24cdb2dd3d335c6616",
+    "name": "Tether USD",
+    "symbol": "Tether USD",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706918",
+    "address": "0xf61c52a99293d3d9824d67c409812aa637ee2252",
+    "name": "BNB",
+    "symbol": "BNB",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706919",
+    "address": "0x5003025bcfa23af9cad546417129abc238695c6c",
+    "name": "TRON",
+    "symbol": "TRON",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706920",
+    "address": "0xe17646a44a32994c6e52d7b1a7e18e2f5fd449b2",
+    "name": "MATIC Token",
+    "symbol": "MATIC Token",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706921",
+    "address": "0x84ce1146f5b6425df90eab66966319b5780f6c59",
+    "name": "Uniswap",
+    "symbol": "Uniswap",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706931",
+    "address": "0xccc151ca884766e4fa02850e09d586b19d415f6c",
+    "name": "Tether USD",
+    "symbol": "Tether USD",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706932",
+    "address": "0x648c08d079b84f9fd35401e984fa00869533a82d",
+    "name": "BNB",
+    "symbol": "BNB",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706933",
+    "address": "0x5a1b8516f109b4a9492e163c3012b7634edb9ef1",
+    "name": "TRON",
+    "symbol": "TRON",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706934",
+    "address": "0xc4fa9c4deed5bea72feabbd4caab9a7229315c71",
+    "name": "MATIC Token",
+    "symbol": "MATIC Token",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706935",
+    "address": "0xcc914e60b0c1596dbe91e07cd6483ed1960ba0d5",
+    "name": "Uniswap",
+    "symbol": "Uniswap",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706938",
+    "address": "0x30424e3ae05c81091e59f3c371cbfcdc1345dbae",
+    "name": "Tether USD",
+    "symbol": "Tether USD",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706939",
+    "address": "0x675fbc468f31d6cd1998ee919f182b073f1ff771",
+    "name": "BNB",
+    "symbol": "BNB",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706940",
+    "address": "0x945c692504688cb5a5fe56adab75e09793a67cc4",
+    "name": "TRON",
+    "symbol": "TRON",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706941",
+    "address": "0x1b6255d6f7cf15871bd8544d956331e1735a79d0",
+    "name": "MATIC Token",
+    "symbol": "MATIC Token",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3706942",
+    "address": "0xe705523288877d9c04aa1c872260d847a34b2850",
+    "name": "Uniswap",
+    "symbol": "Uniswap",
+    "totalSupply": 1e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3711250",
+    "address": "0x7330898d8ec12d9e095e7f083352fa0a49d7245c",
+    "name": "abiw fungible token",
+    "symbol": "ABIW",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3711275",
+    "address": "0x00d1d344db8cfa993364361c20457ef1d228039b",
+    "name": "abiw fungible token",
+    "symbol": "ABIW",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3711303",
+    "address": "0x0203c34a68f6fafa4b286303ce3e24fde707d875",
+    "name": "ImscaKUVuW",
+    "symbol": "SCGyb",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3727959",
+    "address": "0xd4de922012611f636c734dd7afcdb7235175e39b",
+    "name": "God",
+    "symbol": "GOD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3727966",
+    "address": "0x243d33cb6ff15320bb7c5bf45a87033c0f89198b",
+    "name": "God",
+    "symbol": "GOD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3728064",
+    "address": "0x6ce28f571afeb80c5b06067ad761dc5367996375",
+    "name": "God",
+    "symbol": "GOD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3728080",
+    "address": "0xb1f4efe22ee7afc494cd6bf94ee9fec28fc70386",
+    "name": "God",
+    "symbol": "GOD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3728087",
+    "address": "0x24c6fe8d7d49905b571d196b932bf2fea2eceb42",
+    "name": "God",
+    "symbol": "GOD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3728102",
+    "address": "0x8784fb7375909a24a68e048911913dffaa8dce9d",
+    "name": "God",
+    "symbol": "GOD",
+    "totalSupply": 100000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3728130",
+    "address": "0xdb45d19803d80d9e3e0f0d16ea97e80470ec271b",
+    "name": "God",
+    "symbol": "GOD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3728149",
+    "address": "0xe85567e73adaeba71a9c753be582863016c516db",
+    "name": "God",
+    "symbol": "GOD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3728173",
+    "address": "0xb7566399f046e9efdba19dee961b7dad4c772c87",
+    "name": "God",
+    "symbol": "GOD",
+    "totalSupply": 100000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3728189",
+    "address": "0xbf9aaea7ae69a22ac0683b9161f563d0c0accb54",
+    "name": "God",
+    "symbol": "GOD",
+    "totalSupply": 100000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3728272",
+    "address": "0x1770639378b63cae0d9573a895154ceb8e666527",
+    "name": "God",
+    "symbol": "GOD",
+    "totalSupply": 100000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3729099",
+    "address": "0x72971d3881bbbbfd86efa19bac8954bcf8c7265e",
+    "name": "God",
+    "symbol": "GOD",
+    "totalSupply": 100000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3729186",
+    "address": "0xe5665f6734212993d90878361972b5bf105c3618",
+    "name": "God",
+    "symbol": "GOD",
+    "totalSupply": 100000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3729276",
+    "address": "0x8bb7069134905181a45a01c2d4dc79897ff78015",
+    "name": "God",
+    "symbol": "GOD",
+    "totalSupply": 100000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3729327",
+    "address": "0x8f261fe4243290b5f5f1119e44b1811887db2525",
+    "name": "God",
+    "symbol": "GOD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3729358",
+    "address": "0xf0db3635d1ef227d0ed9f26a0b5ecb73a52760f8",
+    "name": "God",
+    "symbol": "GOD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3729392",
+    "address": "0x214f71edc09aada1a4505b7a8da9e71d21a5f28d",
+    "name": "God",
+    "symbol": "GOD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3729460",
+    "address": "0xed855e67b2495858a99e39c6d7fb5fd4a30193b2",
+    "name": "God",
+    "symbol": "GOD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3729482",
+    "address": "0x096720d40df6e3ad97babc8e2ab0cc785f925f6c",
+    "name": "God",
+    "symbol": "GOD",
+    "totalSupply": 100000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3729630",
+    "address": "0xd7963ec94f6758583258f13cc3872bafaf5b159c",
+    "name": "God",
+    "symbol": "GOD",
+    "totalSupply": 100000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3739396",
+    "address": "0x7ec01b3a6f34056482a0140f0ce3e7b7298f06ec",
+    "name": "ERC20Mock",
+    "symbol": "E20M",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3745668",
+    "address": "0x59853daca23082cb9664dd846f24498e8f9ab640",
+    "name": "VaultToken",
+    "symbol": "VLT",
+    "totalSupply": 100000000000,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3745670",
+    "address": "0xc8f12ea011dc8623281bbe055112497432a9afba",
+    "name": "VaultToken",
+    "symbol": "VLT",
+    "totalSupply": 100000000000,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3745767",
+    "address": "0x79d76cb609f7a4da1073fcd97c0b75f6c9aa4ddf",
+    "name": "VaultToken",
+    "symbol": "VLT",
+    "totalSupply": 100000000000,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3745772",
+    "address": "0x4e33db2a868c524c987f5f9c6e0bead7f38d2af5",
+    "name": "VaultToken",
+    "symbol": "VLT",
+    "totalSupply": 100000000000,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3745777",
+    "address": "0x1aaa6f452100b125a30f9c38e7644ede9782bf3f",
+    "name": "VaultToken",
+    "symbol": "VLT",
+    "totalSupply": 100000000000,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.3754000",
+    "address": "0xfc1d814dd96662e930d5012b3ca68eb513ba019f",
+    "name": "hvqefHjMXT",
+    "symbol": "SpuSS",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3756766",
+    "address": "0x00000000000000000000000000000000003952de",
+    "name": "MyToken",
+    "symbol": "MTK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3759670",
+    "address": "0x13d5ada7695dd6b269a156aa02a5f050e0692621",
+    "name": "PJeEGqjHZZ",
+    "symbol": "uLCxP",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3762963",
+    "address": "0x234b071bb1d0e95e936d1c413843a45d45d1f2a2",
+    "name": "iRDTeEZePN",
+    "symbol": "HYOAs",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3763091",
+    "address": "0x96151ccf5c760bc299ada32ae482b42f9675b17e",
+    "name": "CuxjDxBoZw",
+    "symbol": "URvja",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3774186",
+    "address": "0x00000000000000000000000000000000003996ea",
+    "name": "PROPTOKEN",
+    "symbol": "INDR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3774188",
+    "address": "0x00000000000000000000000000000000003996ec",
+    "name": "PROPTOKEN",
+    "symbol": "INDR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3774190",
+    "address": "0x00000000000000000000000000000000003996ee",
+    "name": "PROPTOKEN",
+    "symbol": "INDR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3776902",
+    "address": "0xdc3332c31762c3a09e6023b6342dc07cabdb6be9",
+    "name": "VRJAM Coin",
+    "symbol": "VRJAM",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3777027",
+    "address": "0x9a9eca6b991840683d929e34356adce1a03eeb08",
+    "name": "VRJAM Coin",
+    "symbol": "VRJAM",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3778336",
+    "address": "0x4759d2e2041d51020b77aa95824b910a5dda29e8",
+    "name": "VRJAM Coin",
+    "symbol": "VRJAM",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3778710",
+    "address": "0xd948a23c486d2598008d5f0593bfe9234a30539e",
+    "name": "VRJAM Coin",
+    "symbol": "VRJAM",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3780554",
+    "address": "0x1ab67f04c5ab02e63f40eaaf08522a565432351f",
+    "name": "ksndknwjn",
+    "symbol": "dnjsndjnwe",
+    "totalSupply": 40,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3780558",
+    "address": "0xca458cf0b28abc24d24a304bf389fd8d94102bbc",
+    "name": "dfdfgbfb",
+    "symbol": "fvfwswdvfvffer",
+    "totalSupply": 20,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3791901",
+    "address": "0x7dd85c1960aded672f0ecce5b90c471eee18e2a8",
+    "name": "gchfcfgxf",
+    "symbol": "JKIHU87",
+    "totalSupply": 30,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3791942",
+    "address": "0xf9d1869f18c8c7cabab6026e6c7c802679d933a9",
+    "name": "vahvghgh",
+    "symbol": "SDFRTY756FG",
+    "totalSupply": 40,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3794785",
+    "address": "0x3f4d2f9b54b6654d4bcb82b27520859101daf2b1",
+    "name": "BQWnhjYYpq",
+    "symbol": "TLXXe",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3794823",
+    "address": "0x9b75ffbeaa4b2e645b768795f13ea9456cac3f5f",
+    "name": "BPuIUsGGGA",
+    "symbol": "AjDzQ",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3802321",
+    "address": "0x8ee9df60a204a0b2934474c9a4162788dc6100a0",
+    "name": "gcvxsdgdgh",
+    "symbol": "CVFD563265",
+    "totalSupply": 30,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3805527",
+    "address": "0x0cd47b48e24109d92f262cc2a777e431a96161ae",
+    "name": "nrjCqFdLmK",
+    "symbol": "uPxLP",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3806803",
+    "address": "0x0d55d9a84d64f362fb267252b7a36a70e9d29ab7",
+    "name": "Wrapped HBAR",
+    "symbol": "WHBAR",
+    "totalSupply": 2500100000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3938704",
+    "address": "0xe2104b3da37312321728c97fb9be720c580e7ea8",
+    "name": "utDqYFoTzr",
+    "symbol": "AqbbB",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3961908",
+    "address": "0x245deeaf0646f82441b89338fa0419c36b4baed2",
+    "name": "Mouhghghdx",
+    "symbol": "NMHJU8976",
+    "totalSupply": 50,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3969748",
+    "address": "0x6c3d407ec6f5e2028e5e3f43d14dd5256f248ea9",
+    "name": "Basic Token",
+    "symbol": "BT",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3969751",
+    "address": "0xc82721e287d8786e24286d96913a85586941abb0",
+    "name": "Basic Token",
+    "symbol": "BT",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3974120",
+    "address": "0x2f4cd2b55988a7ce0cefe1f8427d2dee4f66eba6",
+    "name": "gfhfcctdy",
+    "symbol": "NMJK9871Q",
+    "totalSupply": 40,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3974216",
+    "address": "0x859b63990e46f8d1f41cb978179a4ea9fc5f15a0",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3974286",
+    "address": "0xed7e55523d8b545a440d26ea6666f69e8afbc320",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3974318",
+    "address": "0x735012315cc6e5337b8402cf1dd29101157b53b4",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3981485",
+    "address": "0x2a7b17ed107904c817d52d1f36f9302eee276b8f",
+    "name": "ERC20Mock",
+    "symbol": "E20M",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3981511",
+    "address": "0x9b917a84761cf36002b86943dcf20d27d5125a46",
+    "name": "God",
+    "symbol": "GOD",
+    "totalSupply": 100000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3981598",
+    "address": "0x668db9e90233a9cc226c0e749642008f098b45e2",
+    "name": "God",
+    "symbol": "GOD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3981607",
+    "address": "0x97e6709aa6d7f88190737bb4e0df3d4c41e03b87",
+    "name": "God",
+    "symbol": "GOD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3981616",
+    "address": "0x0c8581f105c2769512982193f105f6e925b8a566",
+    "name": "God",
+    "symbol": "GOD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3981623",
+    "address": "0xffb13a0841d98c5fb7828754d57a23385e883bc5",
+    "name": "God",
+    "symbol": "GOD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3981629",
+    "address": "0xc4e81d20df968c7d4fec68b1354c6e3890735253",
+    "name": "God",
+    "symbol": "GOD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3982253",
+    "address": "0x4067744f469410660ba53ee99d74f5edc8918318",
+    "name": "ghcgfch",
+    "symbol": "JNHIU985",
+    "totalSupply": 30,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.3983625",
+    "address": "0x3b51b97c278fea94f3d6a1a5c38e2082c9800a11",
+    "name": "Basic Token",
+    "symbol": "BT",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.3984707",
+    "address": "0xee55901a4f163b77312283eccca9b84e535a950e",
+    "name": "Basic Token",
+    "symbol": "BT",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4177724",
+    "address": "0xc5c1f53dcb6bde1bcdc77a553807f0700dd9629e",
+    "name": "hgfjhg",
+    "symbol": "NMHJU89",
+    "totalSupply": 10,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4216640",
+    "address": "0x27b446ca42a27fc611c3d16b131d4ad80a0be4bb",
+    "name": "gvhdscghcsgh",
+    "symbol": "XZSDW3546",
+    "totalSupply": 20,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4216908",
+    "address": "0x31d3aa0461d7b49456b242aaeebd35957b3a3134",
+    "name": "vhchjxvh",
+    "symbol": "XSDFR86897",
+    "totalSupply": 20,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4222694",
+    "address": "0xa3e40d4b9e6a76ddc1c3406e9766a181beba6504",
+    "name": "OrbQDyNFUo",
+    "symbol": "CYfap",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4229247",
+    "address": "0x9e54886a14620df1b971f1c2a596fd5d543d2c43",
+    "name": "sncjnjndjne",
+    "symbol": "kdndjfenfbhcjkndj",
+    "totalSupply": 50,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4230446",
+    "address": "0x83d7e1801992d8b24e31725a9a772ea39426fd8e",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4230498",
+    "address": "0x4197a8c86d1b2d4a854ab12dfbe3f28af938cc49",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4231956",
+    "address": "0xf92e56b870ad5bad4b055b95a2033d5cce9719e2",
+    "name": "vcsdjhcvhd",
+    "symbol": "CVFG67876",
+    "totalSupply": 10,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4232019",
+    "address": "0xbac7032d6ba1b10fce6ce226f6c6f148cbb2349d",
+    "name": "jgvhhchajv",
+    "symbol": "FGH675678",
+    "totalSupply": 10,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4232924",
+    "address": "0x336b4d5744f5490ade897a7993a2054d8e87df95",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4233920",
+    "address": "0xd4be5699c4c27127aa3a3b68889a0be7a19c509f",
+    "name": "GLyFRQYYoL",
+    "symbol": "IJlGK",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4234384",
+    "address": "0x2dc7aadd74d055b53943b895d3a68f534afe2601",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4234908",
+    "address": "0x2986d9721a49838ab4297b695858af7f17f38014",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 1e+26,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4236916",
+    "address": "0x48280299599d2f0df6da4f298852d03eccc4c5d9",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4237000",
+    "address": "0x3ccf811559f5c465ec51c5e0f2c459985e0de61e",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4237151",
+    "address": "0xa58b8abb985cfc61654c1712a87277abce9e0007",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4237192",
+    "address": "0x1a5087790a73a569f5892bfdd4801826a40949f0",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4237210",
+    "address": "0xdfc9f970c99bded8633c9912b86e80acdc8a619a",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4237402",
+    "address": "0xccae3c92878fa7f026472e5e636965e11d49ed7d",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4237816",
+    "address": "0x85999afd0167e1a79d7a577f8ab99818dd849ab7",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4237829",
+    "address": "0x1de8c498aa21adb88f6ae78fc13942fa462479c9",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4237854",
+    "address": "0x9f5dffbcf3619a6b407f2312cc711b5915c5183c",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4244912",
+    "address": "0x6d257f85429f37909307934b2d9b7cc0f6ca6dec",
+    "name": "HGGHCJ",
+    "symbol": "HGJH7856",
+    "totalSupply": 10,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4245434",
+    "address": "0xbed89196ae3b95951d6dd27ca8ffac076baba31c",
+    "name": "hndshjhdjs",
+    "symbol": "CVFGT68787",
+    "totalSupply": 10,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4245972",
+    "address": "0x4c0b33a44313dcf6b8fe096b05e5d93163df34b8",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4246264",
+    "address": "0x2693749f08257157c4fbd4a1c970b6f5f5066a1a",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4246369",
+    "address": "0xc7a03bbe50a4206a3b58757014db50fa21033f0b",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4246436",
+    "address": "0x229cb8607453201076d97eca591de5c194296162",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4246451",
+    "address": "0xcec2cea0147078ea88c9c034a94201f0bd5ddce2",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4246474",
+    "address": "0xca2c8c4d6d75c511177ec23d45165af890ad8e63",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4246502",
+    "address": "0xd1598725555b1d7bbd2115ea620b2c4a6402e29c",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4246567",
+    "address": "0x128c10811f5d04ade25306276d00f119e168d397",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4246670",
+    "address": "0xdee04814ac98796ace8b0846c68c8590dda3cd61",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4250699",
+    "address": "0xff59ac84349c7249229964a224cf7986b0ad49c3",
+    "name": "SNUVfpWisr",
+    "symbol": "aaOme",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4250934",
+    "address": "0x0d363a7336146e3aa6215292844bd6637b712577",
+    "name": "mOIsIyWRlE",
+    "symbol": "wNZLF",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4254958",
+    "address": "0x980c72f19de61ba33f3df5cb138ca4b2071fedd5",
+    "name": "jnjj",
+    "symbol": "jnjnjnj",
+    "totalSupply": 12,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4272980",
+    "address": "0xf92496316432e9eaccab99ddccfd7e40a4d8fe46",
+    "name": "ProtoToken",
+    "symbol": "PTT",
+    "totalSupply": 1e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4277570",
+    "address": "0x1f3e9191af36493a079a874551b831802d290dda",
+    "name": "MockERC20",
+    "symbol": "MERC20",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4277783",
+    "address": "0x5f6f92916e3d8551747bc897626c1911082d3526",
+    "name": "MockERC20",
+    "symbol": "MERC20",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4277845",
+    "address": "0x541981cd1231da78f96ec10ac3c74391d373b155",
+    "name": "MockERC20",
+    "symbol": "MERC20",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4277852",
+    "address": "0x5c978806ca63468879528260e6f2c3e8eec0f4b9",
+    "name": "MockERC20",
+    "symbol": "MERC20",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4277923",
+    "address": "0xf47bd22ff4c584714548ac17dbb58227da8c0b17",
+    "name": "MockERC20",
+    "symbol": "MERC20",
+    "totalSupply": 790000013,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4277939",
+    "address": "0x2c3eb5e593256fdadd42a69630d01a7ba395e7fc",
+    "name": "MockERC20",
+    "symbol": "MERC20",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4278009",
+    "address": "0x64fb7b46e54522301776f35693029374c387be7b",
+    "name": "Wrapped HBAR",
+    "symbol": "WHBAR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4278186",
+    "address": "0x962a164542a3eeb923fead5363f23af9a4f4a9ce",
+    "name": "MockERC20",
+    "symbol": "MERC20",
+    "totalSupply": 6200000000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4283188",
+    "address": "0xbabaa8520d376d793a2d31911d74a7f36d80b5b3",
+    "name": "DwovZCuOev",
+    "symbol": "nvNiE",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4283527",
+    "address": "0xfc3eb8d0745d491720d9f7ee92f2ece685ee0c8c",
+    "name": "mXIRevzCJs",
+    "symbol": "eEAkF",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4283935",
+    "address": "0xc7171b17d0bb7f3f0d4d46039940b25ab23ae4ef",
+    "name": "MockERC20",
+    "symbol": "MERC20",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4285094",
+    "address": "0xdcbd01cdaf58a2a11468cea1f3f6db135719d980",
+    "name": "IJUOZxhHua",
+    "symbol": "LcwQs",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4287135",
+    "address": "0xb5e7a98a43828c3b4ae0016ece6a027c5938b5b4",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4287179",
+    "address": "0x0000000000000000000000000000000000416acb",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4287222",
+    "address": "0x0000000000000000000000000000000000416af6",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4287256",
+    "address": "0x0000000000000000000000000000000000416b18",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4287270",
+    "address": "0x0000000000000000000000000000000000416b26",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4291786",
+    "address": "0xb9233c9f4dd2505458cc2e8ca26742ac3bc6bce9",
+    "name": "KYmVlsFMVy",
+    "symbol": "mXQeQ",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4293738",
+    "address": "0x000000000000000000000000000000000041846a",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4293743",
+    "address": "0x000000000000000000000000000000000041846f",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4293763",
+    "address": "0x0000000000000000000000000000000000418483",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4293766",
+    "address": "0x0000000000000000000000000000000000418486",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4293786",
+    "address": "0x000000000000000000000000000000000041849a",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4293788",
+    "address": "0x000000000000000000000000000000000041849c",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4293870",
+    "address": "0x00000000000000000000000000000000004184ee",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4293872",
+    "address": "0x00000000000000000000000000000000004184f0",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4293896",
+    "address": "0x0000000000000000000000000000000000418508",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4293898",
+    "address": "0x000000000000000000000000000000000041850a",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294074",
+    "address": "0x00000000000000000000000000000000004185ba",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294076",
+    "address": "0x00000000000000000000000000000000004185bc",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294084",
+    "address": "0x00000000000000000000000000000000004185c4",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294087",
+    "address": "0x00000000000000000000000000000000004185c7",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294090",
+    "address": "0x00000000000000000000000000000000004185ca",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294092",
+    "address": "0x00000000000000000000000000000000004185cc",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294115",
+    "address": "0x00000000000000000000000000000000004185e3",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 20,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294119",
+    "address": "0x00000000000000000000000000000000004185e7",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294141",
+    "address": "0xd1f468b918c967e01f429f37d4abec7f6fb69cab",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294257",
+    "address": "0x0000000000000000000000000000000000418671",
+    "name": "Wrapped Hbar",
+    "symbol": "WETH8",
+    "totalSupply": 20,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4294261",
+    "address": "0x0000000000000000000000000000000000418675",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294284",
+    "address": "0x85f35a928610e647017fc1c0616de982af642c4a",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294307",
+    "address": "0x00000000000000000000000000000000004186a3",
+    "name": "Wrapped Hbar",
+    "symbol": "WETH8",
+    "totalSupply": 20,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4294313",
+    "address": "0x00000000000000000000000000000000004186a9",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294332",
+    "address": "0x4a681451983c0a32cbe3b6e45773a7b1141284cd",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294680",
+    "address": "0x0000000000000000000000000000000000418818",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 2000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294690",
+    "address": "0x0000000000000000000000000000000000418822",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294707",
+    "address": "0xa54b7e02722602795a186b57f604026bdc6248c0",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294748",
+    "address": "0x000000000000000000000000000000000041885c",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294751",
+    "address": "0x000000000000000000000000000000000041885f",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294753",
+    "address": "0x0000000000000000000000000000000000418861",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294815",
+    "address": "0x000000000000000000000000000000000041889f",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294819",
+    "address": "0x00000000000000000000000000000000004188a3",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294829",
+    "address": "0x00000000000000000000000000000000004188ad",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 1000001000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294831",
+    "address": "0x00000000000000000000000000000000004188af",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294836",
+    "address": "0x00000000000000000000000000000000004188b4",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 1000001000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294838",
+    "address": "0x00000000000000000000000000000000004188b6",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294840",
+    "address": "0x00000000000000000000000000000000004188b8",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 1000000010,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294842",
+    "address": "0x00000000000000000000000000000000004188ba",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294851",
+    "address": "0x00000000000000000000000000000000004188c3",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294856",
+    "address": "0x00000000000000000000000000000000004188c8",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294863",
+    "address": "0x00000000000000000000000000000000004188cf",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294865",
+    "address": "0x00000000000000000000000000000000004188d1",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294875",
+    "address": "0x00000000000000000000000000000000004188db",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294877",
+    "address": "0x00000000000000000000000000000000004188dd",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294904",
+    "address": "0x00000000000000000000000000000000004188f8",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294906",
+    "address": "0x00000000000000000000000000000000004188fa",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294914",
+    "address": "0x0000000000000000000000000000000000418902",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 1000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294916",
+    "address": "0x0000000000000000000000000000000000418904",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294919",
+    "address": "0x0000000000000000000000000000000000418907",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294921",
+    "address": "0x0000000000000000000000000000000000418909",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294931",
+    "address": "0x0000000000000000000000000000000000418913",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294933",
+    "address": "0x0000000000000000000000000000000000418915",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294952",
+    "address": "0x0000000000000000000000000000000000418928",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 1000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294954",
+    "address": "0x000000000000000000000000000000000041892a",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294956",
+    "address": "0x000000000000000000000000000000000041892c",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294958",
+    "address": "0x000000000000000000000000000000000041892e",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294963",
+    "address": "0x0000000000000000000000000000000000418933",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 1906610895,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294968",
+    "address": "0x0000000000000000000000000000000000418938",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4294984",
+    "address": "0xac4a2c1c7fd68e380ec4af697aac83c15f2e6c73",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4295119",
+    "address": "0x00000000000000000000000000000000004189cf",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 10116194906,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4295123",
+    "address": "0x00000000000000000000000000000000004189d3",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4295134",
+    "address": "0xdf01615f8b0ef0512ba313c230b8d8f3f9f78986",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4295193",
+    "address": "0x0000000000000000000000000000000000418a19",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 2,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4295197",
+    "address": "0x0000000000000000000000000000000000418a1d",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4295217",
+    "address": "0xccf8449d40f805d81dec04e16230264e705c8136",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4295283",
+    "address": "0x0000000000000000000000000000000000418a73",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 20000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4295285",
+    "address": "0x0000000000000000000000000000000000418a75",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4295298",
+    "address": "0xf4886cc6854d475249f968e0144105524880e2e3",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4295336",
+    "address": "0x0000000000000000000000000000000000418aa8",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4295338",
+    "address": "0x0000000000000000000000000000000000418aaa",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4295353",
+    "address": "0x0000000000000000000000000000000000418ab9",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4295355",
+    "address": "0x0000000000000000000000000000000000418abb",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4295365",
+    "address": "0x0000000000000000000000000000000000418ac5",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4295369",
+    "address": "0x0000000000000000000000000000000000418ac9",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 2,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4295371",
+    "address": "0x0000000000000000000000000000000000418acb",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4295391",
+    "address": "0xad9971b172d68756b5e94a3821f357972621b90a",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4295550",
+    "address": "0xfe2d7e57ac289b4c7b328b9602337bc95d418f8c",
+    "name": "qZRGGzFitP",
+    "symbol": "RHJXb",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4299306",
+    "address": "0x00e9815baa763d382eeaa20c097982274c632df3",
+    "name": "vhchj",
+    "symbol": "CVFGH877",
+    "totalSupply": 20,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4300820",
+    "address": "0x000000000000000000000000000000000041a014",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 20000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4300822",
+    "address": "0x000000000000000000000000000000000041a016",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4300829",
+    "address": "0x3892986a4e27a66e8701e48ea1ba6b4acf6d7976",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4300861",
+    "address": "0x000000000000000000000000000000000041a03d",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4300863",
+    "address": "0x000000000000000000000000000000000041a03f",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4300873",
+    "address": "0x000000000000000000000000000000000041a049",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 2,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4300875",
+    "address": "0x000000000000000000000000000000000041a04b",
+    "name": "Sample Token",
+    "symbol": "STKN",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4300880",
+    "address": "0x76277612c3e35c69e768f4c03f3242c2115fae36",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4300998",
+    "address": "0x011d34cfdf10e771702a1bcf7821ef799d4db260",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4301009",
+    "address": "0xbab72077413d20e4bc2bc181545d912fed71fe16",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4309083",
+    "address": "0x94485bf5219b73985d7b00571dc979caaf057e2d",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4309235",
+    "address": "0x65fc6b32aa7c56fa62347f5ad34a6e71067b515a",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4309265",
+    "address": "0xa8f81df5421cfa13da7f4e43f44068ace5bf1e40",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4309279",
+    "address": "0xcd46e2f14eb85c5df611e1eb1b9a16f486b212cc",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4309436",
+    "address": "0x84a766da35abdfecf1528b4a75e772244b4543f2",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4309446",
+    "address": "0xb2177639350a6284d7715833d1c06a8a29345173",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4309512",
+    "address": "0xaf9a2bd1581409e1ab7478ddce6836d9ad466548",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4309604",
+    "address": "0x994e370ebaad72b8780fc0457e0e1185f3aecc70",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4309647",
+    "address": "0x7da3b3e21d46e84011f3c58484b90ccee7c9dfda",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4312158",
+    "address": "0x3135f598940d06b92e6cd9467b2cba23c01e431e",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4318619",
+    "address": "0xbcc89f072b6ba8afd650714fa5f69a51a303ed2a",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4318677",
+    "address": "0x9c2de2ac19f188eeb98773edc96357d49e5911d9",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4318713",
+    "address": "0xa315d0ce2993ad748f45e8cd5b8bb771bcd17f59",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4318745",
+    "address": "0x9385e9ae864d5149755dcea2fdce944f414c954b",
+    "name": "vQCPXElfay",
+    "symbol": "NHxbW",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4318747",
+    "address": "0x72e6d1ebd7ed072f8820a81245fa3026b3548a51",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4318794",
+    "address": "0x421684102489f16734124629dbdd3ea9b28d48d7",
+    "name": "UCKciPdIiM",
+    "symbol": "VDUpU",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4318813",
+    "address": "0x6cd2492c78756c720d465e221335b744ee720c20",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4318891",
+    "address": "0x0610f34f0556ef77b57ad73ba01df639d9a6b4cd",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4318929",
+    "address": "0x8469f79e8bb79ca4c10111e71fc78fb38a6f786a",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4319142",
+    "address": "0xa02e77e8e121db154ac87af6dfbf8603d7b5ac93",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4319308",
+    "address": "0x97b9e0525c97ae5b4d62eb47dbf4806e5e3b664d",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4319324",
+    "address": "0xf9c1db8dc5e5ecd11bf5d3fcbdffd5779e0d8463",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4319356",
+    "address": "0x089d6d062330557f4649916fcc9ec789834f7ba9",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4319376",
+    "address": "0x4c7873c947cff878191e935b56861d57a97ebf1b",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4319392",
+    "address": "0x7e68b0e13433ef9a6a8bfbb7314910c88ff499c7",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4319447",
+    "address": "0x2b627ad7a38b10d65f04d2e332b03671fb7dd287",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4319469",
+    "address": "0x4607d2cdc724ccf7cdcba0a0011dc2b991e5ee37",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4319481",
+    "address": "0x00681bfbd5d78a6f3fcde7b5dde872ec62cda4da",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4319495",
+    "address": "0xdfdc1470b21bbcbc031f665350959cdbafb3ad4f",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4319511",
+    "address": "0x48e3254a2dc00bbd25160769138904f2d34942e5",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4319539",
+    "address": "0x9493c3723d8d74fecbebe89f937387e10c8ddc8f",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4319602",
+    "address": "0x80043488847af55215097ac5dc02c89eb24689fb",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4319674",
+    "address": "0x7215276a350ae4e67771981f32c6352ad2972e4a",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4320309",
+    "address": "0x5c1c3804b95130712aa2743b031f55c883159c2d",
+    "name": "Energy Token",
+    "symbol": "ENERGY",
+    "totalSupply": 222492,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4320312",
+    "address": "0x6fbd93d0a4fa31b9383abcd45581a0d83fa47af8",
+    "name": "Consumption Token",
+    "symbol": "CONSUMPTION",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4321577",
+    "address": "0xb67380d4ff605d4b89e0e8e949a3c548ba2e8b6e",
+    "name": "Energy Token",
+    "symbol": "ENERGY",
+    "totalSupply": 35058,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4321579",
+    "address": "0x491d53d31bcdf57bd4bc06cd9362403faadff222",
+    "name": "Consumption Token",
+    "symbol": "CONSUMPTION",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4321845",
+    "address": "0x2224e2c4c551483ad4f71b6d3fb7fada0e109f9e",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4321859",
+    "address": "0x58ac6b7659155dc22fc2479482e3e806d86970fc",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4321872",
+    "address": "0x2877f5d579deb687d5177c3332dd0790b3e223a4",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4321895",
+    "address": "0x36a8e496f57fedcde6176edc6855abdb55591a4d",
+    "name": "jsjsj",
+    "symbol": "UHHH",
+    "totalSupply": 20,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4321897",
+    "address": "0x8031783540cba3c0095650d969f01ef41b6996e0",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4321910",
+    "address": "0xa833e7574d7533d73304f95fa35048fe18d774c9",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4321996",
+    "address": "0x2755eea5017cb52d3a73ef76f8b05d8c3edcbced",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4324473",
+    "address": "0xa2030f49b6f06908c8075525c1ecba4254f61245",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4325401",
+    "address": "0xe920a07ada752657805b487041d634ac64427e6f",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4325418",
+    "address": "0x7fbb0f41f7d90bf6892d63121724de00f890cba0",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4326296",
+    "address": "0x677abc297a6a72b4cf207201a230904bb4fdb06b",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4326343",
+    "address": "0xc02003bc2b35e8e79b19f8bfc97a7cc75ba20dd1",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4326352",
+    "address": "0x60d90be60c4b88356b686076405fc152f90d00a9",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4326359",
+    "address": "0x5d34a7b1072da73859658b58814db1c87b909442",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4326425",
+    "address": "0x6138d3a0ba5f8f52355b61efea2fecd1591400fb",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4326480",
+    "address": "0x77d42bab899e7f15681e2ea87770497048d0c388",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4326638",
+    "address": "0xb1b4308199ba9a66d13fb12c295e1ad352dce005",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4326671",
+    "address": "0x363b1775a641a8a2b8ab6e5e0a438c093857a4f9",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4326733",
+    "address": "0x515904ffd3643febe798e29446f63a39d919db62",
+    "name": "EzSMqOghjY",
+    "symbol": "rqHMi",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4326740",
+    "address": "0xbc6c0268a11b77118eb19c6f8f11eb239919ada2",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4326775",
+    "address": "0x1288fdb20efd5502c7092a334e5749e8d6ee2b43",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4326795",
+    "address": "0xab3426e4db9863a647a39284b9c76b6ed0f3b24b",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4327180",
+    "address": "0x5dff2f99ba9b2cdb0199751231c595a8f121edbe",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4327248",
+    "address": "0xf103b8140239812e41da769b3516b8af0fd1a41d",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4327376",
+    "address": "0x8ba2f6dd4b7a46bec232bc51bfbcf8425c05f3e3",
+    "name": "flRBiWMvsr",
+    "symbol": "PZiUE",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4328692",
+    "address": "0x8cce601772f0c818e914dd3a756c2e107430a9ad",
+    "name": "Digital Dinar",
+    "symbol": "DAC",
+    "totalSupply": 1000000,
+    "decimals": 2
+  },
+  {
+    "contractId": "0.0.4330032",
+    "address": "0x8dd0a977e5c0b30a9562109b1c38451cb98db829",
+    "name": "hcgf",
+    "symbol": "NMHJ987",
+    "totalSupply": 10,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4330145",
+    "address": "0xbaec251f753cb994f6632d3f1417eea11bf8cb38",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4330149",
+    "address": "0xb89829f4558692bd02b015d379574b12b719917e",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4330152",
+    "address": "0x31a856b17fff189f191d6b02d949a6bf5155a816",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4330155",
+    "address": "0xb9a73111db82e194135fc685cf93abd5e285b353",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4330158",
+    "address": "0xded611457f2cf6552ddb4e0e4fa3df686f034766",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4330160",
+    "address": "0xe391745400d097211e9822a588b7d9f4856529de",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4330535",
+    "address": "0x4814a675343d379cb709d9574bc67905491923e3",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4330545",
+    "address": "0xa5b40c64fe52496d525e4f72844706d69b3c1146",
+    "name": "wfWysOjXHR",
+    "symbol": "uEfFQ",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4332031",
+    "address": "0x0cb76537091f8f78877296af991ddd8b688396e4",
+    "name": "fds",
+    "symbol": "FDD",
+    "totalSupply": 10,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4332041",
+    "address": "0x77569c87991122aa2bcf7ace5bc747547e484731",
+    "name": "hvhgg",
+    "symbol": "HPF653",
+    "totalSupply": 20,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4332072",
+    "address": "0xd6af83c8d7e8caaae2508395def9b88815c6e428",
+    "name": "anxhedhegh",
+    "symbol": "djhfeggyegy",
+    "totalSupply": 30,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4332263",
+    "address": "0x08629df58f22fe38b4ef44876745a287afff2ba7",
+    "name": "jbdjheh",
+    "symbol": "dnbebfb",
+    "totalSupply": 30,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4332388",
+    "address": "0xad8871f9d0b4443f3659a472653944c79fa69903",
+    "name": "bhbhb",
+    "symbol": "edheh",
+    "totalSupply": 40,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4332434",
+    "address": "0x91408993057eeb3a2b0117a6ae321f782cc730bb",
+    "name": "hchcja",
+    "symbol": "XSDE45",
+    "totalSupply": 10,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4334236",
+    "address": "0x62ef56f39aa373cdcf3a2e3aeb37abae613cefd5",
+    "name": "MESME",
+    "symbol": "MES",
+    "totalSupply": 1000000000000000,
+    "decimals": 1
+  },
+  {
+    "contractId": "0.0.4334243",
+    "address": "0x0abcdb46e082d6308653ec38502d0798ab667b53",
+    "name": "MESME",
+    "symbol": "MES",
+    "totalSupply": 1000000000000000,
+    "decimals": 1
+  },
+  {
+    "contractId": "0.0.4334250",
+    "address": "0x42a38fb306054cb4434dd217a0bf8736213af0c1",
+    "name": "MESME",
+    "symbol": "MES",
+    "totalSupply": 1000000000000000,
+    "decimals": 1
+  },
+  {
+    "contractId": "0.0.4334258",
+    "address": "0x538ef294aee69ada3229a7a442444f16fa11c40d",
+    "name": "MESME",
+    "symbol": "MES",
+    "totalSupply": 1000000000000000,
+    "decimals": 1
+  },
+  {
+    "contractId": "0.0.4334475",
+    "address": "0x3d696eecb9b5eb6260bef6920cd56c00c460d1f7",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4334524",
+    "address": "0x16f99cf7bb865b82fe20a6a397115839f03a209c",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4338205",
+    "address": "0x2dee3148a6f18cf4bdb0893675995877d2cb3148",
+    "name": "edked",
+    "symbol": "ddckece",
+    "totalSupply": 11,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4338506",
+    "address": "0x9180fb31c5a92db67f418563992e4b5d4ee9d8a2",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4338508",
+    "address": "0xfb79bd2c82746623976782a7dd138da6dd6b5f3d",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4338510",
+    "address": "0x0bf579751029f69d3ddafafc8080130086ec7b7a",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4338512",
+    "address": "0x6386bf1091ac40fa2b4a2811fbcc72487510b69f",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4338514",
+    "address": "0x9e0befe3807224adc146c38462f231fca4d04bd2",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4338517",
+    "address": "0x25ecb7aca180182f9e1526cfa204f23b1df20e01",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4338567",
+    "address": "0x3a413516fc1e7119e30fca9c5dca634f01167385",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4338584",
+    "address": "0xa793009d05bbc0aecd68f7d6db738ec0a7c31279",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4338587",
+    "address": "0x6322364ff3e59de5d43854d24d9a044531d3dd60",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4338592",
+    "address": "0x9c29a4b0483a3566bc42c645bcf7fddbf6e6b102",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4338596",
+    "address": "0xec3dda21b854eac526c73f5786d8601ae666a995",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4338601",
+    "address": "0x16eb073ac85e77b0fc5b19d0039b5bacf696665c",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4338604",
+    "address": "0x6e46c1ec366fa84671925d5e5f00e1338d24eee6",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4338786",
+    "address": "0xe04de12a760fc160d167a947b4516c3e17e0f9c2",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4338788",
+    "address": "0x5676fe367f121c5313f386263844694e4e3a287b",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4338790",
+    "address": "0xfc26c4f78c35cff50ac8bd9599f6fd9af82caf36",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4338793",
+    "address": "0x8bad852d0c0a9bc66196b2a833183db4d05e2711",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4349706",
+    "address": "0x5424e0018eba1f534c631c75d62e78a0cae8077d",
+    "name": "ghfhgd",
+    "symbol": "VBGH776",
+    "totalSupply": 10,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4352733",
+    "address": "0x7b24cda2262b287151bc5be6e846e589795aa6ea",
+    "name": "Token B",
+    "symbol": "TKB",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4352734",
+    "address": "0x780c726b0efee29c7a2b9956ef404fe9b5156df3",
+    "name": "Token A",
+    "symbol": "TKA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4352735",
+    "address": "0x97275e73edbbcfb6d779a9bc66177804ee5e136f",
+    "name": "Token B",
+    "symbol": "TKB",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4352736",
+    "address": "0xc000a107d0bb0b12d982cac785e628f86409e1d3",
+    "name": "Token A",
+    "symbol": "TKA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4352737",
+    "address": "0x709962a9bbc1bd8525a8638cd3e8c1a59c471ce4",
+    "name": "Token B",
+    "symbol": "TKB",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4352738",
+    "address": "0x46de94d61a85140d6e03a0c06ac33c332b067140",
+    "name": "Token A",
+    "symbol": "TKA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4352744",
+    "address": "0xf9cd6f74fe34bb6e92875ce3243b53afd9771a16",
+    "name": "Token B",
+    "symbol": "TKB",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4352745",
+    "address": "0x57ad523eae797f600eee3fbaee8b2d0544f4319f",
+    "name": "Token A",
+    "symbol": "TKA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4353211",
+    "address": "0xec870bbf530a5d87f3469a9719c1670700a36b03",
+    "name": "fjcfnc",
+    "symbol": "fjfjcfjc",
+    "totalSupply": 12,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353681",
+    "address": "0x8cf396e560d6898ff2e8c71051212528108ee01e",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353683",
+    "address": "0x7083a2db57b0b5dcd12c642532ea04dbbf8d44a3",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353689",
+    "address": "0x1ac049dc36e5437e2f6d3acf5c21231682a038d3",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353693",
+    "address": "0x455e144d4687ec126baf415c7e7cb3553cb1f61b",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 2000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353698",
+    "address": "0xcb7e56d4cac418b990b6bde3843eb90a62dfcbfb",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353701",
+    "address": "0xe72fe61ba71d8bf2e364c2fbb46f899fde067123",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353702",
+    "address": "0x997d9ebce4121069b84c83176bea0423c23a3bbb",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353709",
+    "address": "0x2a225f0db7f1ab901494bdfb6374a8c8b8fd98a2",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353712",
+    "address": "0x72c49fdbd98f0f3f0cdc6f02ae9f25270d8ae68d",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353716",
+    "address": "0x8b95c92963304fbcf4fcb5edfbaf55364ace0187",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353720",
+    "address": "0x4979ee1adba982e5fb63921ded72e4f0a9d2ae6b",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353724",
+    "address": "0x7b1e92185666c281680fc027ae180cf9ad0a98e3",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353726",
+    "address": "0x8ff66974f4f07501bd82d50bf9de8fb9c6004925",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353727",
+    "address": "0x7ca54bf3c566e92517639121678933f6d663a8d7",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353733",
+    "address": "0x9b88cd21622a675fee7508e2206ce1f3d54b21b1",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 104,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353734",
+    "address": "0x18f1f85ffab5199c8e9f09b6ae612fbf50d405c0",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 200,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353735",
+    "address": "0xd3ae587e50f5a8797a94e4b8aa4022f7d12f6fef",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 10,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353736",
+    "address": "0xde42b11935eacd60707dc7f38d8a9153115f6bbe",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 20,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353739",
+    "address": "0xa2576a531de015661a1a66784d8b9fefe2517b43",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 105,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353743",
+    "address": "0x6d0bb6c9e55b33a7500310d04ed3b413b35ce6d6",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 200,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353747",
+    "address": "0xbb31bb19319c6431c831e74e3f9667b25f7e6189",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 120,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353772",
+    "address": "0x39a5b92521d70e41891e975fcf55d3b46b941354",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 104,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353773",
+    "address": "0x2f4e0787bb4f37b55beef525667f7d3ff3110150",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 200,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353774",
+    "address": "0x8352f8f399cff175a770f011eeb0262d152575a9",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 105,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353778",
+    "address": "0xda108dcac78e9a2cce2111f12b9bbae77db4ec36",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 105,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353831",
+    "address": "0x37bb1a4e9a677e4819cd32d034c718834a8611f5",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353834",
+    "address": "0x521c130802b6c0d5038f1bab445122282156dcf6",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4353837",
+    "address": "0xba0960c797041c575c306ef9c990639ea6dc9259",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4355555",
+    "address": "0x17846f00fd836a3f5cc3bc449b53df46f76a4e7f",
+    "name": "UsNKMpyXHo",
+    "symbol": "RiZHt",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4355680",
+    "address": "0xbe4c23060bd36adebfce85c2f84c4abb2913654a",
+    "name": "IkzCntkWpF",
+    "symbol": "kgTXK",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4355718",
+    "address": "0xbb881bc74152ba89865c4d7600f691f25a2e13a3",
+    "name": "UwdYArUnto",
+    "symbol": "cSssm",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4355745",
+    "address": "0x9629d458c3e7fe0f5180bf91a89e0e4e12c75b8d",
+    "name": "jXVsuuZdVf",
+    "symbol": "nxchu",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4356770",
+    "address": "0x991c941d5bd3828f0da6250a01efa8ad923cfdde",
+    "name": "YTQNWdURQq",
+    "symbol": "FwUxA",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4359455",
+    "address": "0xc830399f08e324e9387b68f23ea40f3000efefe8",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4359469",
+    "address": "0x3ba4f16e615448c44b5b953b779b684f7afaeb0d",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4359471",
+    "address": "0xc67ab099e53b04d4e8306ca193c2be6b0640d312",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4359473",
+    "address": "0xe79855de53f47594158d0817ec04d705d6f885d5",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4359476",
+    "address": "0x0886bb32be3ff271ae12e076cf11832bbd800cd9",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4359478",
+    "address": "0x2b45e7f27026e5c6cef56d908fb80d3c2b2b45ab",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4359485",
+    "address": "0x17b609807ef45c81566fee89301df0444c6a0210",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4359488",
+    "address": "0xb453c1de9cedecfcef68bc9c10912a69f3267a7a",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4359827",
+    "address": "0xa5da0f80fdc18050e2bb6684fc514e1687ae184d",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4359841",
+    "address": "0x8cf756a4bf284c4ba9ca3500a6538fb58500f0ec",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4359850",
+    "address": "0xa9288a37010791b72f09fc34d6ec53cb308aef25",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4359855",
+    "address": "0x43b9a30c9f6f55b7041849981d7db02450b8f61f",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4359860",
+    "address": "0xb8316e541defae17e1da8eae7f2df583131ce763",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4359892",
+    "address": "0x3c4feb276d6e0a6fa7c2da1db404d285c112f31a",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4359913",
+    "address": "0x118fa199be922b719234d182baa7f5d62dba235d",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4360198",
+    "address": "0x0cfd2858bea0fe65527fad3a40276bb7971c98ca",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4360221",
+    "address": "0x2513a0ad8a164273727c5f537ec1a17504e50224",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4363638",
+    "address": "0x306938b0850ced83c1bf26dae14b5ff2050980bc",
+    "name": "TEST",
+    "symbol": "TEST569",
+    "totalSupply": 100,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4363932",
+    "address": "0xb5c95bed293755f00321991dc3ee5af3fcddb607",
+    "name": "MyToken",
+    "symbol": "MTK",
+    "totalSupply": 419100000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4364184",
+    "address": "0x9fd3e7a9fce1f5b08351842f3d6835e54c8f02ab",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4364191",
+    "address": "0xb115d6368ce494a1b7f3877af51c33f533236068",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4364213",
+    "address": "0x570fb385fb9a9debe96351420b0c6d32eb0700ea",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4364236",
+    "address": "0x20499c3119abaf8044652e5350e810b64d69e180",
+    "name": "DeusX VJAM",
+    "symbol": "VJAM",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4364272",
+    "address": "0xd06c60fa287d091850ecfe5897f158dcb717dcbd",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4364348",
+    "address": "0x5d37f0fb1cce9be54f3867832d9badc9b5c0effa",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4364403",
+    "address": "0xf33521d0851360fe30639f98bd706a738d0bf382",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4364405",
+    "address": "0xcb498ee7cdcd048b7a6dad42834d502fe09245b7",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4364728",
+    "address": "0x94fe276e0bebfa7499354c200f49fc85274836f2",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4364736",
+    "address": "0x9c427d80102830f5c2f7ab549fd223ad4961d886",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4364763",
+    "address": "0xdd6502de2b8baf11f621f32b5b3342662d0aaf9a",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4364770",
+    "address": "0x53b41bf7cd6cb1b63c0084939bb15a1798929cc4",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 2000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4364810",
+    "address": "0xd0c772954a5202a1db34418e1e4ee70a16d0b3aa",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4364822",
+    "address": "0x852628851ce31f6f9ba183ee94762e15297745fa",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4364842",
+    "address": "0xb28e58a936f6ee88ab51e84ab4834c1801d0d769",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4364845",
+    "address": "0x74b7e5046a29be5b1bdc07ed3e58e743fb574942",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4364861",
+    "address": "0x0172291a918bd55c91be11f1f8ab833d13e77fa7",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4364869",
+    "address": "0x7c9f89db3bf230c7f4f96cae8a79e81de263a830",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4364881",
+    "address": "0xc43a101fa8c37bae1f6dc26951b8988cbffa09c2",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4364894",
+    "address": "0x475d8718d90cb694e72ebb3c2bc6f404679ac93d",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4364897",
+    "address": "0x7e3ba07827bff1543efa196b34e6b3dcc23f2710",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4364907",
+    "address": "0x95e53b841174969fb1fa88b4224b83fb253a9812",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4364921",
+    "address": "0xf41cea2072bffb4153733183c4cb95ebc77b8879",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4364927",
+    "address": "0x0d22e9752580ae1b8f676863c708c0c0e2ae258b",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4365018",
+    "address": "0x8ae4d52e3f8269bb4926190f23404f58a06258ba",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 104,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4365027",
+    "address": "0x2f7bd4a5065fbc85bccaf1cfe2bd6d0749f26d16",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 200,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4365035",
+    "address": "0x693c5a3d9278478ac12f4e383b16ef4d82ec7907",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 10,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4365039",
+    "address": "0x19b3f668a3eed17a50cb1fad0fd11f4bd90e0c1f",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 20,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4365054",
+    "address": "0x323578b6bfa1f959722b9d617c84ca7f9722e0e1",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 105,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4365074",
+    "address": "0x468797009aa480a24b7cbc294a22a0f757795b61",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 200,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4365096",
+    "address": "0x6af31db2f8eb45df8bc6da05761549c8d9733d13",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 120,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4373614",
+    "address": "0x74c99d4d1cbf084bd00256c1ba90e1828f748a53",
+    "name": "vZbyte",
+    "symbol": "vZBYT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4375435",
+    "address": "0x00943e1b4b9a12351963d8caf4d41672e42e0ba3",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 120,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4377117",
+    "address": "0x7d459104260ed9d790d41a7c43f1c587402b803e",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4377179",
+    "address": "0x0242b058d9b085d3b6cc68db8eae9f015e6c325e",
+    "name": "MyToken",
+    "symbol": "MTK",
+    "totalSupply": 1.0655817722222e+22,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4377193",
+    "address": "0x7de1d4b93c3ffffa8fae24b8fdc391bf9e8b6e1b",
+    "name": "MyToken",
+    "symbol": "MTK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4377306",
+    "address": "0x8552787b782ea723940747408dc2c24aebe4a00b",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4377661",
+    "address": "0x9fd47cabe41eccc2c22f6a0af79aba36d6b9b13a",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4377672",
+    "address": "0x03798be77fdcdcdd501a8ad6d8ecee89a7e72017",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4377694",
+    "address": "0xcf94360aa6a996cf2cd2d6b2bb5057a2dde6fc42",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4377747",
+    "address": "0x02135f4932a0c68722892458a8dad0c1882d4a64",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 2000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4377751",
+    "address": "0x41f266810181a3212f6c4a08322fb2825819f28c",
+    "name": "vZbyte",
+    "symbol": "vZBYT",
+    "totalSupply": 247504616059572130000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4377797",
+    "address": "0x0fe3eb431a255b64ab06ed7b4aef4421d57dce78",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4377810",
+    "address": "0x8acf2656562f3af66411c75df30996bef3a17406",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4377813",
+    "address": "0x0e7a477c58b73d83fcb9524140460315582b9ee0",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4377846",
+    "address": "0xd5e58dbfc1ab8fd8e6f8f55ce92bf683f44b5a88",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4377890",
+    "address": "0xadce8167faf330d3156f5a61d88c7af41944f7e4",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4377910",
+    "address": "0x063ff2fab751d18c6d3fd4a183250c007c45fe4d",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4377927",
+    "address": "0x6d235d8ed81ad74618b700ab6b616ab1da674ebf",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4377932",
+    "address": "0xe3b95eea4a16a5e3a14c1ad8ac2cc93cb16b8c55",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4377937",
+    "address": "0x51273b2d9b9bcb9d2f976e6086b4c94a78c26654",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4377941",
+    "address": "0xae4ad2cd59a461928110637e6368ae4c6d1e5379",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4377943",
+    "address": "0x3b2744b0544d52831c219b42fb0dd798e9eb111b",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4377946",
+    "address": "0x39fb72aad8018da9316ac75394e4987ff67137e9",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4377955",
+    "address": "0x306e3f4bb59af00c58bd2195c02e174476fa2d2b",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4378030",
+    "address": "0x28c7d1f1c575eca8eb0f2470e40e47e7be0b37dd",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 104,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4378033",
+    "address": "0xdad80fc18778fc84d553ff2e3d85cb7292fcb3e5",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 200,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4378038",
+    "address": "0xe4dd17bb3ce00a0d30b37ad4440d6dfbc00b4145",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 10,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4378039",
+    "address": "0xcad79b1b242613ea9b7c3548c48abaf75e42dc6e",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 20,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4378043",
+    "address": "0x0cbfaac91302e4fb2cf1f7ce69fa8e1b90704d89",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 105,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4378061",
+    "address": "0x96dcf25f8c3c90ea05e57bd068d24ec88901dd0b",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 105,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4378069",
+    "address": "0x2cf181ab6e94f59d65660b09bc096ef539e7ae10",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 105,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4378112",
+    "address": "0xcb66b5ff5699435e18079d25d1e9822a90c2b4d4",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 200,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4378160",
+    "address": "0xb96b6aad1398ffaf66e20ae3f94e188da99ffdec",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 200,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4378178",
+    "address": "0x8d74c09fc7bfd281933884dbde0aa69b88952901",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 200,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4378281",
+    "address": "0xe29543e020bb23806a7c4c403cde8ef466c93e84",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 104,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4378282",
+    "address": "0xf20993c69fac623ce85e16d79c13611a34fc744b",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 200,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4378283",
+    "address": "0x395bc747dfc0d179b58cd401b7eec4cd754ea211",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 105,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4378286",
+    "address": "0x042c88c10cea809a50fca667abee2cbbd592bf58",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 105,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4381938",
+    "address": "0xb26ebce2ee509aa721602a65a58858b915b65fcc",
+    "name": "ERC20Mock",
+    "symbol": "E20M",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4383185",
+    "address": "0x8842da7ffb06b60a68fa97ec343476325f3f7362",
+    "name": "HST_TEST",
+    "symbol": "TESTHST",
+    "totalSupply": 10000000000000,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4383186",
+    "address": "0xedd60303c6008db7d015f1a14bba62751adda372",
+    "name": "RewardToken",
+    "symbol": "RWRD",
+    "totalSupply": 10000000000000,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4383239",
+    "address": "0xb5c918d20a4c88c4fd612efd3eb2e70702315a8e",
+    "name": "RewardToken",
+    "symbol": "RWRD",
+    "totalSupply": 10000000000000,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4383240",
+    "address": "0x8abb298e214530d7b3b0ca4d7ca0fa5230ac9ba5",
+    "name": "TEST_HST",
+    "symbol": "HSTTEST",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4383760",
+    "address": "0xef7d40144d5811f7d0b895207abfcca4824a352e",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 104,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4383763",
+    "address": "0x2489f7aa0b793ac1b74cb273d38f27cb1b22e781",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 200,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4383766",
+    "address": "0xb67cc74e5266a17d1836b3aedb2474a128a4dee6",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 105,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4383769",
+    "address": "0xc30beb06451f8e6e6dd1225b965290ad088707d0",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 105,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4383972",
+    "address": "0x6775b40b41e43f42a4c6e55507c129e2a5d9acfe",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4383991",
+    "address": "0x5c1819ae018ea0c4c4a6c812cc46ec4aeab3f910",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4384105",
+    "address": "0x1e462613f1d632ce5fdd48803c9e08afa22fce8e",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4384186",
+    "address": "0xa55ea73f115b5e394bf2b9014cda082c2b258d2f",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4384188",
+    "address": "0x59a7e53b3456abac252e57b41334cfa4f4599eed",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4384190",
+    "address": "0xf7196a4c4a96fc21ff626f501e9bd431af31fc39",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4384193",
+    "address": "0x35a5cd85cf7b3ffcdc40bc1c5fd8c2679f4716c4",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4384199",
+    "address": "0xa48199bff58b20142ccaff23d40af6172847a6d5",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4384201",
+    "address": "0xcb85917f5a2b5882d7d49f0837d760fe1d8e34ac",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4384346",
+    "address": "0xc79c2c8f5a65af9de5ce64f4c63c0b06ee11b369",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4384348",
+    "address": "0x2fc71ba95525d181106f3304564a0604703f71f4",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4384360",
+    "address": "0x2d51d70e98362eb81daa95de159108f5f4a7fd2a",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4384363",
+    "address": "0x271a42c5d67f057a4a81aa3edd9785a5a54f70dd",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4384365",
+    "address": "0xebf4e302528d1eb815ce4e9ea6bad5953a44c897",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4384368",
+    "address": "0x9f606f639da8f56f145dffe15e0e19726bb59b8a",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4384370",
+    "address": "0x575825e5844ff031155e00382fab79b79ff6cd0c",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4384452",
+    "address": "0xc8f1def4799f1c764fd515bf96a6e64931fb1ca2",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4384459",
+    "address": "0xe779957e24b66496a85b586a4c1174a3e8a0850a",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4384461",
+    "address": "0x4cbdf693e0d68c2b1174d20913ddf8eca6acee56",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4384463",
+    "address": "0x02d3bb96a74928c1ceef75fa6471ea8818ff8eb7",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4384466",
+    "address": "0xf47f887482863da1194f5b4d23d667b19ef5654e",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4384471",
+    "address": "0xd384d254f4a80df400d87924fe917dac4a84a0a1",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4384476",
+    "address": "0x76fb78a47f43c8c833315e9de7112b7965fd329d",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4384554",
+    "address": "0xb03ef692b7c7e555b10534a16acb8da4e1b8d9de",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4384557",
+    "address": "0x97bba43071e4da6112578bf11e929efe194ca5bf",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4384562",
+    "address": "0x34a0390512259a5343576ec44c2c74b9b46c37cf",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4384568",
+    "address": "0x6f6f5a18a9ccd225df6a705d0a3fc3568c6fe848",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4384571",
+    "address": "0x80c086c8f40a0b066d5e261f40d810db285c0bf6",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4384573",
+    "address": "0xed72b936b3d31ed82496374f1458b48de9f62917",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4384575",
+    "address": "0xf52f50cada5d1e1f79a031952c1e80ffd0cf0455",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4386039",
+    "address": "0x0aeaebd4b4cc3d6569b2f73dd0bfc4dcacf90fa0",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4386041",
+    "address": "0x9d9c2fa118f2527945c58e9d69f457f066e9f572",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4386043",
+    "address": "0x9422e810a0c77d95bf3796af3e34a07918ad64df",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4386045",
+    "address": "0x11900e42c0ce8ee71897fa4dc136d6907a333ed5",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4386047",
+    "address": "0x7723ddc9e1f00c24ec37d432177f81a89238b633",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4386049",
+    "address": "0xddaffce4f91e0e4129916a57f7c8f2b09b4db06e",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4386078",
+    "address": "0x8b2bd981bc46d61462c8e8e4328443f6403cb0f1",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4386081",
+    "address": "0x09c113ce11cecf40f939c9a72619fa4d1f113705",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4386084",
+    "address": "0x28c3de352847252aecbae6e4db1c4aea1fdcdcab",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4386090",
+    "address": "0xc88ede023a349d397c55cac1bada4a30828d7eb4",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4386094",
+    "address": "0x7a2d49723161fddc99a8ee7724f431b90c8b7ae2",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4386097",
+    "address": "0x9c08980e8a6d84aa3783c3dfe7e340809f2aa1c8",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4387067",
+    "address": "0xa529bb48924a4096bd9b5f3186bb198f67f78548",
+    "name": "xXLiujzyPz",
+    "symbol": "lhasR",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4387118",
+    "address": "0x14bc56e09b36e811640599410b88276edee46235",
+    "name": "AtLdvPQTQM",
+    "symbol": "KPzkj",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4387402",
+    "address": "0x6b7d6e05c5de142a309402d9f45fd7de137807b7",
+    "name": "VXrfVMSuxL",
+    "symbol": "opjuU",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4387728",
+    "address": "0xb244e9117897511ac809e9939bb9de81375d7751",
+    "name": "Meme TV",
+    "symbol": "MTV",
+    "totalSupply": 1.5e+28,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4388085",
+    "address": "0xc62e339acb360dd44683fd74234fdfc06ad8da50",
+    "name": "hacbjhcvs",
+    "symbol": "JHUY876",
+    "totalSupply": 10,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4388517",
+    "address": "0xde8c912017880a82b40ada60c04f99ccb0adad60",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4388519",
+    "address": "0xad1643bf6e61a0d3ff1e546ca8dfdae233429922",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4388521",
+    "address": "0x22fbb6a8012f431881a13a22955c94204dd5db62",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4388523",
+    "address": "0xd699eda8fab440f7353d5986521e75b89829402c",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4388541",
+    "address": "0x973f68ecbec9db734cd158add20c6e9389c5e5ab",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4388545",
+    "address": "0x0a0e511ecc2592add09f2906e1aee82948e6a876",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4388548",
+    "address": "0xd0e886a7c550be39d6f0e79db27816ec91093e0c",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4388552",
+    "address": "0x968efc3cd0b9fe448b6b4545db7e89945805dd48",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4388555",
+    "address": "0xb0c2a40eb2be971a778f5ab1b436239e3008c739",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4388564",
+    "address": "0x35c4e77d12abe209cec1520a90cd46e5bb363187",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4388569",
+    "address": "0x5b596d2b301b2f8259e4ba3270340e9d35beb753",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4388630",
+    "address": "0x9318aa1011e59403efd5ea3f3e4e51d1ef24c09b",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4388664",
+    "address": "0xb7f324e49e5c7aad8163c0b499b7ab06c25611ef",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4388668",
+    "address": "0xe36885022d44396f26b77f4b4ec427687a70af26",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4388672",
+    "address": "0x96d0565ea6db71588947faa8b1bdd5317d7b7352",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4388677",
+    "address": "0x0e6c4a4a731b8429a375214f6930e83315652211",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4388680",
+    "address": "0xa5f8283e1f0b1cac67580071338f3dc6507b5e20",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4388683",
+    "address": "0x00f06c1c244dacef22880ef4fdbefafe27627bb0",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4388685",
+    "address": "0x271697d4b353444ea4f7a8f9bca62076e35eb103",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4389917",
+    "address": "0x248950bc383181279b7446b13921efd13b5912e7",
+    "name": "WMkWeakowe",
+    "symbol": "vZSqc",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4390447",
+    "address": "0xb89ef4c32a38bfc51f6c5c47b35cfd05f62d87a4",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 200000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4390853",
+    "address": "0x4213a83b4e62f72c644b0f9e9ee8c34fd6b62e40",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391025",
+    "address": "0x840ed0c34b89d2da870d7a7ef3804330213dff9d",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391041",
+    "address": "0xeef16b2e925210db41d37752b946934cc2cf30ea",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391047",
+    "address": "0x4384725de6f57c15ad311eb2d2cb62a62dc0d616",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391049",
+    "address": "0xd7a6d9b38de3e7f7e3aee94a2d381cc7516ab6ac",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391051",
+    "address": "0x7ef871a05b2cd430be8b89a51030c0bcb21978dc",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391053",
+    "address": "0x82cfa401933bff0857e9a2043cbdcee700659a6f",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391055",
+    "address": "0xb4d4b2d0d946634e1449a426a61d43c8564f5c36",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391118",
+    "address": "0x01647c3e6db75e18184c0529952acec56001a25a",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391120",
+    "address": "0x3df158d623a96eb3400d67b89a37f19f86f85ab2",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391122",
+    "address": "0xe4b885d449a382e3f4995a7b3599ca5b259b4806",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391124",
+    "address": "0x8c6e0646cf9fe44321a78fe9b1d8f586a03e8ed3",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391126",
+    "address": "0x43029ab439bdd367af1c0bc9e828e81311289c78",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391129",
+    "address": "0xef5117010f1b22aceb9c68187789c010ab609524",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391131",
+    "address": "0x5dbb2b4698e506f3f1af322bdaf2ad6f9ec8fece",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391141",
+    "address": "0x05535e4708ae4d09de62ccd658638902007904a9",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391252",
+    "address": "0x9d8b0e560df8469c01fd8bbaa70543e06d5cfef6",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391255",
+    "address": "0x72bff41792183f056fde1532fb5abb834e7223c8",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391257",
+    "address": "0xea4eff5a8d89b0762cdf9e49b0b86aaaaf1aadaa",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391259",
+    "address": "0x6265f5108027d9ce9ec56986acc0584edb372125",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391272",
+    "address": "0xebc3ddf3c41b4aabcf1eb73e73ca614a5de3ff54",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391279",
+    "address": "0x32fe3a45e28a5683f0ae4184a4ea3558f5a9bc73",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391281",
+    "address": "0x85aa4853d14f5fd0bc9b61b443385bb3eb231a54",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391312",
+    "address": "0x0d2a350a3f7ac02f69de7e5706aae7e5ef34fbcb",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391318",
+    "address": "0x71e78608b88e017a52f147a5c07b33edca0b785e",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391322",
+    "address": "0xc1480c3782c16ad12a539bff95954dddc21fca87",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391328",
+    "address": "0x69cbf16a53dc4e56fe18be14fb76caf2a7ad94ef",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391332",
+    "address": "0x96e2d1d4fe74ede65d7b56d83d68d00c743993fb",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391336",
+    "address": "0xf56dca9217db5fca43283a86aa64e18f4fd8902a",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4391340",
+    "address": "0x3cb02e4a62d41e7c6c5227354b5ffa42fd6a3324",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4392136",
+    "address": "0xd23e77b7e1726577006799b7194b6ae31958a839",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4392813",
+    "address": "0xadb2484e57ca12794683ce0b0100079156365e76",
+    "name": "oihJFihprV",
+    "symbol": "JVunH",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4393719",
+    "address": "0x1e18b0912f5993a1de390a65d83e86bcaab52c0a",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4393721",
+    "address": "0xeeaa62a89ee4a9aaad975d2a8e0d355e3325fb0b",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4393723",
+    "address": "0x12defe661b5a797272d3d80235300a4ad487eae5",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4393725",
+    "address": "0x395714ac15ee2e7cebb9e27f63a76490cc1262c2",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4393727",
+    "address": "0x6f28f80be86dfb9ce892bc61c10a5a00b14139af",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4393729",
+    "address": "0x81766817103e6bb3cba9cc13c2d68b2502290049",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4393731",
+    "address": "0xf0ab8c5fcce4ca7335bef1d926794608bd814097",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4394480",
+    "address": "0x63c508a8426eda56ae63ccac0b0b3ccb8ceb26fe",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4395629",
+    "address": "0xa0f4ea85713acfc277d12f61f7399438900905c4",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4395631",
+    "address": "0x314f49f7f69f147e8f1bcdf9acafed8e723ed509",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4395633",
+    "address": "0x57b69a622d86141af27d37db2c99b5cbd89a297e",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4395635",
+    "address": "0x8b9860f4dd3f92fb49e86aae3e5e769a7a6a73da",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4395637",
+    "address": "0x300d8b334c27a3b19ba146bd01a3edd015b0aabe",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4395643",
+    "address": "0x85f9c1e8e1b40df0a1ffd76f4bee0aa55cbfd153",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4395645",
+    "address": "0x622f32dbbcb02b76ccdaaaf191f28d50343377e5",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4395652",
+    "address": "0x88ebefdc84a58bd0f6684c2ee0374aafd7cc8a72",
+    "name": "sdhjvchg",
+    "symbol": "ajhgfkj87656",
+    "totalSupply": 30,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4395712",
+    "address": "0x10781fa36acc7f011b8d1be1326dfdb14bdfb1ae",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4395739",
+    "address": "0x9564b8db648cef80b6b83e80e963efc24004c1ed",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4395794",
+    "address": "0x3a2d83804d1d006122ae853dcaf133b15455d0dc",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4395854",
+    "address": "0x3b789490b75047bb9e3584e9813a855011b5a73c",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4396172",
+    "address": "0x4b165dff87df9b48ac17a7347d20292854a0c481",
+    "name": "TestFT",
+    "symbol": "T-FT",
+    "totalSupply": 1e+33,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4396185",
+    "address": "0xfefdacc6fa219a732000f5c3b359fc87cb719838",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 1000000000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4396442",
+    "address": "0xc986113adbb5841115a8235449f7a57d17c5eae2",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4396695",
+    "address": "0xf0942bdca1eaea71f09a0ed9cfd27a1e453633fd",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4396730",
+    "address": "0xad39dbbe185972029e1829805b54c0bc82eee383",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4396820",
+    "address": "0x4ab2ec4d682a244441094d427012577c3b0791b4",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4397994",
+    "address": "0x831b924b4f1753e325af3ac2ec0de1a96fadac57",
+    "name": "TestFT",
+    "symbol": "T-FT",
+    "totalSupply": 1e+33,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4398301",
+    "address": "0x16058b6aba58c6804fc214aa8a5e3ec240d1b0aa",
+    "name": "jhhjhjh",
+    "symbol": "7887",
+    "totalSupply": 89898,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4398392",
+    "address": "0x0000000000000000000000000000000000431d38",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4398416",
+    "address": "0x0000000000000000000000000000000000431d50",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4398503",
+    "address": "0xef3d084fae740ecd9d471ae211e3333df903c7be",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4398508",
+    "address": "0x55f1e2b23b58026ae6e1628aa9e3753a2df065db",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4398673",
+    "address": "0x0000000000000000000000000000000000431e51",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4399524",
+    "address": "0xce62313bd3616b19485f17b465782fe223011b1a",
+    "name": "pNsONcJCXw",
+    "symbol": "kmTTi",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4399752",
+    "address": "0xd038542668578327d1eaa5fcffc89d9d33416d06",
+    "name": "gWQjbkDocO",
+    "symbol": "VwziI",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4400016",
+    "address": "0xf3c9e6f2c7674d9305cd8520a35e56b734fa0ab8",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4402009",
+    "address": "0xf7ce7f266684713eb5197affeefdc5e358bf43db",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4402080",
+    "address": "0xe156c3c42590ac46ae2e102f785f38b1cdda0dd3",
+    "name": "Token",
+    "symbol": "TKN",
+    "totalSupply": 100000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4402083",
+    "address": "0xa74cab8ba16b99573bfdeabdde7b265f1386ce72",
+    "name": "Token",
+    "symbol": "TKN",
+    "totalSupply": 100000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4402402",
+    "address": "0x98666d09d4c2134a3ec7a4b5beca0268a986e682",
+    "name": "bchjcshv",
+    "symbol": "XSFGH876",
+    "totalSupply": 10,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4402936",
+    "address": "0x7c4ad8e3a8463f95c66ddab26ada0fe333252059",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4402966",
+    "address": "0x75f6cf352f07a9ff196aeb60a72ad5688e8be1fb",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4403011",
+    "address": "0x5014a452fe0a936ac03cd3f0ffee40ac670620d1",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4403134",
+    "address": "0x5384a8c6b57383b4a62a4d2f66fd2cc53660a17e",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4403291",
+    "address": "0xf6c957a2cb98269837279df7eb086f6923953ddf",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4403927",
+    "address": "0x6fa84e9798c206ea99644e657b5a45cf5f584740",
+    "name": "MockERC20",
+    "symbol": "MERC20",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4404343",
+    "address": "0x68e865143b0ed79e7cb142b63bbd8aeb8fc04e08",
+    "name": "edlel",
+    "symbol": "dkcdmc",
+    "totalSupply": 12,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4404806",
+    "address": "0x34b83c63e5953268127be472bdbae6cace3076b6",
+    "name": "Token",
+    "symbol": "TKN",
+    "totalSupply": 1e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4406614",
+    "address": "0x7efcf62fcc0aa485ee2390a008d2457c85050b36",
+    "name": "wiwoow",
+    "symbol": "sqwwoow",
+    "totalSupply": 12,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4406775",
+    "address": "0xfd79f2776e4ab153f5eba6cf6b11dc3e1c85d5a8",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4406777",
+    "address": "0xa41082bcd83a7b3c00a03f0a9d0603ef5dff1fad",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 1000000000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4406782",
+    "address": "0xbdd9b97a342291f40a2ccbfd54495bdd4428bc6f",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4406788",
+    "address": "0x77e79285f7c4c97e91ff45f80f6833f758d2c02e",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4406796",
+    "address": "0x2423c5408a022289d2df6633fa64e5b6b23f0f40",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4406825",
+    "address": "0x0f319c0b2f2494f7ac1b99e2039ab75ecfa124e7",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4406992",
+    "address": "0x5135da46add03946bc4ab052220b396172fe5588",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4407191",
+    "address": "0xb95b2c3c5a5f98abf76c6a80a30445c4f9c38c7b",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4407273",
+    "address": "0x57325f9964e45267e0899407a9a4439ac45b2f84",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4407371",
+    "address": "0x6d52f5ceec6b2af6222e14b0e4778179be687e59",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4407891",
+    "address": "0x0412325fc529f237b8731a72eb05a8484d2486e4",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4408295",
+    "address": "0x6e3d1f36de041a7022ff028319e7ee7f1313d64f",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 1000000000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4409355",
+    "address": "0xfe886e83ff5b63f66caa304c832aea41af4f63d7",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4409372",
+    "address": "0xd289b3be1853c7c2fd806b58196d022033ab35a4",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4409377",
+    "address": "0xc3c7b48347990103d69a5b39b1ecf85f75f0afc7",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4409383",
+    "address": "0x9e9c3e52e07059ee3ebba4fc44839f37adf118ef",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4410547",
+    "address": "0xc7981d29977fa60f589b65b1e610430f6d0b8411",
+    "name": "MyToken",
+    "symbol": "MTK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4411965",
+    "address": "0x4c686764759bb37284ca79ce94ae13f4a7d70069",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4411967",
+    "address": "0x7279e01958a6a3000a2a575341e4fb0eb75ec8f8",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4412021",
+    "address": "0x5ba6b6085bf59e69d3b734b0aa6e2bc0bf421b97",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4412054",
+    "address": "0xef0bb25516b48f836967c6808232ff4c5d87e20c",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4412087",
+    "address": "0xc714f4e541b6d8fceb823f9c5fff21c4ba66c7b7",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4412092",
+    "address": "0x66ec5eff88c6df71adff8cf4cb05d0e37e615330",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4412100",
+    "address": "0x5631a85c3c6cf0339832c501d2a26b9f8267910c",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4412102",
+    "address": "0xd223b2bc2ca55fa512a2468922e6d32b30522309",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4412111",
+    "address": "0xe5554ab3656ee1a6043fe348acff3b57ebd5d8a6",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4412116",
+    "address": "0x66b08e6b2d699f7037d14a927fb5de35e37c1b5a",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4412143",
+    "address": "0x6e4c7a1a3a13a3c8c9b6bc863aa8a98ee15a563a",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4412145",
+    "address": "0x0da6f3b89365d045a23af52fcf6881965f2435bd",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4412166",
+    "address": "0xf7a47a3d42bccbad52d3e195e2e45562a718b1d4",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4412175",
+    "address": "0x8252e38b5711f46bf4d0c30a550244845b756775",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4412183",
+    "address": "0x61316f82c955855a540b28ef26f0052894bb1493",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4412989",
+    "address": "0x31f9c0a22a3fb3fe3068760add9978f582fb97b7",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4412994",
+    "address": "0x1d6fab5d10e5f4ea9dfd0a645d02823bfa971340",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4412996",
+    "address": "0x74cf4baa7fdbe2e1bc14958ee62f63313b6e596b",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4413054",
+    "address": "0x7b2b651f2a69c54c4ac314a735c0debc5a1d6894",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4413097",
+    "address": "0xbadca6a1925e58280f2de2feaa41206421ac02ac",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4413122",
+    "address": "0x494237142d1ca82066f80b410d1fd546b2137e54",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4413151",
+    "address": "0xb842573672e894b5b222585845466577195dbb7d",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4413172",
+    "address": "0x3eaece750b26f2e38edd5aa008f99ea242614fdb",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4413182",
+    "address": "0xd14117376c8c8108312cba8cb98f8f8232da1a29",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4413188",
+    "address": "0x874ddf65f42c9581d7e1c5c944230766207b2adb",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4413201",
+    "address": "0x6c81e405f4537d9365c7e292214e1116fca75203",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4413225",
+    "address": "0x12299274fad16a62f479469a64ac8faebd594e1c",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4413229",
+    "address": "0x44b89580c9ff5ffdbede37dde8016d991a9ca2ff",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4413245",
+    "address": "0xa6ed3ac87a341e591b6fe30abef9b96b0f19a646",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4413349",
+    "address": "0x2361fb44fceeb1f4536d0f3de27e69f8dba6730d",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4413351",
+    "address": "0x3f28d06385f0ea7742f660423a674217be12a892",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4413360",
+    "address": "0xe8209ba4d0dcea04cd1a9f9b749f672a5fcca92c",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4413367",
+    "address": "0xdc9f02c9279b3304d9ce044b0009792bce37a9a6",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4413378",
+    "address": "0x234be3006643cd3175f0662ac9b4178246227acf",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4413386",
+    "address": "0x0a34726da52b40f767824b535df498ebf4801632",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4413459",
+    "address": "0x202d9db1dde66bf083cf147c3ab91b5cd75028dc",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4416445",
+    "address": "0x92a2773a6e627d8a68f4255ae12f95b86d656cc3",
+    "name": "zvvdFirNiD",
+    "symbol": "JoMWw",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4416736",
+    "address": "0x9891cdae74b051837f2e44a1209b9c18f404ed59",
+    "name": "VUAEuzbVTs",
+    "symbol": "rBRDp",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4418516",
+    "address": "0xb603ff1ed542c68c9c4cbcb935245687ef1721f5",
+    "name": "Wrapped Ether",
+    "symbol": "WETH[hts]",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4418519",
+    "address": "0xcf95bca057fa6504d57840a37f500d8e1f427870",
+    "name": "Wrapped Ether",
+    "symbol": "WETH[hts]",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4418524",
+    "address": "0xfecb995a1c4eaa468d14c2fd3327f9fa00963ae3",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4419250",
+    "address": "0x04bfc1ed0cd3f4d95c8324e2bafe8b67f807c865",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4419758",
+    "address": "0x581effbc758895c789cbfc64ed45342394292360",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4419762",
+    "address": "0x5ab38db228aa357f26470c045761ed5522f02c4d",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4419836",
+    "address": "0x65a801cea5c432e06c3a146525608f2a3d521930",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4419843",
+    "address": "0x3661b29b7fd45a1b444aafbfda10b4f5974ecf0e",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4419849",
+    "address": "0xdaf3d8a70f545c6b3a96eac8b3dc4efaac77f13d",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4419852",
+    "address": "0x5924c5d561b356879da43b0a9f9631b54967a17b",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4419909",
+    "address": "0xf4b44fd0bd7fc5b1cb70b5ca97166003cc4c8889",
+    "name": "rgfgh",
+    "symbol": "HJKL",
+    "totalSupply": 10,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4419963",
+    "address": "0x719e80e6bf2ae5b760e26eb0890314f5453c451c",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4419967",
+    "address": "0x7716dd20ab890d2c900403dbce4599f88a7c7112",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4420755",
+    "address": "0x67b3dd16629f4bdd63a52b364d092ff0507f0b50",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4420759",
+    "address": "0x95b57223cfe2c8715f94d28637486dbb9bb8aca9",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4420762",
+    "address": "0x3210491c94844042eb4e82da8298e3a72693b9b2",
+    "name": "XbVVQjgBwz",
+    "symbol": "PELpZ",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4420865",
+    "address": "0xe57138796fe047187b4d94cf3bb15458df1d56ff",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4420869",
+    "address": "0xdcc75feea27dab65b01e799330d81d205a2f2882",
+    "name": "pgSElHqlko",
+    "symbol": "CkiKK",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4420899",
+    "address": "0xcabdb70451d1e30f9da19067c25db5394591e050",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4420955",
+    "address": "0x8d8424a340a75bde0d315d5f74aee9c4e40dccde",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4420987",
+    "address": "0x8dc02c9da34e60559756165e76e123256a81c0df",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421053",
+    "address": "0x5d7298be9a9404f53286fcaa122719083b40f963",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421063",
+    "address": "0x51ce4c15029520395248d48c879255998a73397d",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421067",
+    "address": "0xf794632aedb8a30739248a9a839f6eb89e2d5a0a",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421074",
+    "address": "0x4aa4c04dc897dfc84f33f0f1112ac93344ef8cb0",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421098",
+    "address": "0x38cc85a4e80d8f72c4155c2e6ff8ab12f6fc55ea",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421101",
+    "address": "0x7d592437e241dee30463681d14c39bc9a57bc463",
+    "name": "QgPRRimrlX",
+    "symbol": "SgsFV",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421133",
+    "address": "0xd2d8b4a9904c992ffc4d6cffb3ae5b9dbf736de1",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421142",
+    "address": "0xa58dc40e0b0c4d7bf51d46a73b0a6f83bc937af7",
+    "name": "iAiQjifDzW",
+    "symbol": "QIVZQ",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421144",
+    "address": "0xc690cf54929553a28b8046a94bdbf8491b627120",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421152",
+    "address": "0x98e8e77cd8e5c025f59d2e9fc46ccd892d9b1255",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421154",
+    "address": "0xb4b834d0f2b119aafce52ddbeb9f7a7b015b6275",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421161",
+    "address": "0x91fe2109c49a60c62d16a506b090a724ab7851e9",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421182",
+    "address": "0xa182ba253990801a10baa99fb677648385af9df7",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421184",
+    "address": "0x38b1bcefb042d742aa84d8c258e71145bfb17626",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421186",
+    "address": "0xc39b031c861e7ccc2fce59d2eec40f9edf5138f2",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421189",
+    "address": "0x36068b25a45b5e4fde2bcaaf30b8e13b943c18bb",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421200",
+    "address": "0x8c893e88b38d6109fc9ca3ead02d0953d128a947",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421202",
+    "address": "0x975e28fc702ba600abdb90b5c66af4606180e2b0",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421212",
+    "address": "0xfc146790752d8b2f7e28065c15085d0d286b6224",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421214",
+    "address": "0xa855476a972c7363fc05504e804c26efc2b17cec",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421276",
+    "address": "0x7b6850a07173bad22df27c0e10429859b346e43e",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421295",
+    "address": "0x50447c67145cbb3486becb7acf10176b38445f30",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421307",
+    "address": "0x7786f402e09ea2ea54cb04ffc65e468c2f9681bf",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421358",
+    "address": "0x50fb0aa6c677cd977ea89e7ab74a3cf4a46125b9",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421362",
+    "address": "0x120019d93c8ae5e7e3ec250e3e25b9dd47a5579b",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421372",
+    "address": "0x523368d4a9cf94d6448f15ce455d7d701039e21c",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421374",
+    "address": "0x31a1219530b4c366099c467fcea40307c258790f",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421382",
+    "address": "0x3632abd8725a6d603e634982d2f26c22dbe347ca",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421414",
+    "address": "0x78f06ea8bba6a132dbeee10c48546e2f593c067e",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421416",
+    "address": "0x86bd7f98007dd7e4d76285d17e5ee800ea2b3789",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421423",
+    "address": "0x26dd66bc9969488b589e44a35f21039df62db6bb",
+    "name": "WnvenBkzhv",
+    "symbol": "HUgbZ",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421656",
+    "address": "0x8971a53c49f196cea334f4717dd4ab604bfa51c9",
+    "name": "JsYFYWXQZl",
+    "symbol": "dKlum",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4421664",
+    "address": "0x2f56e580b5261dd365e6cdd4386ccc559acfe768",
+    "name": "WmAjMuxExY",
+    "symbol": "ipfAo",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4422051",
+    "address": "0xa385088377e966da68ea8ed999ec57e6cba3908f",
+    "name": "xpYPsdliXC",
+    "symbol": "uEzlN",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4422231",
+    "address": "0xf000521267067df13c46c314b7ee453dadfabb21",
+    "name": "ZVBBXVJYEm",
+    "symbol": "QipIr",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4422404",
+    "address": "0x12f3bad70a079748df0ae0ae591980627ddcc356",
+    "name": "EWTrrinaoT",
+    "symbol": "vNlpX",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4422440",
+    "address": "0xf9ad0fb47dc966379b87376e62a20badb87b7fd2",
+    "name": "easmajIlyn",
+    "symbol": "emMOX",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4422476",
+    "address": "0x7db51e031c1b524b0557f836908109ff222415e5",
+    "name": "JlGYyDKiyE",
+    "symbol": "sdlCt",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4424140",
+    "address": "0xf7f0d845b4b1eb170c8d28e3594be340b9f3d5f4",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4424174",
+    "address": "0xd664ee045ff93675750c83d59e02fbed7a6cd052",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4424177",
+    "address": "0x39cd883d0787b1d14fdab89e82e04fed71446b3c",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4424225",
+    "address": "0xf80ecd1a59874fa84e6b094912a69fe9be70d101",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4424236",
+    "address": "0x51500093a0cadce712be15c5f4c25d58fcbb1d57",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4424283",
+    "address": "0xef9248f7de0dde839b838b4dee2d6ee6f27f21ea",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4424605",
+    "address": "0xf972e66058b0019c1fdc164e6bfe4a87102a6d25",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4424611",
+    "address": "0xd16ca35a9fbd42a2729814c080485502af40c14a",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4424620",
+    "address": "0xe8dd91059fe912ee6aa1910cd3995800329a14ce",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4424671",
+    "address": "0x2a24a81bed265ff1fadb815fc0bea7e496d359f5",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4424815",
+    "address": "0x15a3f50b397c41a39c927f1eae44e01c1cb2868a",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4424834",
+    "address": "0xc01256157dd4befa7e531afc48b304ce864ddd61",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4425202",
+    "address": "0xc5ec3d7c5b25acc05938bef84eda02c1dfe42983",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4425204",
+    "address": "0x12efe3c9cd6d987aacd5c41d0a39176fd3b78162",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4425206",
+    "address": "0x1c8654c7627cad03e6e734f77542ac7f7a06207b",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4425208",
+    "address": "0xee7303036dc668378779a17bbb2e9d3c9dcd8dd4",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4425210",
+    "address": "0x9d6cc21e43d0f78a5948d0020767c28d67d6356a",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4425212",
+    "address": "0xa51cb6f1652f7b433826f3d07abdfd723c911194",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4425214",
+    "address": "0x06243ae4ca4e70e39bcebfc80bfa700cd60a9947",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4425242",
+    "address": "0x3fdbd1456ac426a42ec26422f07bc0aa596d5236",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4425244",
+    "address": "0x42210890ce461f05dcb11a586b4dd5ba6ee829db",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4425246",
+    "address": "0x268b49bbfdcc9a5d020492c054a71d99a30ea5cf",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4425248",
+    "address": "0xdbdc9628bb6b17fd65d79bf9d5f4cf614a4ba87c",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4425250",
+    "address": "0xd2828411b5d4021e224e175e373e741e00669681",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4425252",
+    "address": "0x24a5def7e83d5ed583ab7f45daea6c22071164d1",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4425254",
+    "address": "0xd9a2b0d47b6377f38c0547bc790fbcbbff575079",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4425270",
+    "address": "0xe43b3d0e58ee3dc4c91061da914baddb6f336136",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4425410",
+    "address": "0x707eb1344349c2c349c1d5e8b5e939668f3aa6f0",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4425412",
+    "address": "0x9d71fc0319e0578dc19718aed3e7c5be7159d728",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4425415",
+    "address": "0x186b770f728e21244e106fe56af527dae21b6311",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4425417",
+    "address": "0x60a9d1a284851ff0fa4a6691960be2882bd04b5a",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4425419",
+    "address": "0x4bec0aaa155d8501142810f847472b8cc888e324",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4425421",
+    "address": "0x6a2adfb21bb564f2a444b2a7c4d03b033429c84c",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4425423",
+    "address": "0xb94bc553656b8bd0a3c7c4119b301c26b3e4c2ec",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4425530",
+    "address": "0x2fbc49c3c9c6fd75a22481072ad99ec755d44a79",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4425570",
+    "address": "0xb0b71b2650ca70c223cf8353fe92c940fece1ff7",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4431596",
+    "address": "0x7e8fe58749513001c6758e5174fcbdce97bdf5ca",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4431601",
+    "address": "0x54e2b765504eef886933629e7ecb99a971fe15b6",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4431605",
+    "address": "0x6bdce954124e27ba83b85d2ac49dad8fef994334",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4431609",
+    "address": "0x5748602fc9948ac1b3482839a2055305f7f152f9",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4431611",
+    "address": "0x95602eeb9f10552f18d71ebbe1e2d70e21a0fb33",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4431614",
+    "address": "0x6afcf8c63181898926f8f5abf72464de974d246e",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4431616",
+    "address": "0xb8da90b09a3cc777c3531566d066ab7d6da28f3f",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4434051",
+    "address": "0x41878a5ef5303d41e7783dca7e321e1d0ead1bf5",
+    "name": "myToken20",
+    "symbol": "erc20",
+    "totalSupply": 1e+39,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4434202",
+    "address": "0xbe7cb87de75d785cd75fc9668060a633fea721fa",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4434309",
+    "address": "0x8f7ba8595226eae4ca4d1c0aded4f6c4f0cac719",
+    "name": "0xBurn Token",
+    "symbol": "0xBurn",
+    "totalSupply": 1.9995e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4436874",
+    "address": "0x9a31401e2eac6fbaa6f051beb9b7406019f08a4a",
+    "name": "Aave",
+    "symbol": "aave",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4437715",
+    "address": "0x73ce88b022225fa42c29ac4de7b0b3a5629557c6",
+    "name": "krypcCoin",
+    "symbol": "kry",
+    "totalSupply": 1e+39,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4438055",
+    "address": "0xf3398b649f49675c6ba1071dfee4f3dc4b4fba2a",
+    "name": "DSwvyCVnwY",
+    "symbol": "ZFBRV",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4439092",
+    "address": "0x5867302bd509519b2274cd2dc7718bc1293ab8a6",
+    "name": "GhZXGdOqdh",
+    "symbol": "fdrgk",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4439113",
+    "address": "0x22e0c39576be1cfc5362ad75dc87e02ce0c9e317",
+    "name": "OsWEYaGxId",
+    "symbol": "eBLdO",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4439141",
+    "address": "0x8cb2ef71d8530fc1372d00117e9573c23ba2e3f5",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4439166",
+    "address": "0xcc8e779fc88a70a2286ff06c94274f2214e19528",
+    "name": "HeRjRtvlBH",
+    "symbol": "qfPok",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4439250",
+    "address": "0x3944fc6c9d0b448feb670dee6885319890122d7f",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4439262",
+    "address": "0xf74a502689064dc2c9504a7665430fc3f4acdc20",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4439273",
+    "address": "0x2232ad21101eb68b9ed70a2fac2a42ab14a1573d",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4439316",
+    "address": "0x9dd85eb5258c9be3f1887d392ad0419229c3fc98",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4439501",
+    "address": "0x0bdac6ad5ad3159650dc834b12e9728b7cb3db5d",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4439600",
+    "address": "0xc556534ffe892fabf67766f55097d5b3cb5e2430",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4439634",
+    "address": "0xa5a3efdab7539e4fcf8ecf52d0d7e9e96b7decf2",
+    "name": "Aave",
+    "symbol": "aave",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4439677",
+    "address": "0x6cd03b2e1a15e57f874319db5a508864bfb7514b",
+    "name": "Aave",
+    "symbol": "aave",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4440049",
+    "address": "0xc55cba236d5c34a1a975aafb42c0f04c0fb0e78a",
+    "name": "QIemQFYRBS",
+    "symbol": "CyoJG",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4440449",
+    "address": "0x000000000000000000000000000000000043c181",
+    "name": "MyToken",
+    "symbol": "MTK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4440805",
+    "address": "0xc82fd6aa1683b37e3dd534c2d77a6c6d36e67dc7",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4441104",
+    "address": "0x18c0f166e3ee82e9e7e4ebe02819b7677bfcad50",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4441173",
+    "address": "0xd991d59326fae0fdae9fcd19c403c09439416300",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4441217",
+    "address": "0xf6879c4e86447566d4e968de16d4398a399563c2",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4442993",
+    "address": "0x5d576d0b3a1d0ae859248aeb317be0a0a863884d",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4444450",
+    "address": "0xf9b5597919f8ce7f3553aac868fe4f7a76810785",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4444511",
+    "address": "0x0b07972324d15e22199ad5892308439f9037e7ea",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4445124",
+    "address": "0x8ade1c5c5f3fb9a7c99f32da0033d42f31bae4f0",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4445128",
+    "address": "0x67112b16f0d8fb021b94a57be574753002e8a3ec",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4445131",
+    "address": "0xdf3a681b95889a493aa4360156034396e88d693a",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4445134",
+    "address": "0x9abb8c4efc091483334c1efdeaf0b9c397e6d210",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4445144",
+    "address": "0x4324ed9f065a8c33a214049fb50f9d11aaeae56d",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4445483",
+    "address": "0xb9f529f2bb0d2cb527f1634261d3cb899bb6e39a",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4445525",
+    "address": "0xf44a1150fd6fca127b2957728af2371ea797eac3",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4445548",
+    "address": "0x7ff1709adce6629c33f3c06b62131c5d3579f33a",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4445994",
+    "address": "0xdb2f813c427acf076f115ddb13f3a0e09bfb384a",
+    "name": "yxeeKevHJG",
+    "symbol": "HGFKY",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4447053",
+    "address": "0x7e210e2c9be7447cc2595d770b0da292e6d13d31",
+    "name": "dHsSkcRGTk",
+    "symbol": "pxWyl",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4447133",
+    "address": "0x5b98769a591ff2266a8c615875d3df6010947435",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4447135",
+    "address": "0x772d2c2999affce882286a22b9917bf0731a5868",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4447137",
+    "address": "0x6537aff1a175caf820354c2f7c6aaa936556e733",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4447144",
+    "address": "0x948fd0ef4b5588b37b7663ca081138e3b4a97bc4",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4447146",
+    "address": "0x3dfb235ebb4ccf745010abc8a8db0ddc239e6790",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4447150",
+    "address": "0xb41157eea8f75e162a07921112368ba4620b4987",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4447152",
+    "address": "0x7c9d626222527f8d812a368e4f8979340dcbcce7",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4447173",
+    "address": "0xac0904050c4e56f16afebec4a8a4f4b33d291bab",
+    "name": "RSpKfhroiT",
+    "symbol": "XbjIr",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4448704",
+    "address": "0xe7063b238e87be5d7a5ceb7e6633373708db400e",
+    "name": "MyToken",
+    "symbol": "MTK",
+    "totalSupply": 100000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4448724",
+    "address": "0xbb6f3ee65fd0c6df66d29b5ad9f3a8695a638172",
+    "name": "MyToken",
+    "symbol": "MTK",
+    "totalSupply": 11111111,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4448737",
+    "address": "0xddaf91685cee6dbd113cb936ff1ba22f14e5c6fc",
+    "name": "MyToken",
+    "symbol": "MTK",
+    "totalSupply": 1111111111111,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4449387",
+    "address": "0xa39d66cadf6ae1835d83d6495f7496da2c6a43a7",
+    "name": "rfkmrfm",
+    "symbol": "rfjrnfjr",
+    "totalSupply": 12,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4452168",
+    "address": "0x420b263b676743431f1ada17eec17a6338db404b",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452172",
+    "address": "0xae1a5b06ab31936f00d122a98ce48e4e0af01d9e",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452175",
+    "address": "0xfc3332aa1570a57cbb895079f80a9ff1261e4655",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452180",
+    "address": "0x261c989b7194e15eb25e9f1c9d657fba5376d160",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452186",
+    "address": "0x8d3b6e2bba9dc9ca7b281c5fd7525d7359826eb0",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452193",
+    "address": "0x54d5aa4bd3f360e87bd87d0f14c0e67f57d71405",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452198",
+    "address": "0x05eb5886a0dcc0bf258e89572b58dbbc88e75159",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452240",
+    "address": "0x64f2cac51d656fd73c7b27829ed8101038c499a5",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452243",
+    "address": "0x0ee3d18d9ac650cd8568c5c1afcdf6c1f5492aa4",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452247",
+    "address": "0x4120ac9f6fb6cc531a0cc3e500749deb33e0e770",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452249",
+    "address": "0xa2b56016bd24478ac5533054d1e2c6a7139cb33f",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452254",
+    "address": "0x2a2174b0c63e59abd15dac5c4d58ff9a7d5218ae",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452330",
+    "address": "0xe24f6a8a6e412e94b4827b2f3ac30f8ba277f64a",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452339",
+    "address": "0x907bc83b0fedbd022ec9b29a4eb2bf296dee6241",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452350",
+    "address": "0x6eaff117d5110876fe983841a84f55336d8bd961",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452361",
+    "address": "0xb1c0a40aef92163a1627b5001057ca07c9d9bf49",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452372",
+    "address": "0x5db6c0fcbef3318c1b7443c555c9bbd5012dee33",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452386",
+    "address": "0x6af664a738214f16d83815daafe6f7c3c5d78c2b",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452396",
+    "address": "0x878f7437c27c403b34f222460729ceacfed8f155",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452410",
+    "address": "0xfa4c08914f3dcefdee05e180ec6071de9f67e6f4",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452414",
+    "address": "0xaa87775e2ea867cc74601ff29cbdd4322ea85454",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452420",
+    "address": "0xa51a6069f93ccada23342470678b3a9fe5b1a333",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452422",
+    "address": "0xd18baa10fa596d0e8a61436a40064b57d1ca1c6a",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452424",
+    "address": "0x1a30a05b82c3adb3637cb9d56cf848a89fd41835",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452430",
+    "address": "0x7820ba594cbb6c01411c5a901f3c420e074f097d",
+    "name": "oRHLbkQBMa",
+    "symbol": "Qzxxz",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452431",
+    "address": "0xedda43d39845aeeca5f64162f3d5e1b1f9d7febe",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452434",
+    "address": "0x68383627c10e2bbe2dbb241b314582ad7e832e5e",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452524",
+    "address": "0xa26aa55aadb81dca3a9696b6d085cd864762f6af",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452531",
+    "address": "0x0862df35aa1235645747502b7a67244ab23fe567",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452537",
+    "address": "0xae8359751a452f09b44e70d1b0931aeb89829e19",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452544",
+    "address": "0xf44c66881ac774bc9774c731a35831e461d45ccd",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452551",
+    "address": "0xcd9e70149b9f785bec88a204114b1b8e6955f20c",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452554",
+    "address": "0x7a7fdc3a93a56f861465fb3ba802ace1960bec28",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452556",
+    "address": "0x1340d925af4d59961c253eb2002688ef73099e0c",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452635",
+    "address": "0x75b872676d88faf88c2aeb7a6d609b85ff24abe7",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452637",
+    "address": "0xec0f76055335484bab5bbee317b71bc09a90eb8e",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452640",
+    "address": "0xd0227ac419ceb5093c17c2bf21fe618b1689e1ae",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452643",
+    "address": "0x29a2456c2b3b9abe8190d3548119fece25535b86",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452645",
+    "address": "0x64aadf603d50fd4b9016996cb24aa24570555d1d",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452675",
+    "address": "0xb510c98925e893c57b53e2b93441a95ed3b527ff",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452678",
+    "address": "0xfb733147eeb7637f17e2802cd122c56022986d9c",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452682",
+    "address": "0x140c7de313c6fc8c4d0846cc0db9b3868edae5ab",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452684",
+    "address": "0x910b79ae62397721d07a99416b0af4081c06362c",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452686",
+    "address": "0x17d777c13d8865b09cb214fac88038b0385ea539",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452690",
+    "address": "0x739ae82bb88d0546b2f3d4ef253cef81d44e939a",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452692",
+    "address": "0xe1c7468a3076af5555b216144d5362b1b71453d9",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452732",
+    "address": "0x43ad7fa036bd95c8a71892bf67b810ee764f5712",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452734",
+    "address": "0x91c55b422565059324224c9b3fa337cfa7730dd7",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452736",
+    "address": "0xff401ab6f28f410be5844cf45a7fe7cc199e3829",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452739",
+    "address": "0x16f0d1a27aaed63e1089b7155afc0eb68d219e4c",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452741",
+    "address": "0xef154baa284e16c02f819dfa75d73495c6359283",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452743",
+    "address": "0x2da080797521e8ac1a6598c228c220bf1099b5f8",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452745",
+    "address": "0x268cf54df799efbb4510b67ce7ba73ded922656c",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452810",
+    "address": "0x482138ac84b7b95e2d2050b45f875a3387c7e282",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452819",
+    "address": "0xa94c1437ab92cd2ae39851dd0c59f3add187d9b5",
+    "name": "RbvSNBBqJR",
+    "symbol": "wGJgw",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452820",
+    "address": "0xc2dad487d8ad1961a650c4e4393b3daffa3efd5c",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452830",
+    "address": "0x461737bce744d52a077ad27a9751838222b71559",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452840",
+    "address": "0x20ca7138fc1fff27df81cc2ad8d4f73031f53daa",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452847",
+    "address": "0xd1a65f08ca484bd895249126eae6adfae98a4c6a",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452854",
+    "address": "0x11777b95fefaaacd203d5fb1868cc55c4bd43818",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4452863",
+    "address": "0x318d7ea689b84d2efe5d2a956f2d264c13e1c1df",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4453002",
+    "address": "0x3cfbbd5718b977a317b93aad0302f9fa3776edaf",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4453008",
+    "address": "0xcc695f42f3acac8b78a06e1235fca47dd3ab722d",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4453013",
+    "address": "0xa2c5c6ef27ef702cf386b132e196907d00397463",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4453016",
+    "address": "0xa313594a916c9224f2942c849e31d5b02fe6cab8",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4453020",
+    "address": "0xbdcd558c50f2fc9bf063cab799497b3a870bcb3a",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4453025",
+    "address": "0x519ab319976c68d61d632a914cd50a88a7c0f742",
+    "name": "PxLGlmSoPF",
+    "symbol": "OfzRb",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4453027",
+    "address": "0x4a01c6def10cafd5195b3e473ef3e651de322a9a",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4453029",
+    "address": "0x3207afd6a48e7757f44466530ed533789aa9cd45",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4453191",
+    "address": "0xf6fa511f037806ab89638d8ef3da01d81b5151ba",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4453193",
+    "address": "0x20e00a2b13f29adf26ea96c7ef0341f35e5653c2",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4453196",
+    "address": "0x3eb4c08cbbbf8aaa3d8eb364a4023ae9c33435e4",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4453198",
+    "address": "0x7a8a3dedceb3ecabca845fa71cc1e51f9dba4228",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4453204",
+    "address": "0x527f87f5b2fedc1e410fe77e99ff3a3ca5a5817f",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4453210",
+    "address": "0x9f8b19433b76d47ef2b959e0dbee5d6216ecd713",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4453219",
+    "address": "0xdacd8f0befb64cf97d9b42af32150a52f1c8170f",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4453634",
+    "address": "0xa99b10713ac5ca1364ee7fed9d088163d519486a",
+    "name": "UKlJuUsUrX",
+    "symbol": "WJQAB",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4453668",
+    "address": "0xc9cb7438e2af26ecde7f9b43b47e6b0c2443039a",
+    "name": "hffTmxIriz",
+    "symbol": "pmIlj",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4453801",
+    "address": "0xef9b3006a50ccdd5675b98427aec282c30b04993",
+    "name": "ZxZGkMbXeb",
+    "symbol": "kBDlZ",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4454681",
+    "address": "0xba52ff7ece4fda8469b935ad376796bcc53fe391",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4455104",
+    "address": "0xb7c34cb41c50c6b68479610cc70755d9df4ebf02",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4455114",
+    "address": "0x6185d053a2354cf9c2a529dc3ae87e1605f85580",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4455130",
+    "address": "0x240f9792c07f14dd17866d6270a5b171dcacf5b3",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4455153",
+    "address": "0xb1201dce7d8c0c7d2fc256eccf81770cd29e1a2b",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4455265",
+    "address": "0x9a97ef4cb5bed7b8a52f691633217c1cb73fdbdf",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4455278",
+    "address": "0xd66163bbc1c86b6baef7b44ecd743ccd0c4b8fc7",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4455353",
+    "address": "0xa76e6687075ca19c7691023e457d1aea4e973c28",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4455367",
+    "address": "0xa78305564e65ae182e8868a1f34eae575ae93250",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4455824",
+    "address": "0x803d8a177b57d6eddac3e0f01b72e91a16c60bd8",
+    "name": "AUSD Stablecoin",
+    "symbol": "AUSD",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4455826",
+    "address": "0x517055d52194edde9b9e2162a5a8a294af34f492",
+    "name": "AUSD Stablecoin",
+    "symbol": "AUSD",
+    "totalSupply": 1.0001e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4455864",
+    "address": "0x93ebcb1e24ab7a3edaba2ebeb74491f823ff6814",
+    "name": "AUSD Stablecoin",
+    "symbol": "AUSD",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4455876",
+    "address": "0xbb90fe93198d6acc96e0e626b89f561f287df4c4",
+    "name": "AUSD Stablecoin",
+    "symbol": "AUSD",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4455891",
+    "address": "0xf6a72c0040d75c1b837dc5e497a1885e307b0ea6",
+    "name": "AUSD Stablecoin",
+    "symbol": "AUSD",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4455913",
+    "address": "0x78755ad7f8ce7ae2bdd4145bfbe76f0a63f42361",
+    "name": "AUSD Stablecoin",
+    "symbol": "AUSD",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4456160",
+    "address": "0x9766d8437f5986cc02e84a2e9e49ebd283e672c8",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4456175",
+    "address": "0x6266b0695ea7e43c72acecf2acb43dd0ccff50de",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4456787",
+    "address": "0x222271e9f824d811fbb75dadbb831a9083ffddc2",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4457591",
+    "address": "0xa4dd7b2564e6b0b5dc79a713ed653d96c9813666",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4457593",
+    "address": "0xfed3c2d03a8a54662619dedb793ab3630bfb5168",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4457596",
+    "address": "0x152b918e598911331e26163e1230544e9239ee47",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4457598",
+    "address": "0x65d1f22021f8d726b1b93088593f98291b611372",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4457600",
+    "address": "0xace0a8bedda6286e751895c9ebf1af89e1fe5c26",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4457603",
+    "address": "0xd682fa4e5210afd02f32e4be00f89988057534bd",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4457605",
+    "address": "0xd0fa168a397a5eb33fdd043c4704e437edb5aee7",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4457614",
+    "address": "0x079cc03c1cabdb385ab4b8ceca91d28c57c379bb",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4457616",
+    "address": "0x170758f9f807a93d40877d7b7901926965b73cd6",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4457626",
+    "address": "0x94ac02239324fa2adf8b5d06eae582a3901ed063",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4457628",
+    "address": "0xe09c43a0367cc77e11d7c8507a124d40411bedd6",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4457630",
+    "address": "0x3f7a0b123ce1db35d78f60c6794bd42a1a7b4a3c",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4457632",
+    "address": "0xbf450b5a24cfa4d23f3901622524c777d08584d4",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4457634",
+    "address": "0x69823f599691dcd831174f6273d58731d15e289b",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4457636",
+    "address": "0x811a5b0bf63b5f4d51144985c78a389fcb900a96",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4457640",
+    "address": "0xf974a7ed88809922726e6e32627f0d0c665ebcc8",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4457989",
+    "address": "0x17607462e69bdaa6953712643c3ea2c4caf30802",
+    "name": "ehrXRYbtYz",
+    "symbol": "bpOzx",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458138",
+    "address": "0xa993c4e7614d77609a172bb5b6ee6646db46c59f",
+    "name": "yqJDPUJNzq",
+    "symbol": "FknIw",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458256",
+    "address": "0xcf89ddd5a4dcc0dfa905fc3c57632d20fc1ad59b",
+    "name": "rQUUhpBJjH",
+    "symbol": "hdWnJ",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458352",
+    "address": "0xd5ff6a076a5235234f09743050a0fe40faf79f92",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458376",
+    "address": "0x198a8f2f3280091a4d5efd173084a795c16e91fb",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458377",
+    "address": "0x5e5de181597dd8f4f90c461b5ed749579375bf5d",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458379",
+    "address": "0x1940a4bfe056f779c297eaac91f2c882f9f0cd77",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458380",
+    "address": "0xa3785336f0a661b6f2bfe43ea3377496fa3d7794",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458381",
+    "address": "0x9cc2193693d9849181e6f4770f1e67cfdcca7450",
+    "name": "xsauce",
+    "symbol": "xsauc",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458384",
+    "address": "0xe167f57c541c0d2dd26fbf67d5c31c4efb2ba0f1",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458385",
+    "address": "0x6fd455a0a1158a604079e1442eeb207c1552aa79",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458514",
+    "address": "0x4293092877aa4bccf967450ba4621696e6064098",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458521",
+    "address": "0x6cb0e99812b17b265f23597b27bcde2b04f04477",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458524",
+    "address": "0x3af261e6a6b4b4fe31b9788335328c19de802348",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458526",
+    "address": "0xdb69b897c34fef6df2c3c39a51fef2689c2c92e3",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458529",
+    "address": "0x3b9e2aac15ba83bddcf708c6244840518000774c",
+    "name": "xsauce",
+    "symbol": "xsauc",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458530",
+    "address": "0x3a280d31a8e6cf65ce79dfce13e605c88eaf3e0e",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458557",
+    "address": "0x58ac7f4608be7b229fb67d2c567e99d53d86e77a",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458558",
+    "address": "0xc2b4a54b9b75a48c3c01dbea3364dd3e2bcca379",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458564",
+    "address": "0x4d591b48a779236852a352b72f13ba5367e516eb",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458569",
+    "address": "0x60c66bde2d3f7927c0e6dca07a865a63c5340204",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458570",
+    "address": "0x5411f5e8426d4dae94189d20c462d0196075ba53",
+    "name": "xsauce",
+    "symbol": "xsauc",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458571",
+    "address": "0xff87bd0b5999dfa04cf55a7fa099dfba4ff4b219",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458573",
+    "address": "0x6bf4baf28bd2fcc766b098dd76003b38cb794083",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458632",
+    "address": "0xc4c5ff8ea9c2ad964a9c0ae7fea8f82583f6fa3e",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458634",
+    "address": "0x32c06c6a6d5f43039284d363dbb681cc9e1bf11a",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458640",
+    "address": "0xa263d43eed4ae6f6218d16100be934747dd7ebec",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458641",
+    "address": "0xce57a4b26e4445d3697a1fef72c3cf9ad90e6714",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458646",
+    "address": "0xac2e6a8db3c0538f132f771d7909b694f4c4fa08",
+    "name": "xsauce",
+    "symbol": "xsauc",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458649",
+    "address": "0xa717314e8a82cd67f890fc328f45626bb91b3ea5",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458650",
+    "address": "0x5edc962dbabc1ddf4b68d59332461ee644286d67",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458752",
+    "address": "0x6021b090413e54362f7778a839c7bce25b725a83",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458754",
+    "address": "0x2dc94e77d720cc74e359bd6004708a6310d3beed",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458759",
+    "address": "0x8d178cf31a24d3de3e935c3d42b98158f0c81758",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458760",
+    "address": "0xa5bab730533a2df918bcccf7441bffe26664038f",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458763",
+    "address": "0xcfa40bb5d2fecde8a65c15627736ad989a50dead",
+    "name": "xsauce",
+    "symbol": "xsauc",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458764",
+    "address": "0x8999f1386ab75383f30bf9439da69d9824086cb5",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458765",
+    "address": "0x3ec5fe107caddb15e99ed3390544f0f63f9388ea",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458795",
+    "address": "0xf57c0fbdfc041b68ad530eff7e2152080ee0c337",
+    "name": "AUSD Stablecoin",
+    "symbol": "AUSD",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458811",
+    "address": "0xdc4b7b73056c6764dc275c902b9dddba1e4f6e9e",
+    "name": "AUSD Stablecoin",
+    "symbol": "AUSD",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458822",
+    "address": "0xab7bb5bb253066c038d933536b8457311c40ce66",
+    "name": "AUSD Stablecoin",
+    "symbol": "AUSD",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4458953",
+    "address": "0x4e37a3a8d628f4d7e83cb3bc547944fae514c262",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4459205",
+    "address": "0x73a06c47f124c813c1a1418387347925e70f80b0",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4459207",
+    "address": "0xe1c95dd27e60bb21143ce45106e44c2eec603d22",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4459214",
+    "address": "0xb57eb14bc4ae8dbbaada4fbd316f7481480f7fdf",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4459216",
+    "address": "0x15ed3876b9eaaaad578774194c7fa8fe7bde3d3e",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4459217",
+    "address": "0x13e12864e787b25ba5475e8df784449f2ba11a7a",
+    "name": "xsauce",
+    "symbol": "xsauc",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4459220",
+    "address": "0x5c29d2dd02c886a384e0ed8a79e995341d323cc0",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4459221",
+    "address": "0xecec54e11c5d43226613952e02c7796565c915d4",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4459244",
+    "address": "0x900090e47fe072cf5d3adc8d8fe41350550d0aa1",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4459247",
+    "address": "0xf2fba4ec905a079d1e06afa379427a87a7917326",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4459248",
+    "address": "0x887d69a2c596197bb2e612449719f8500ec7177c",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4459254",
+    "address": "0x45f6da6cddf6397f7877b82a1d200ea904ed3888",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4459255",
+    "address": "0x7a626bb345b4f9053474f8b2dd15563d8f110881",
+    "name": "xsauce",
+    "symbol": "xsauc",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4459256",
+    "address": "0xf6cc429716c405881d98d8a70dbf03a0def2a4cf",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4459261",
+    "address": "0x0a6c4096288b320b5056a47d9cc0b3f018f8ad62",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4459692",
+    "address": "0x01a78290948ca7c226dbeaeba14d0ce13a68d0bc",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4461511",
+    "address": "0xb84756a07816b45fa1fbb8fbdef29c2c75fcde85",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4461523",
+    "address": "0x8dfb06d9d4e61da4e5984af2d7e54be1582194df",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4461528",
+    "address": "0x7ff780f79016536aaae9f625b90160e578c981d1",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4461537",
+    "address": "0xdfa941c4a3ef254d107e3d6d6d2e4f3d73524de0",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4461541",
+    "address": "0x55ef8e0d4b507269d9276abf171bbe2ad7996d39",
+    "name": "xsauce",
+    "symbol": "xsauc",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4461542",
+    "address": "0x44ee9e7c346bd20f88d616193fd2dee80a8751f4",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4461544",
+    "address": "0x348e1f55f614f82e9d9e1ac53159482187008515",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4461568",
+    "address": "0xee79fb4c4d8f27352adbb95816aafd369fde7641",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4461575",
+    "address": "0xcfaf9991273d15012267f90896be411e91fd8eb7",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4461576",
+    "address": "0x952bc49ffc734bb25e860ce24b118c5654c92e58",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4461581",
+    "address": "0xa1eadc3437542701b334af428edd9e9641173522",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4461582",
+    "address": "0x9d77dbc96d30f770755ee4f00ad25e4108457a72",
+    "name": "xsauce",
+    "symbol": "xsauc",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4461586",
+    "address": "0x50b8c1e5876c0f75aef0988fa4c2c545f8cfbe9c",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4461587",
+    "address": "0x5bf719831003861728bfa6c4ab25c154c1ff9404",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4461612",
+    "address": "0x1d0633ea597b4e9b120804f8a7b8a4089c9e39ea",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4461615",
+    "address": "0x91ca72a596e9c147d8ba6ea117dfe49b111935b9",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4461616",
+    "address": "0x1149464d4415a4ba7b76741cbbc7dd0febc4effe",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4461620",
+    "address": "0x395d222ee61bac6968b2212618c159e54f07b55b",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4461622",
+    "address": "0xd10ec0aded76a379953a55c6a62d9e1ca3c460b9",
+    "name": "xsauce",
+    "symbol": "xsauc",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4461623",
+    "address": "0x0842dfde59b70f55863e10d44f1c856fe2033ff8",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4461625",
+    "address": "0xf30872e6b3d2ba69b10796ed39b00f0f0cf70432",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4462482",
+    "address": "0xf5dfe02c4372ec6a713d3a8a8e29745da10c2fac",
+    "name": "AUSD Stablecoin",
+    "symbol": "AUSD",
+    "totalSupply": 1.001e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4462758",
+    "address": "0x66dd6d63ad03e5558a5c424315317a85d4098d3b",
+    "name": "AUSD Stablecoin",
+    "symbol": "AUSD",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4463065",
+    "address": "0x6ca81efa24fd25967820ab21b4824d1774846e43",
+    "name": "AUSD Stablecoin",
+    "symbol": "AUSD",
+    "totalSupply": 1.001e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4463136",
+    "address": "0x2a5cd1f314a2dbdbc3de7d861b0751e1ba7190bd",
+    "name": "AUSD Stablecoin",
+    "symbol": "AUSD",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4463141",
+    "address": "0x4424e6691ff83a976be9d0006c23badc52b29c97",
+    "name": "AUSD Stablecoin",
+    "symbol": "AUSD",
+    "totalSupply": 1.002e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4468207",
+    "address": "0x0000000000000000000000000000000000442def",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4468218",
+    "address": "0x0000000000000000000000000000000000442dfa",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4469544",
+    "address": "0xcbc9bf0cee3a573f373a8220a104fb6b916a6f8a",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4469547",
+    "address": "0xb18038617644a8b7a7883f80b001263652efb2b8",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4469551",
+    "address": "0x202815d1de5180eda629bc8534da4f2326433b32",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4469553",
+    "address": "0x1cfb4ed8e0a840b3e8147f169254657a3b87a979",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4469555",
+    "address": "0x18d191e9df9cf6808810afaa3b5a27d5292bbf3c",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4469557",
+    "address": "0x9a3976f01baed2f528ae9abc5390a4f793b38ade",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4469559",
+    "address": "0x1fb9086ef0cd15f1b35377b9a554a409b2b4f691",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4469895",
+    "address": "0x0000000000000000000000000000000000443487",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 40041811010,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4469903",
+    "address": "0xa949616c9d5dc1d028a73982b3e903b1a8f648f9",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 232379000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4469905",
+    "address": "0x0000000000000000000000000000000000443491",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4469917",
+    "address": "0x39027423edc2493134ac6f4e5e3bf0e6197c5a37",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 232379000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4469926",
+    "address": "0xe45cc1bfbb8cd85b69445a7c0513d6a0de4c061f",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 232379000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4469932",
+    "address": "0xab29fd113c9b051944399fef482c1fe835ef9416",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 232379000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4469941",
+    "address": "0xa3b7e1814a6bcc8bec727e68a0d096069fd35e48",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 41011010,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4469943",
+    "address": "0x607187c04141a529cf9460bbcd1549b143f49d2a",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 700000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4470134",
+    "address": "0x084daa1202eb3cfd0ff2fc9e1c81ebca21b24cc1",
+    "name": "name24thjune",
+    "symbol": "symbaol24thJune",
+    "totalSupply": 12,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4470162",
+    "address": "0x34acc61df45c43d0e76c578905401998ac40d7e1",
+    "name": "JUtMacxZeS",
+    "symbol": "SvKAP",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4470356",
+    "address": "0xaca6717ec0bc5b4423753dd350944cad6cbf81c7",
+    "name": "RSVthicBCw",
+    "symbol": "QpLFM",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4470499",
+    "address": "0x8db920799a7f1a70d0de85a3b430829134b94207",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4470501",
+    "address": "0x1f4da4f1de1ffef87b56cc21d18f344340530863",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4470503",
+    "address": "0xfcac0f2b5f9fd1ed38e88972a9eecf39c36db027",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4470526",
+    "address": "0x086ebdc49881841c6321c73755e702ea4e695b48",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4470535",
+    "address": "0x7379c91051dac0e67ca8ad8ea3d007992d12716b",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4470537",
+    "address": "0x7e38997324eeafedb52203a282a054dd900883a8",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4470546",
+    "address": "0x4f19c7aa9ddc30b959306ef64afbedcc3139101c",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4470555",
+    "address": "0xa82d419599c436a15ef8829a0da386de1f22eea8",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4470557",
+    "address": "0x575f83209dc5b83250f3e2e83d034b507e57416a",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4470562",
+    "address": "0x4cc82ec55c03feca01483585fecd6a70edc0f855",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4474751",
+    "address": "0x8e76ba96b672b70a3e69c199ceae2ede7c5a35a4",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 100000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4474850",
+    "address": "0x00000000000000000000000000000000004447e2",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 12379596971,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4474862",
+    "address": "0x176549f0be8ebd4636618526915519844e1e1d7d",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 232379000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4474878",
+    "address": "0xf508e2eb5ddac94bc0558842ac6d90ddc1d81cbb",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 11000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4474883",
+    "address": "0x22a65fa6ae2b5a3cc24e3a6e3a08e06b7ef8cff6",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4474902",
+    "address": "0x33a028c44289b745ceecb355584207035b1e8592",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4475318",
+    "address": "0xa31ecd672ca8e29f61bf1f991d72c831ad1f5f02",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4475426",
+    "address": "0x0000000000000000000000000000000000444a22",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4475435",
+    "address": "0x0000000000000000000000000000000000444a2b",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4475444",
+    "address": "0xaf26c847bfbba53d195b198c7dcd0efbb2360294",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4475473",
+    "address": "0x0000000000000000000000000000000000444a51",
+    "name": "Wrapped Hbar",
+    "symbol": "WHBAR",
+    "totalSupply": 46429234016,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4475483",
+    "address": "0x0ab13dd2c62dc5a3f86a20325da8aa16a389aca4",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 29651081024,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4475484",
+    "address": "0x666a43a0e4803f465aac9919ab00ecff1f1754ad",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 30014202173,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4475485",
+    "address": "0x8b733a3c26597f842d8bd234fd2bcd5930601319",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 5573692957,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4475684",
+    "address": "0x36f3057ccfb512e50a7a1abdfadb3c0f50c995dc",
+    "name": "My Amazing Token",
+    "symbol": "MAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4475685",
+    "address": "0x955e16aba91de0e04fbd3223c9cea572186745bb",
+    "name": "My Amazing Token",
+    "symbol": "MAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4480660",
+    "address": "0x294f2502889cc8d5c2667eedd74f2a370b37e3f4",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4480677",
+    "address": "0x5a73bac542d2ae736541078365aa23bc58c349c2",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1997842051430,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4480855",
+    "address": "0x612e0f1a6c3f7600440791b7ecd7272d1e3dc96f",
+    "name": "Loki",
+    "symbol": "LOKI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4480954",
+    "address": "0x6bdd73f3f0315cb1218477ce1dbbf8bd0bf422dd",
+    "name": "Loki",
+    "symbol": "LKI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4480958",
+    "address": "0x6b60df1439aff8e5b877ceb0047fc5421b4429e3",
+    "name": "LOki",
+    "symbol": "LKI",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4480996",
+    "address": "0xefc809a059f2e3d8d2e8c0709030104a9c908550",
+    "name": "hedera",
+    "symbol": "hbar",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4480998",
+    "address": "0x53b799e47434abeeb4674f1c2cc3b48a8d533df1",
+    "name": "Web3New",
+    "symbol": "NewGold",
+    "totalSupply": 10000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4481039",
+    "address": "0xe23263d5ff6ff70b03495d9470f1872e3875f441",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 2246347,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4481164",
+    "address": "0xe19a4844d8fdd8284cf93449054bd7433babcc47",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 430300001000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4482663",
+    "address": "0x7da02b34aff116c33b7ed6517047f9ca21a18976",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4482666",
+    "address": "0x25af5daff2fba9afe5596bbb52fad4697c8aad20",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4482668",
+    "address": "0xa544fdf87605d6cae3d0e40e35e54007404f1238",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4482670",
+    "address": "0xe2a231ac68aac1bda5f53f62615392fdf50a7e0a",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4482673",
+    "address": "0x2e61282010fea7b655639ca33e85589b638d0e69",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4482676",
+    "address": "0x069ba4348e38fb2c016475264999399c69f992bf",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4482687",
+    "address": "0xda469aa31489a9ec4d562a7a0da37a5d596a5f18",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4482810",
+    "address": "0x86c7d801a4555303d7d46f7927d56083cc9817f1",
+    "name": "jdnejbfb",
+    "symbol": "bdfbhrehh",
+    "totalSupply": 30,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4484759",
+    "address": "0x82143106b5098891ff98aed8b5ad2cc04b3aaf38",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 53450594891,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4484968",
+    "address": "0xd26d30e23f151e00b1756ef722f247c5738da65c",
+    "name": "Test Token",
+    "symbol": "TST",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4487243",
+    "address": "0xda647b1cc7da24c8229f37daa09881df73e3e350",
+    "name": "Hedera nativeCoin",
+    "symbol": "HBAR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4487298",
+    "address": "0x4f59c6ead8083d81a6025a05272a7e3c06481462",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 5000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4487313",
+    "address": "0x78178164faa12d656df0b92ae6cecc905445bc52",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4487317",
+    "address": "0x9e86f123e39a225ae1bf4ea7c71ffc1a1bf9adc6",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4487319",
+    "address": "0x43d41950333a6e46b161c3cea68e636ee8cc7a77",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4487324",
+    "address": "0xe3e5595c40243920331e323832f3f846839ea5fe",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4487327",
+    "address": "0x72a673f6f4cd4b6c09016644bfa62cbb0eb46775",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4487329",
+    "address": "0x5507910d1cc6f81718c66e59661faedc60bfd860",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4487331",
+    "address": "0x67a748311b6d377e279b17d9fbe0eff6b4c31a4a",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4487338",
+    "address": "0x90817c512acba6c14633d929a4609db28125773d",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 3000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4487701",
+    "address": "0x2901a753353f33e4c46b102e458f9519a2084546",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 20000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4488289",
+    "address": "0x5e004513c1b0dbbb6611326e0b9a60366d075ca6",
+    "name": "snGZpmPHfE",
+    "symbol": "vjwvL",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4488785",
+    "address": "0x0000000000000000000000000000000000447e51",
+    "name": "Demo20",
+    "symbol": "DEMO20",
+    "totalSupply": 2e+22,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4488800",
+    "address": "0x0000000000000000000000000000000000447e60",
+    "name": "Demo20",
+    "symbol": "DEMO20",
+    "totalSupply": 5.287276600010612e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4489297",
+    "address": "0xe52ee848746e5a19b97dbbf767c62301251c8b41",
+    "name": "ImperialsCreditsChild",
+    "symbol": "ICR",
+    "totalSupply": 5,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4489328",
+    "address": "0x47c0d25d87f438c7cf5a48e1f584f88b4ca4703b",
+    "name": "ADToken",
+    "symbol": "ATK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4489384",
+    "address": "0xc250b7d87024f3bc014c77c167bd8f60c7f832b8",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4496424",
+    "address": "0x756aac2122bf0d0a7ea129240fc25430278aa88a",
+    "name": "MyToken",
+    "symbol": "MTK",
+    "totalSupply": 1e+26,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4496652",
+    "address": "0x0e47b0fe5177c5e42dff81ee5cd99aabc24457f0",
+    "name": "MyToken",
+    "symbol": "MTK",
+    "totalSupply": 1e+26,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4496671",
+    "address": "0xe92421f277dfc27f2565735fc5a551e5a86ed02d",
+    "name": "MyToken",
+    "symbol": "MTK",
+    "totalSupply": 1e+26,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4496691",
+    "address": "0xc1f866be72c3bf4e7815025051fb50173629d99c",
+    "name": "MyToken",
+    "symbol": "MTK",
+    "totalSupply": 1e+26,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4496712",
+    "address": "0x0e9b321d3fc9e66ead2ae59f850951791559997f",
+    "name": "MyToken",
+    "symbol": "MTK",
+    "totalSupply": 1e+26,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4496735",
+    "address": "0xfb897f2d6bb8da1e79b576f5ecd74cc926fa993c",
+    "name": "MyToken",
+    "symbol": "MTK",
+    "totalSupply": 1e+26,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4496737",
+    "address": "0xa5f23d0a2c99cde7ed5c9719448ff38d56314a80",
+    "name": "MyToken",
+    "symbol": "MTK",
+    "totalSupply": 1e+26,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4496866",
+    "address": "0xebba12d977ce96ba73e1e5c8dc665bd7364c2404",
+    "name": "MyToken",
+    "symbol": "MTK",
+    "totalSupply": 1e+26,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4496971",
+    "address": "0x3f549b3c5a7f46d7f0ed3efe38293d7cb5d109b4",
+    "name": "MyToken",
+    "symbol": "MTK",
+    "totalSupply": 1e+26,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4496991",
+    "address": "0x7d03fea828b2da8fba393570d8a0fcfe5c4650db",
+    "name": "Mock Test Token",
+    "symbol": "MTT",
+    "totalSupply": 1e+26,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4496995",
+    "address": "0x5013a6bf98eea77653bbe06c6c370810d050fe19",
+    "name": "VRJAM Token",
+    "symbol": "VRJAM",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4497037",
+    "address": "0x803bdbb60e7788de146b0bfa011994b2a8c80433",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4497040",
+    "address": "0x2c3276c3fd1aac7269b142c987f6866a59128742",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4497042",
+    "address": "0xbe5a99c66d5a7ade323e42708605bf8c99ce7913",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4497044",
+    "address": "0x6b0c54e1d58e8826268fb125d687d33dfe7ab1e1",
+    "name": "VRJAM Token",
+    "symbol": "VRJAM",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4497046",
+    "address": "0x2ee01e899018175266fcf661033fb8cdbf2055ea",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4497054",
+    "address": "0x1668e57b2416b17ddadb3f0b40e6449b8253400a",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4497056",
+    "address": "0x377d8676b96841aef49ca2c4aab4643e10712fdb",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4497059",
+    "address": "0x2f1968f754f06458c35a08d542c294832dafe9c7",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4497061",
+    "address": "0x7394f110a612c29b9f226bb916a16c78eb00ec63",
+    "name": "VRJAM Token",
+    "symbol": "VRJAM",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4497082",
+    "address": "0x7322ff1cc889e10e524e3aac3caff9c74d4569bf",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4497084",
+    "address": "0x3aea5038eb24170c769f14d941dbfc3f6fbe4f40",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4497087",
+    "address": "0x17402e1dde5674066fbf656961625be4c58af75d",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4497089",
+    "address": "0x5c59264d6228b27d16e4b8879eda654aa1548a5a",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4497092",
+    "address": "0x34a2863860ffcbe7c56e851a8d088abfbb2a2628",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4497100",
+    "address": "0x96cce204e81e44de6ca6af28094ea152cd3e9b58",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4497105",
+    "address": "0x0ea9048ef9445272ae9f305135926bf90d35a789",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4497357",
+    "address": "0x245f06974f673b3a3635d41b74b6eca0ce43d2da",
+    "name": "VRJAM Token",
+    "symbol": "VRJAM",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4497374",
+    "address": "0x8aebb789902d35d8290237f973b266214c046f7e",
+    "name": "VRJAM Token",
+    "symbol": "VRJAM",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4497658",
+    "address": "0xf6143583abf5bbe38f08d46bbb8caa91bb916ae2",
+    "name": "VRJAM Token",
+    "symbol": "VRJAM",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4500152",
+    "address": "0xc32083c28a9bedf7124a39020a484dbb164c3448",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4500155",
+    "address": "0x226add7c74a384bc8dc1269e1c610c4c8f7ab44f",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4500161",
+    "address": "0xe5684d69ae5b8ffa81fe8d247aba4589efed3949",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4500166",
+    "address": "0xa264397faf19912df5c0e2b41fb75943a7d2dbfe",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4500168",
+    "address": "0x08e38136074a7079d253fd6aecdd1dfc2423680a",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4500170",
+    "address": "0x239a7960779a07bf6bb11d3b630f196854dec6ee",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4500172",
+    "address": "0x38a32cdd653e4dc0dd42034b4eb2f089275eb590",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4500250",
+    "address": "0x43d42235bb1762063d8e728c6de3862635aa10d0",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4500252",
+    "address": "0x18ff16578ba19f4d1aa67e98ba529fd4b7d52bfb",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4500254",
+    "address": "0xba6d71f619dbde1ac6c13eef3e5be00783712d1d",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4500256",
+    "address": "0x8a9aaf913532bd8ad5427b885f81183bfb06bca8",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4500258",
+    "address": "0xfec230a4777eb0c061518e4b97e200c9da341a31",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4500260",
+    "address": "0x975abca90353fc4b8eab35222b56228297a1f32b",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4500262",
+    "address": "0xc541a7524fe74c6bcb7d36afadf6d4104cc233e3",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4500295",
+    "address": "0x0ccaf1d6c4e9a1419d3a20830359fcd7437a0947",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4500299",
+    "address": "0x91a123aff80f039c830c980472e7061a3262edef",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4500302",
+    "address": "0x1bce506dd788332b699ac5bf66e13615687de44e",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4500304",
+    "address": "0x2d128f1f5bdca0ef7d8aedd8a69243cd16f49b9d",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4500306",
+    "address": "0xb8f459ebb3379635c3be3aaad56ddab9d0f4b449",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4500315",
+    "address": "0x820b6e6621e2ebae3152914e23b4d68e0134f468",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4500319",
+    "address": "0x093ae2e3e938db11688125ef75e84a1749bbdba4",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4500321",
+    "address": "0xa19a74de0009861663bc378f35ed51ba22f0f308",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4500325",
+    "address": "0x20eada9e977304c2ab7c9a312a8f5374ad12a418",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4500327",
+    "address": "0x884ff3b255f7332a97cf29b766ab5afbfcd02e50",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4500330",
+    "address": "0x3c1966556dfad301fede5a1c14ce17710e32963a",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4500332",
+    "address": "0xbc6b091ac2c51c1c0046b23b879275212b44e113",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4501056",
+    "address": "0x0aa54e74f9ee4eb8f387c09c0300f56e9edb32af",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4505324",
+    "address": "0x388d410157faa8e73e878c13593d2279f9526507",
+    "name": "AUSD Stablecoin",
+    "symbol": "AUSD",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4505349",
+    "address": "0xfd0f82a1f559fdf2fcf358cfd031059b915685be",
+    "name": "AUSD Stablecoin",
+    "symbol": "AUSD",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4505471",
+    "address": "0x24fc88ff21fee99bc13c64628d8270ecc69ae264",
+    "name": "AUSD Stablecoin",
+    "symbol": "AUSD",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4505619",
+    "address": "0xf20649e5c8adc9607a78142ddb1f2fca6e6878e3",
+    "name": "AUSD Stablecoin",
+    "symbol": "AUSD",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4505699",
+    "address": "0x7a7f5787418283fbc96cc9b1ca93e0f132f21783",
+    "name": "AUSD Stablecoin",
+    "symbol": "AUSD",
+    "totalSupply": 1.0002e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4506946",
+    "address": "0x2c2271857f48908a195b6728a68ab3b406400480",
+    "name": "FdAYQIagQj",
+    "symbol": "frOpa",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4507450",
+    "address": "0x286a1b8d0aefb9cd33cbf0b2eb81a082bda493a8",
+    "name": "XBZTtrPzwp",
+    "symbol": "XiMhz",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4507617",
+    "address": "0x6d5a0ec3799aeb4189e6107d2e5e6f5205d96f19",
+    "name": "lleLjHNVsq",
+    "symbol": "VFxMY",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4508068",
+    "address": "0x3623d96e5e626d26762da7ea598b9eaa13254e37",
+    "name": "Tether USD",
+    "symbol": "USDT",
+    "totalSupply": 1000000000000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4508515",
+    "address": "0x000000000000000000000000000000000044cb63",
+    "name": "677Token",
+    "symbol": "677T",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4508629",
+    "address": "0x000000000000000000000000000000000044cbd5",
+    "name": "da",
+    "symbol": "da",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4509034",
+    "address": "0x000000000000000000000000000000000044cd6a",
+    "name": "ERC677",
+    "symbol": "ERC677T",
+    "totalSupply": 2e+28,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4509044",
+    "address": "0x000000000000000000000000000000000044cd74",
+    "name": "ERC677",
+    "symbol": "ERC677T",
+    "totalSupply": 2e+70,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4509151",
+    "address": "0xd5611c32e6b83ac3803d573b36227b96a8ebc66a",
+    "name": "IVYFinance",
+    "symbol": "IVY",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4512165",
+    "address": "0x012a8d942b5549f217b3472fca5d367f9aa82fe8",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4512228",
+    "address": "0x98a3809870c19770ce534bdb6f59e72dbb573936",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4512243",
+    "address": "0x2aa5512de170fac18831d88aa96e3eb118950c2b",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4512254",
+    "address": "0x793716d269086e271dc7a8a8ae2a0d757f3c664a",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4512259",
+    "address": "0x82144a6b73f8391ee36cdf0a3a34d4c5bda8ce99",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4512280",
+    "address": "0x5b1b42a08a8ad07f597706a03605802dc76deeba",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4512289",
+    "address": "0xcc73500cd1159da2f2534ae80a8d415c772d4138",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4513767",
+    "address": "0xf6d6e986d0ebb2365273ac8fb43c53e5f00fba5c",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4521450",
+    "address": "0x83aecc1c0956e846f010ce79dacc413d84e469b2",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4521457",
+    "address": "0xf2dba4fb35fcaaccb1d5fc7d289793e9f9310351",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4521471",
+    "address": "0x3b479279cb6b0949b51cd7335102b4a9e41c3348",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4521485",
+    "address": "0xc643b5163bf354470949b26625f4563db2698690",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4521493",
+    "address": "0x91384ab55f6da2a3d2f0410b0dddae55cab8160b",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4521497",
+    "address": "0x6ac3d6112222ae0b1ce20ec1c049a7a310397ed6",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4521500",
+    "address": "0xbf453720a0fb70d436b1aed5fb59e9c3f76d0fa3",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4521703",
+    "address": "0x85709575fe4ff2d475794247357dc8fc59be93f5",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4521706",
+    "address": "0x1dc379df5187162c7bcb134157b4cb670b78b50d",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4521708",
+    "address": "0x353e1eddf52acc576868bd2e21980f023572305e",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4521710",
+    "address": "0x8ffc94a2872d14f5cbc922b9cb051f944d09a659",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4521712",
+    "address": "0x1c80e54adec0e06157f45ea696a4c1c01ef4d339",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4521715",
+    "address": "0xc259a38b306b23e231fff51e4a9632b7bec292d1",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4521717",
+    "address": "0x7f53d76aa8ab70b451db897bdfda5dbf8c906556",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4521739",
+    "address": "0xb07470674aaf314b2b3271b6d0436c49d20a52c5",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4521742",
+    "address": "0x8227a65c713feda720c1eb8f7f03a7dc5a30c106",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4521746",
+    "address": "0x5a3391e069bc166306eb6c83f176f4d8f7bde007",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4521748",
+    "address": "0xecab63e46555c7a51bee6dfc3b95c8bd5165a782",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4521753",
+    "address": "0x09f5a1a346fc570bccefa36618f862f14a0a0ea3",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4521755",
+    "address": "0x63fca8420027fd95ac386a2e8ae294352076ccf5",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4521757",
+    "address": "0xb10e154e6d6f708683f70a4e6380cd5c07dc6b87",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4521829",
+    "address": "0x3a64142ec177923aed759bcd62b31b32682facf1",
+    "name": "GenericERC20",
+    "symbol": "GT",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4559668",
+    "address": "0xd0a91d390332027cc7991cdfd09be3099fabc3c9",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4559679",
+    "address": "0x7769c6a85d5bfa2235ca6d1fd5f9147227cae5f7",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4559689",
+    "address": "0x6ed3d4835c6d3668aa1f02337c9bddb7bcd90e3a",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4559702",
+    "address": "0xbf27b14ffbd87d1d8326e2d38df496890d3d9229",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4559712",
+    "address": "0x23c2e50122cb2cd44e59a510c5ff68ffeb7a687d",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4559997",
+    "address": "0x2967667452444f7ed31a796dde910f05a94ff13f",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4560009",
+    "address": "0xf17c01430f8a7d3b8ff0e8ad6411823b67d595ea",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4560019",
+    "address": "0x7763d3bbb4023919982bb0cf12ac59e4f167252c",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4560027",
+    "address": "0x344ffafa1eccb623840a5e1a4bc37248ec4f498d",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4560029",
+    "address": "0xa6a4d16f52c9020dcc4f34b4b98c38e8aa9614c5",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4560031",
+    "address": "0xe7b233cbf03adef9f47f5996b1a179f12ead9bbf",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4560033",
+    "address": "0x5fe394353c8e6284b86d5a49a6a551c58e8dfc31",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4566635",
+    "address": "0x58606621206ebbd09728b46bd6884dd82f06a3af",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4566637",
+    "address": "0xfbb83bff028fd0747bb2be115b1454965466126b",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4566639",
+    "address": "0x516de80204e8fc96f8bbd897dc71bd75d7f2e78b",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4566641",
+    "address": "0x66d6ebb018ba7d9d35d00d280f2e211d0c82882d",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4566643",
+    "address": "0xec4616e279145a600c7ba82b4b4701b3fdc45e62",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4566645",
+    "address": "0x8ab009a5608cff66086e49c6a1ca1e9a1a245f7e",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4566647",
+    "address": "0xa9d93e5d38ca0a3777ba2be7a73d870daa967328",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4566656",
+    "address": "0x954561e9f3942af6ab10d6e77800354bef4288fb",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4566664",
+    "address": "0x9302a7f4cac9eb68c12cb3582c0f432e40896001",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4566666",
+    "address": "0x43bb3e2b3460bead845380544bc7fe59ee0fa21f",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4566669",
+    "address": "0x304fd9d7315ace10d21eee022ca6272d68cea67d",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4566671",
+    "address": "0x17b1fe94f359ecdfa40ff2c80f366ac4eda72cda",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4566673",
+    "address": "0xe0f0569c6cfc32e6b17f013a83362441f899e786",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4566676",
+    "address": "0x2f6089f51c47d38d085d7047bfb439b91c2a7d49",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4566685",
+    "address": "0x69b09eaddab35e88b888f02b9917b8158c83b42f",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4566687",
+    "address": "0xc3e2db60092261d2192f0dabebcfd53b7c857b82",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4566689",
+    "address": "0x26538be39f073d0f8b39d61d79f2e944f9dc5fd9",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4566691",
+    "address": "0xe0c36e1cfc1442b72dd168f72d494c765d894300",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4566693",
+    "address": "0xab770cea66d7bc8347f2936652b63268a156c1eb",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4566695",
+    "address": "0x4da5529f09491f1a50ef1809b533c9ac71c992b3",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4566697",
+    "address": "0xab7458fe7f7fcaa23e900981338ae80c884f441d",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4566755",
+    "address": "0x87cc809fe00e931e0686aaf2496489046ea95241",
+    "name": "ADToken",
+    "symbol": "ATK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4566774",
+    "address": "0x08ec9069eb0ec4aa58a0bf916540297be26736fd",
+    "name": "Test",
+    "symbol": "TST",
+    "totalSupply": 1e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4569431",
+    "address": "0x9fc6dd1c07123743023c71ca62c7a2daa0ba31e2",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4569435",
+    "address": "0xea4d872453f64db6c98796c3b1a47d440fc23f04",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4569439",
+    "address": "0xb60c227d86380879008ab13ed3dce5fe22897fc4",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4569445",
+    "address": "0xc73ee0e28d8845d6ac6dccdeb6988687ecb94b64",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4569450",
+    "address": "0xd3073b260a5b9b48dfb618be0cf05f46c7cc61cd",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4569454",
+    "address": "0x011481498634f39822708811edd2cb7c196cd0a5",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4569458",
+    "address": "0xaa9d2dfeb4e359c5aef5154d2cd4a2888ed95970",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4571292",
+    "address": "0x000e7f211c2368a22cee70227634aea01ca7e5c3",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4571294",
+    "address": "0xa6529e140653fcb2679fb1a643c46725ceac7aca",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4571296",
+    "address": "0x73c7bef5e8889004d9c3d5d802fc20f662299dc0",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4571298",
+    "address": "0x414243ba36c6ebc1913af884f42ed90c701f9503",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4571300",
+    "address": "0xd30d0ae6a4d511be599cf84f3bbfb35091cc8453",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4571302",
+    "address": "0xba25d26a0b8df7863842c45a1290ff54f63e3e45",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4571304",
+    "address": "0x3b6fbf6e5c4d8aecb869e3a643c9646574462cd9",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4571404",
+    "address": "0xbc9da6978043adbb5ce1301c5fdcdcc00b377b5c",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4571407",
+    "address": "0x8f22cee8391ba67dd24065bbfea097edf325c3ed",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4571409",
+    "address": "0x852fa4bb158388bdfef8934b4d8b6520e05d60a8",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4571411",
+    "address": "0xf48fbc040a5c576741eeb1660e94ccc864498941",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4571413",
+    "address": "0x050fa1f60a3dc4769b2c462a5a9fdc55fa32345e",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4571415",
+    "address": "0xf02b56e91c62fbb8cfa28904b239e4b351f937d7",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4571417",
+    "address": "0x7cf4eaee3e70cf2d6b68e2c5ca18199f6b34a8be",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4588864",
+    "address": "0x75ac5e08e8ecad674ddef06a2572e83696b474a4",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4595344",
+    "address": "0xcccd49177ab3e7f651ccfb3cec7e4ba8756e6b58",
+    "name": "rgWuUSqkVi",
+    "symbol": "uyWWP",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4610653",
+    "address": "0xd651e1bc445a6e4b06c3a1c29ca24b2c9f7fbd87",
+    "name": "Test",
+    "symbol": "TT",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4612615",
+    "address": "0xdd3759b4f19be75b149fd24ee279ad3c87f5e515",
+    "name": "GrainToken",
+    "symbol": "GT",
+    "totalSupply": 100000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4613391",
+    "address": "0xae10bb37da37f1f5c9f3925c0f3bb3316f813a4e",
+    "name": "ATOKEN_IMPL",
+    "symbol": "ATOKEN_IMPL",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4615664",
+    "address": "0x98a51938c84e230b8233bdeb16c7fa6a287a8499",
+    "name": "TEST",
+    "symbol": "TEST",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4615672",
+    "address": "0xc7f28077687208deac654bfeaf39c5be62330da7",
+    "name": "TEST",
+    "symbol": "TEST",
+    "totalSupply": 100000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4616010",
+    "address": "0x5ce1851a3e3a9163aadcae8cb9a9b0ceadbfe4e8",
+    "name": "Fungible Token",
+    "symbol": "FUNG",
+    "totalSupply": 100000000000000,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4617931",
+    "address": "0xbebcb51d449b58d112f411b2c6d764fe76c8f862",
+    "name": "dvcPBPDhsa",
+    "symbol": "FnhBj",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4618993",
+    "address": "0xe87a34f0a59a334e0910dbb5d699eccc941c7f48",
+    "name": "ghgh",
+    "symbol": "hghghgh",
+    "totalSupply": 12,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4619304",
+    "address": "0x607c3fcc70c4411ca8d28ed49ee211b582f328de",
+    "name": "MyToken",
+    "symbol": "MTK",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4620610",
+    "address": "0x39993ba204af77a60a6a3f4beff0293f1aa0b620",
+    "name": "birHdqNtvu",
+    "symbol": "WpVpy",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4621174",
+    "address": "0xbee33a66d422b91147f2485b48f3d99b166ceebd",
+    "name": "Wrapped USDC",
+    "symbol": "USDCH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622406",
+    "address": "0x2180863c3f02e18abbe379fa5feb2793bdc857a0",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622426",
+    "address": "0xdd430561f56c8a93480d0e4bb232f6fc6ad3c706",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622428",
+    "address": "0xe4b5614e87e374fdeb89b4dfea3e6075deb8a030",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622430",
+    "address": "0x4da218974e83f92cdf8233a65b3e9c4d43c13a8f",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622433",
+    "address": "0xeaf75eb7a8b813fbd6e714ca3c458541ba43298d",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622451",
+    "address": "0xa233de53ec2b4f2e2b16ea9fc431cc53340850ec",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622470",
+    "address": "0x558d3b929cf7d06ac703d6ce0f831a3961966e81",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622473",
+    "address": "0x0175f6804dde4eaa2fc4f36c50e339a8e760c1c0",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622475",
+    "address": "0x909500b7cae807978bae4754e6acc250062065b2",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622477",
+    "address": "0x99a9af4b9f516ee56d134dd1768194d1fc290c48",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622480",
+    "address": "0x8ba099e0c73d43558c7731e0768247e6db453606",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622482",
+    "address": "0x7e9d0c0f064fa3df1ae89ab139d13018a6875ac6",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622484",
+    "address": "0x1fc3b51958602881a4e2451f54fa271b19f8757c",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622513",
+    "address": "0xc03e7f0a25c6071a6f7a716e661d28ce56c66c5a",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622517",
+    "address": "0x70791a8bc98e89d4e7c9225763bd7dffcf70e000",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622519",
+    "address": "0xddf2d3925b8e91a23447ffd4ae3a07eeb8625890",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622522",
+    "address": "0x3512dd430cc0cc14c19662034aaae116be19eb22",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622526",
+    "address": "0x31e1c9ae3f7dfd9d780b57f08982331e239ad5df",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622529",
+    "address": "0x4e4ddc3f4bb610516a3e28bffb385d14d3122187",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622531",
+    "address": "0xe6faef2ecc53703e9079ef78be82412cf4c2c8f4",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622541",
+    "address": "0xaaa3b1b161aef334fb6c2409d0eae0a5c0424e6a",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622543",
+    "address": "0xb3d73dad38b8b178e02a5ca4be4f46b48ae009ad",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622545",
+    "address": "0xd6ab94a18b9ad2f8b874e567b016b142fb9fe25d",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622547",
+    "address": "0xa6cd02f57df400c8d1599e21dda931f1c04ee174",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622549",
+    "address": "0xae41201f362d8a4c83a18ef72dde31276bed2dcd",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622552",
+    "address": "0x89e2994b1d8190169f3c96c3605ba77d83a42e86",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622595",
+    "address": "0x2b9f5b08d43197b9fc52ea36f6f1c4f517a6f917",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622597",
+    "address": "0xee74514cde94adde8580575f8a7785df50e5d36e",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622599",
+    "address": "0x0b84057a97a0949aa0244a41b1edfe34cdc34963",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622609",
+    "address": "0xadcd62da0070cbecfb39ecb867ba587774557e72",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622611",
+    "address": "0x68514868380510753dfca2c7569b5fc7be008364",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622613",
+    "address": "0xd52c925086bb99a8d41802a5101c5f9627515342",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622615",
+    "address": "0xc2dea88a3c9d64f46951b8eb5c19396412925db7",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622620",
+    "address": "0x24661044ad9981a3f25b7a1ebe778c7f44c5e6e6",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622622",
+    "address": "0xed0adaf0de97d0fb90b59f8797eabdd9affbaced",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4622624",
+    "address": "0x7175bcd8fa70cf219f794121ead03fb82e1afdf0",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4624988",
+    "address": "0x1e0b019b2c4c856d8d78402a4b45e6fefa16d674",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4625556",
+    "address": "0x13758c443fc8d62ed98732ad0d3c01ec179dab31",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4625572",
+    "address": "0xe943ff01962e9848fcc9c317664ea4ce8d2806bd",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4625622",
+    "address": "0x2be18680e9140a4a2ff55ea6bdb7b92e6dd58e65",
+    "name": "An Awesome Token",
+    "symbol": "AAT9430052751",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4625623",
+    "address": "0x8d2174b15531d5d91ade7d8210f2c2a2b2f6d958",
+    "name": "An Awesome Token",
+    "symbol": "AAT7459007243",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4625751",
+    "address": "0x18a3054e759f1c9f9da4dd5a7ee2adbbee07f42e",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4625759",
+    "address": "0xc3442734b646714d2e18795e1b788b43ad1271ba",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4625768",
+    "address": "0xf956cddd99df5a68d0f7fab988dc58726c235e60",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4625776",
+    "address": "0x425685345535aed53d610cae161e2a6b0b5ceb06",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4625809",
+    "address": "0xd82e633655861bd5a45047efaa9e7ef8e9e76c30",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4625979",
+    "address": "0xd630a987d1b0b466af39ed5697500c7aafbf46b9",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4626041",
+    "address": "0x156658c559ffbad64d6d994da6035f364b1f02ec",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4626426",
+    "address": "0x9cb8710332f63296e77d612ea9d8de4dc1a1cf5e",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4626688",
+    "address": "0x4e174ce685b950d2566f9c93df53007b0579f755",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4626769",
+    "address": "0x55d617fa806908ce121ea2c370563d9f9f395c44",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4626797",
+    "address": "0x585b3fabddc0282652424101f3de50c4eb81e630",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4626811",
+    "address": "0x0625929a55b012786e438ec8df120b1b0c652d29",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4629002",
+    "address": "0x9f239fbed13bcbfd2606486e776eab48879b117b",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4629211",
+    "address": "0x5efa8bf0ad87703b0cfb813bd10cec8400e9b49a",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4629266",
+    "address": "0x2219e67645cd3a0237d9f53471765532707c9bd6",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4629275",
+    "address": "0x04d54fcc784708507a9530a1ed090355b8469727",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4629285",
+    "address": "0xb9a25a83074ed505e9b3306a54fdfefe32af8fcf",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4629290",
+    "address": "0x8ce3e31b43186c16e3fe84b22615b2d0c3631c02",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4629300",
+    "address": "0xada472e49f22a7f311c9b3985f5ee0b9450bb209",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4629313",
+    "address": "0xb2e94a1a2f9ce1c4189c870e1ea05a5593c8da37",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4634216",
+    "address": "0x98bcbd20865d5fd76bc46d93b925e9956e9b3164",
+    "name": "ERC20Mock",
+    "symbol": "E20M",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4634234",
+    "address": "0x30c08969eb3456b53d649317a6c8eceb90f66a67",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4634236",
+    "address": "0x2e6f7540915fb6339191c4b37271d50011a96c26",
+    "name": "tokenName",
+    "symbol": "tokenSymbol",
+    "totalSupply": 900,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4634240",
+    "address": "0xc76f4ec115895a85aa0ffcee12ebdfef5b4bad35",
+    "name": "tokenName",
+    "symbol": "tokenSymbol",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4634241",
+    "address": "0x4859b2b263ee574e7319d752788f18ca5753dfbb",
+    "name": "tokenName",
+    "symbol": "tokenSymbol",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4634585",
+    "address": "0x8d9b7d050b6c3eb21d69b2c29d3cd553d080dfbf",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4634959",
+    "address": "0x000000000000000000000000000000000046b94f",
+    "name": "CharityFundingDAO",
+    "symbol": "CFDAO",
+    "totalSupply": 6000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4634990",
+    "address": "0x000000000000000000000000000000000046b96e",
+    "name": "CharityFundingDAO",
+    "symbol": "CFDAO",
+    "totalSupply": 6000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4635029",
+    "address": "0x000000000000000000000000000000000046b995",
+    "name": "CharityFundingDAO",
+    "symbol": "CFDAO",
+    "totalSupply": 6000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4635035",
+    "address": "0x000000000000000000000000000000000046b99b",
+    "name": "CharityFundingDAO",
+    "symbol": "CFDAO",
+    "totalSupply": 6000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4635050",
+    "address": "0x000000000000000000000000000000000046b9aa",
+    "name": "CharityFundingDAO",
+    "symbol": "CFDAO",
+    "totalSupply": 6000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4635052",
+    "address": "0x000000000000000000000000000000000046b9ac",
+    "name": "CharityFundingDAO",
+    "symbol": "CFDAO",
+    "totalSupply": 6000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4635058",
+    "address": "0x000000000000000000000000000000000046b9b2",
+    "name": "CharityFundingDAO",
+    "symbol": "CFDAO",
+    "totalSupply": 6000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4635061",
+    "address": "0x000000000000000000000000000000000046b9b5",
+    "name": "CharityFundingDAO",
+    "symbol": "CFDAO",
+    "totalSupply": 6000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4635098",
+    "address": "0x000000000000000000000000000000000046b9da",
+    "name": "CharityFundingDAO",
+    "symbol": "CFDAO",
+    "totalSupply": 6000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4635188",
+    "address": "0x000000000000000000000000000000000046ba34",
+    "name": "CharityFundingDAO",
+    "symbol": "CFDAO",
+    "totalSupply": 6000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4635191",
+    "address": "0x000000000000000000000000000000000046ba37",
+    "name": "CharityFundingDAO",
+    "symbol": "CFDAO",
+    "totalSupply": 6000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4635251",
+    "address": "0x000000000000000000000000000000000046ba73",
+    "name": "CharityFundingDAO",
+    "symbol": "CFDAO",
+    "totalSupply": 6000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4636464",
+    "address": "0x1d1ccce7a407b3409c9cc670d03f8eefdf8befe1",
+    "name": "ADToken",
+    "symbol": "ATK",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4637092",
+    "address": "0x4c541fe7dd0a8164c58f555a10eedfa31c93e259",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4637225",
+    "address": "0x658f1baca6bfb3685c1099fa2b76bbb449a3bd68",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 11000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4637347",
+    "address": "0x000000000000000000000000000000000046c2a3",
+    "name": "CharityFundingDAO",
+    "symbol": "CFDAO",
+    "totalSupply": 6000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4637353",
+    "address": "0x000000000000000000000000000000000046c2a9",
+    "name": "CharityFundingDAO",
+    "symbol": "CFDAO",
+    "totalSupply": 6000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4637368",
+    "address": "0x6195d076c66834623640e0c25ca950b59e722f71",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4637399",
+    "address": "0x90cd1f5c04c0d2d256f9c621e2c758717520367d",
+    "name": "tokenA",
+    "symbol": "tokenA",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4637400",
+    "address": "0xb7025d3decb37f44b29792c47b339b5e0491ec98",
+    "name": "tokenB",
+    "symbol": "tokenB",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4637422",
+    "address": "0x7592fefe9a4901b06daf37e8c25ab65c985536c8",
+    "name": "An Awesome Token",
+    "symbol": "AAT5799913364",
+    "totalSupply": 37741,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4637423",
+    "address": "0x6aa8460be8319b745907147f5e8ebd8e8d5e682c",
+    "name": "An Awesome Token",
+    "symbol": "AAT2452776746",
+    "totalSupply": 30849059,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4637424",
+    "address": "0xf73088bb5003c900f82fbb1b1f08295d70f3c9b7",
+    "name": "An Awesome Token",
+    "symbol": "AAT4105203497",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4637433",
+    "address": "0x000000000000000000000000000000000046c2f9",
+    "name": "CharityFundingDAO",
+    "symbol": "CFDAO",
+    "totalSupply": 6000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4637436",
+    "address": "0x7f64082e031c7fc0cfe0ff8a7348b27d4a000a2c",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4637437",
+    "address": "0xa4cf104be33d86f66b82716003cc75345e41ef0a",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4637457",
+    "address": "0x9775e387a0e5dd4ca208332693ad4f485684ab0e",
+    "name": "Test Token",
+    "symbol": "TESTrrx7iePgGf",
+    "totalSupply": 999000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4637495",
+    "address": "0x2be76ac7ab0e43b77132a36c95df1b2f0eb0dc17",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4637503",
+    "address": "0xecc488dc8250aa0ab58f1c33ef5a4193996bdd3c",
+    "name": "CharityDAO",
+    "symbol": "CDAO",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4637507",
+    "address": "0x39bc68dfe0d90f3a873ed3fd164ccad297a14648",
+    "name": "CharityDAO",
+    "symbol": "CDAO",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4637511",
+    "address": "0xb739bb151f458104a1c11127221808fa2a02841e",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4637514",
+    "address": "0x86dcbacf6a3bc2a4ac0e66205edaac8b1164c74b",
+    "name": "CharityDAO",
+    "symbol": "CDAO",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4637532",
+    "address": "0x000000000000000000000000000000000046c35c",
+    "name": "CharityFundingDAO",
+    "symbol": "CFDAO",
+    "totalSupply": 6000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4637557",
+    "address": "0x000000000000000000000000000000000046c375",
+    "name": "CharityDAO",
+    "symbol": "CDAO",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4637559",
+    "address": "0x000000000000000000000000000000000046c377",
+    "name": "CharityDAO",
+    "symbol": "CDAO",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4637581",
+    "address": "0x000000000000000000000000000000000046c38d",
+    "name": "CharityFundingDAO",
+    "symbol": "CFDAO",
+    "totalSupply": 6000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4637589",
+    "address": "0x3d0e500feae4a4d2b359c368b91bc535beec498d",
+    "name": "CharityDAO",
+    "symbol": "CDAO",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4637596",
+    "address": "0x000000000000000000000000000000000046c39c",
+    "name": "CharityDAO",
+    "symbol": "CDAO",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4637598",
+    "address": "0x345bd51e3fd478800643bae7624f5db64dd4de63",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4637611",
+    "address": "0x000000000000000000000000000000000046c3ab",
+    "name": "CharityDAO",
+    "symbol": "CDAO",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4637618",
+    "address": "0x05ff339bf2cf487b46d06b3536a1f19a0b3c96cf",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4637946",
+    "address": "0xe31fe06fedc35554e98bff647d81f632045a287f",
+    "name": "MockERC20",
+    "symbol": "MERC20",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4638031",
+    "address": "0x792e1378a50b655f011c8a8c1238fba38d0947d0",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638231",
+    "address": "0x7b84cb7871d88d2acb1489a02f1de0e4da121951",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638232",
+    "address": "0x198be0915edd72293a7f2d0ceb862a22caa3a5f4",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638235",
+    "address": "0xaa0b4cf1a4d69b4f235f99ad327f4f20c16a9ec7",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638240",
+    "address": "0x3cfab3bcb489ab3e218c1b6e6827527e1274c95d",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638244",
+    "address": "0x1e3d3e7686cd8cb1cc5be57e6443db5d8df16a26",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638246",
+    "address": "0xa95faec28e5711732edc0819c8a6a39cc6795e47",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638248",
+    "address": "0x9df6030775e4ac1a105dd22451b80e033b16d05c",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638263",
+    "address": "0x11a2dd3c6f8dae7df0824f4ef4429a94a12b7cf9",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638266",
+    "address": "0x332d1f22ef1a89106e477214e4b3cea2f13e341e",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638273",
+    "address": "0x40ace7ccbb2592d4979acb4879614ad8a2979746",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638283",
+    "address": "0x2691ff0818e805bc2e99a2ead3e143b455764724",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638307",
+    "address": "0xbbc51718dc15a124e7333efd6ad0ed110584a2ba",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638310",
+    "address": "0x46630883ff48cc308d9cd7a9c90b2ae972093387",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638314",
+    "address": "0x500de441d55e788c4ca7e0a9ae8d0a58a065576f",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638326",
+    "address": "0x4d29c083cdda684973b64b6274ead14741c59bdd",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638328",
+    "address": "0xf72fc5cddc61560bf535fa89c9a5e0708c16e3c3",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638330",
+    "address": "0x8112ca8a9f8ef66012c1d2429db3ea20e517f81a",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638332",
+    "address": "0xe1a3621a610b97fb73597ff6ed4be52378e2d802",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638334",
+    "address": "0xbfe5ad12f13e0eacb6b7fa4d580a1b20a0ab5e37",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638336",
+    "address": "0x5a67ec6b14e02f9b07f9eb8e22ffb16c4a60fcde",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638365",
+    "address": "0x43b50c90f29f39b8cee5b0ffecb1905b117611c3",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638367",
+    "address": "0x9cb21c52b9f60847066bc842b135701a65e318fc",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638369",
+    "address": "0xeddec57f09e6bd07cedba37ee698e73d3637e349",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638398",
+    "address": "0x02aea35d6f51e0a87939ea5b3a48732651e4b7f1",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638400",
+    "address": "0x373e426c3d54bc2a2fcc634a52aa2a68bd85c6eb",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638410",
+    "address": "0xc3ee339fa55555b58a7cfbbea2c867723abb1532",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638422",
+    "address": "0xc5f9d90a2115f3bf42fc1621a015914ac236324e",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638449",
+    "address": "0x60414ea22dd5216a9ca2a2b3b3e6b8f41f9630c8",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638451",
+    "address": "0xb548b99e2ecdb65b178b6d2e899f7d72fba39e51",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638454",
+    "address": "0x45d6cf02f9012863368c662cfe8993b089e750a1",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638456",
+    "address": "0xc2b5dd3403ebcfa6a8237c82669de9b5547f31c1",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638461",
+    "address": "0x6b29d69f39044e20bc81ebaf907e0ecaf9ed95b7",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638473",
+    "address": "0xbd3a1e2cd63c526ba6ae28aa725e28a9911cb957",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638485",
+    "address": "0x396bf4fa8dcf181da8fe7ed2470396147444ef56",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638487",
+    "address": "0x1d318abdc1517eb13bffbe27b327826be57102c8",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638518",
+    "address": "0x2596604f2c650e5f0c2e04bfa924b930f8a89c4b",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638521",
+    "address": "0x664d5bd3e7ba50d0831e15d9bba58a6f8e8828d7",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638524",
+    "address": "0x66f3c4dedfedf2eed37744fe05a8c7f02eb914d3",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638538",
+    "address": "0x99c7860a4d9d9c5fbebe8577c07052eaf1d819ff",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638540",
+    "address": "0x8859cad455f2b95d416603b05d2a499cdeb3cebb",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638542",
+    "address": "0xc4ac0e106e5ef0405bebd5caf086de114d7f2aee",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638544",
+    "address": "0x0cad505f41a1fe7a2aa3480452ca58426098089d",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638549",
+    "address": "0x3d819328ce15cec3ab4c1ac89c0c2287a6fafb39",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638554",
+    "address": "0x1fc0d3731db2e5ff25af21d100e4191171b84475",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638563",
+    "address": "0x1948fe7364a39b0435292bf0bc12038a2093cc16",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638668",
+    "address": "0x815355e3ea49e1db0efd495ccb54c465d51b3103",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638702",
+    "address": "0x0f6d1f4306718a832473b8f7c53c5d40177c9ee2",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638734",
+    "address": "0xa12474253762fb30c3ac680b59708bf81da49d00",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638745",
+    "address": "0xd81a9b249fb1380f6f4b845766fe58b9a3a6ce4e",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638754",
+    "address": "0x5b4f75fb5f7d6423cd57f3535cfe6d3eaf8a3204",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638765",
+    "address": "0x12594d3b998f1c4cf6ef99cb42dd425db8b827ad",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638778",
+    "address": "0x828a4c52dbdd67e60189252b5207b2620115ad7a",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638786",
+    "address": "0x8ea40011b2d03b0c06f5fe2833873c12b4db193d",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638794",
+    "address": "0x611dba39f4befb57fa991b58f793098a3ae43475",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638812",
+    "address": "0xf4ee947223b7d9d89348f8886eca9183136d3638",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638847",
+    "address": "0x42cae6b7c081eae8a09f11e6add02217b1054f3f",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4638868",
+    "address": "0x878d7b7f0c3e2b3d905229cb054fbd204bff4d5c",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4639076",
+    "address": "0xbec3aa68111d98a0cb45e8240639fa1dfcfc863b",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4639099",
+    "address": "0x4188fb9e9dc5fb998e840e29ae36f40736a0cd93",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4639155",
+    "address": "0x419722217ca4773ef89d62afe366ae82a717c21a",
+    "name": "tokenA",
+    "symbol": "tokenA",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4639156",
+    "address": "0x78109059c1d594bc2340bb756ee996e7b445da67",
+    "name": "tokenB",
+    "symbol": "tokenB",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4639184",
+    "address": "0x11b14305c416cd6c0b76523eeac822ac4dbafc3c",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4640386",
+    "address": "0x000000000000000000000000000000000046ce82",
+    "name": "CharityFundingDAO",
+    "symbol": "CFDAO",
+    "totalSupply": 6000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4640389",
+    "address": "0xc6eb65484f12f1480405c8d29a967d7abb164082",
+    "name": "CharityDAO",
+    "symbol": "CDAO",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4640392",
+    "address": "0x000000000000000000000000000000000046ce88",
+    "name": "CharityDAO",
+    "symbol": "CDAO",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4640416",
+    "address": "0x000000000000000000000000000000000046cea0",
+    "name": "CharityFundingDAO",
+    "symbol": "CFDAO",
+    "totalSupply": 6000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4640418",
+    "address": "0x000000000000000000000000000000000046cea2",
+    "name": "CharityDAO",
+    "symbol": "CDAO",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4640421",
+    "address": "0x12d767619a9d99958051485c7843add84f647a89",
+    "name": "CharityDAO",
+    "symbol": "CDAO",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4640464",
+    "address": "0x90a386d59b9a6a4795a011e8f032fc21ed6fefb6",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4640603",
+    "address": "0x000000000000000000000000000000000046cf5b",
+    "name": "CharityFundingDAO",
+    "symbol": "CFDAO",
+    "totalSupply": 6000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4640605",
+    "address": "0x000000000000000000000000000000000046cf5d",
+    "name": "CharityDAO",
+    "symbol": "CDAO",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4640609",
+    "address": "0x4c360aaf6014b3caeba98c0fe69360c87c510ed2",
+    "name": "CharityDAO",
+    "symbol": "CDAO",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4640828",
+    "address": "0x175a2a31ee65f9cfd15bdbb8f158f082e56ac0ac",
+    "name": "EnergyToken",
+    "symbol": "energy",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4640843",
+    "address": "0x3d0af023329bb8c818ccc97f0d0dc4c0b969789f",
+    "name": "paymentStableCoin",
+    "symbol": "pay",
+    "totalSupply": 10000000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4640850",
+    "address": "0x000000000000000000000000000000000046d052",
+    "name": "CharityFundingDAO",
+    "symbol": "CFDAO",
+    "totalSupply": 6000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4640852",
+    "address": "0x000000000000000000000000000000000046d054",
+    "name": "CharityDAO",
+    "symbol": "CDAO",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4640855",
+    "address": "0xc031f8bf2e0d5d6fae91387f9298cd30bfdfad46",
+    "name": "CharityDAO",
+    "symbol": "CDAO",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4640869",
+    "address": "0x2bdb8373f19347908c1a4d630a2a3c9af50289d1",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4640875",
+    "address": "0x62f6a094cc897bb2a702a7b4d071ca375ab76344",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4640882",
+    "address": "0x0b70a8fdb5abfdc2b1c0f9bbc78f1ee053d57d47",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4640907",
+    "address": "0x1d4e7892572e541e68f8ef379f96f0635dfdd7b9",
+    "name": "tokenA",
+    "symbol": "tokenA",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4640908",
+    "address": "0x4c4208d3fb82c1704675a364f62c41d0987be2a2",
+    "name": "tokenB",
+    "symbol": "tokenB",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4640943",
+    "address": "0xb02638df2a1a08673f0e67b9aeb2161a9036efa8",
+    "name": "An Awesome Token",
+    "symbol": "AAT6081947655",
+    "totalSupply": 9790990,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4640945",
+    "address": "0x7cf261bb815d344ffb46a4f4ec8ec71b6f6c908b",
+    "name": "An Awesome Token",
+    "symbol": "AAT2167385100",
+    "totalSupply": 83203087,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4640946",
+    "address": "0xd66fd75a591044c44bfe0a90d6d26945ad146d37",
+    "name": "An Awesome Token",
+    "symbol": "AAT9182028744",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4641088",
+    "address": "0x308c4b706f893b850f72e926161a52943bdcf663",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4641112",
+    "address": "0x6abe26a79a5def78dfa1b7ef56b040126520df39",
+    "name": "EnergyToken",
+    "symbol": "energy",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4641247",
+    "address": "0x44ae257774333ec49f7cc643f02c31572f3eb038",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4641341",
+    "address": "0x895668d4e7f59e4a1db1bc3442f97e5e1613bafc",
+    "name": "paymentStableCoin",
+    "symbol": "pay",
+    "totalSupply": 10000000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4641397",
+    "address": "0x56fc82f933d45d7699f5790fb7bd82bd4055bfe7",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 2000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4641452",
+    "address": "0xa39748715cfe92a18041cc4747783680248c3b63",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 800,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4641462",
+    "address": "0xda39f0c35d464c5b86a435ad68e9542d57be7b8c",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4641463",
+    "address": "0x3c84cdcb1dbf4a40d48b85fa444149ff7035ecc5",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4641483",
+    "address": "0x5d4dc31c1f9d0b103b74e65fcc00dabbaa239eb0",
+    "name": "Test Token",
+    "symbol": "kdlJd4dCsS",
+    "totalSupply": 999000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4641493",
+    "address": "0x529cdb3fccb4a55ebcb977255983bef74508a535",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 2000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4641558",
+    "address": "0x83d22ae61cdefc853a1bc406ed5a76f2b2837803",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 800,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4641646",
+    "address": "0x192e1bc0cd485b165634839e3ddf5894f714019f",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4641691",
+    "address": "0xd1286d49850ca1a112cab4f79678c4f08d7ee07e",
+    "name": "Test Token",
+    "symbol": "fFR9IyPCnz",
+    "totalSupply": 999000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4641765",
+    "address": "0x925e3aa6b57f621b7d379cbfd6d771e08076b2b7",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4641828",
+    "address": "0xbdbdb7cc20d7ced56710db0fecd790936c55fb7c",
+    "name": "tokenA",
+    "symbol": "tokenA",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4641829",
+    "address": "0xb173861c3fdba35c790b1d9ac56e7d5a8005b240",
+    "name": "tokenB",
+    "symbol": "tokenB",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4641883",
+    "address": "0x14ef42ac585fda8ed6c914f5a9b1e81d89954b52",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4641885",
+    "address": "0xe96ed83bb53fabc6f0123c938b91b89c018af49b",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 800,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4641908",
+    "address": "0x383b790d1bc3f44dfebd7cd9947ec71609c3c0d8",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4641939",
+    "address": "0xde9d422aae6e3054d4675d561cfa4b47145689e3",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4641944",
+    "address": "0x361a34072407905f9b8d2afffe904868f94662a3",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4641946",
+    "address": "0x26547bdcc25d4404c2fe3a48cd9ea84a92dfa795",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4641948",
+    "address": "0x5e33fbe67fd857213f8380931048ad7bd7380fdc",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4641950",
+    "address": "0x17397b81498a7e5366b86e2814f4e9a75f6dd896",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4641952",
+    "address": "0xe55e49c249d6f1eee3c39bf9fc2bd9a837e54e6a",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4641966",
+    "address": "0xb70667b65e6e7e867d14e1d6614a092e4d2e38b7",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4641971",
+    "address": "0x05a2e98f6ec7e7a5473559e1bc04f798b71f370f",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4641973",
+    "address": "0x28a71b96078f0e0698377edb220e99dd812a3d33",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4641995",
+    "address": "0x269fdb499c85482ecf11a48b642b92ca5bd9df38",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642036",
+    "address": "0x0f965a6ac2ff87abe4635e48376d9b3ad40aa0f4",
+    "name": "tokenA",
+    "symbol": "tokenA",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4642037",
+    "address": "0x969968ab32e141c8114a7ebdf71969f94fd76416",
+    "name": "tokenB",
+    "symbol": "tokenB",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4642105",
+    "address": "0x39d1db723a2234fa8743f9c609427d1db00cb69d",
+    "name": "An Awesome Token",
+    "symbol": "AAT4918583637",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642114",
+    "address": "0x1b61be508a88b9194b22f2e099ac9a8cb2f157b9",
+    "name": "An Awesome Token",
+    "symbol": "AAT2359471988",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642183",
+    "address": "0xd6dc11c96ed751ee2b6763c2fe98f9bb7c9390cf",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642188",
+    "address": "0x8e1ef68cc262f674d57977977ccc227ba42a64c2",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642216",
+    "address": "0x8d6198bfa4e26865c136670636a64469c7c73147",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642219",
+    "address": "0x4170847caeb7acf1e2b4f46632f24531013ea0bc",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642221",
+    "address": "0x15d19f02deab9a0444b5ecab76534301d5820aca",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642261",
+    "address": "0xa4d6883cae66ba337b1baa8a33cccb5ac4a88641",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642263",
+    "address": "0x56217a431224d84b5b5bb33bea03f3e7146fc06a",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642265",
+    "address": "0xeff4f40ec432e23fbe42d2da2d1910be41a0df14",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642310",
+    "address": "0xeadeec36aa2151a6cd32948fd947bd758e874b59",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642341",
+    "address": "0x2f5abaa9dbf9da10613e541ccfc4b140de080edb",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642346",
+    "address": "0xd57c229bdf8d1f6031c0fa647fa90cb25b9cc170",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642348",
+    "address": "0x66d2ececcb70a11da0d748b87f987e41916f9331",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642352",
+    "address": "0x225d43e13867868830c02cf248e3c1bc75e0ffb4",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642355",
+    "address": "0xc9398967dc877c9322ce2a90c958f6b014c1f0ac",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642360",
+    "address": "0x7e58e3e4caef50594ed6c5d1505d3318605332d3",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642383",
+    "address": "0x8cad91014822418bcd2a4d40de10d1b97c9ebfea",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642417",
+    "address": "0xb6f241c665777f4c69afe483305d5bdd75131f20",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642422",
+    "address": "0x8e2e5bfc493515ddfd72d14f3acce601d60c2b39",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642425",
+    "address": "0x359adbd7437a0bd7ada5a0c2bcc2fc830355bd68",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642454",
+    "address": "0xfd70991f13ead553a0598915b693ced1f9d9cac9",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642460",
+    "address": "0x26a1f97e1992f5fd573ec27d822590d8ee0281d8",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642502",
+    "address": "0x5ba299f1dd99ba8d5245b82623a47588f7729981",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642509",
+    "address": "0x0013f57fa1c600c22cd2d2721a71f7dbb5d202f2",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642516",
+    "address": "0x42824a781ec1c307f5c355d39bb7e635de5a92b8",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642542",
+    "address": "0x7f30b5a2ec9a057f52842efa9bed0c1cd47ca9c8",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642546",
+    "address": "0x296748f1a35b7cd276a5c1046ac57f8a1401ab03",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642547",
+    "address": "0x71ddda5178b76524d72457248695fcf29d076c46",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642554",
+    "address": "0xfea09533da134378862442aa66ec90e9006380a6",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642561",
+    "address": "0xfc72ae4894fecaad7c0dcae7bb7f88a0a5a6f603",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642563",
+    "address": "0xaa9085552be68ba9ccf565fd1366624a36d91952",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642633",
+    "address": "0x7c1498cbdea8dc425239ed99f619b6025bbef681",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642636",
+    "address": "0xb07775c1635ac797fa5487c815ffe70e3cf37261",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642638",
+    "address": "0x693b940c8f36023c2e9e2b050edef2be4bcfca2a",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642645",
+    "address": "0x24653d5b456db7c6cd6a155d2ef7e0f1e265d20a",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642648",
+    "address": "0xedc2bba1f8b11852e1de97a56d51975b9bbbb11c",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642650",
+    "address": "0x459792f240597b508e2c4beedd195ac76f432263",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642654",
+    "address": "0xd735b9f123872b54a78244244f942e0c345cdfd3",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642703",
+    "address": "0x5f287b1170690c00bf3d776e2746761d2a21a573",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642705",
+    "address": "0xc607deb3b8643383b5d04d201f707dec7cf75e38",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642708",
+    "address": "0xe63c171cf2c877f9a0a2324c7b2b564598512018",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642713",
+    "address": "0x7e0ecc33c1246a94306f1afeed5cb84f681db647",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642748",
+    "address": "0x47845cd8bf28eeae3981cd73539cd76eeeee4a88",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642753",
+    "address": "0xe772a43097903582d0127246fded630db03b9c3d",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642778",
+    "address": "0xbfba3a7871e597f471dba6d272d31223afeb3565",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642781",
+    "address": "0xcc6132221c7f9e9e48dadf6f5f1e74d089f85c09",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642783",
+    "address": "0x3d104eec02a792ecd2372eed97e0534f05baa0af",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642797",
+    "address": "0x3a106a3e38ad30ea5ad7fb2a0cd8ed3875ee37ea",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642882",
+    "address": "0x209437b787c19c0aecbae0867d1966959870fc31",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642911",
+    "address": "0x77da15d10856a86a8017f833873abb7f1f1cb9f3",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 1002,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642972",
+    "address": "0xbf1757e7b718abf72f7993dcf97bea5e8b849b5e",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 2000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4642989",
+    "address": "0x225d508d7389e6926a8a08298233fc367e2269eb",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4643024",
+    "address": "0xcbcb90af19a2b44fefee701c6da462703f9c2ccc",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4643034",
+    "address": "0x4a32ad1f5f5dba5f18aaea65e225d4d2a43ca9d3",
+    "name": "tokenA",
+    "symbol": "tokenA",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4643035",
+    "address": "0xda14fdd49f55dac608e06766772f9b580fe18960",
+    "name": "tokenB",
+    "symbol": "tokenB",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4643045",
+    "address": "0x2f9cb5345617ab333bd81bec2539b082bc7ec65f",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4643076",
+    "address": "0x82e40a11b3e6ff12f63f152dfc0febf816037d2b",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4643115",
+    "address": "0x77245a4f2c7aed9fa2ddad3c5677ee8a647aa716",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4643180",
+    "address": "0x086bb0a2820dd5e844aae855239ea961b89962c5",
+    "name": "tokenA",
+    "symbol": "tokenA",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4643181",
+    "address": "0x324b00efbdacfe14063c044c90af0695494b9fe7",
+    "name": "tokenB",
+    "symbol": "tokenB",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4643342",
+    "address": "0x622ba29b0ef6e59d8e0a8b8e8c1c9e578addd3e1",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4643343",
+    "address": "0x7bd38f6429950212a1fc17435f6c4de04251ba7d",
+    "name": "Test Token",
+    "symbol": "z41dDFkQos",
+    "totalSupply": 999000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4643404",
+    "address": "0x2df9fc48edfb31735c6fd9e8e99a5f18470c9e12",
+    "name": "Test Token",
+    "symbol": "EZygnqqtLn",
+    "totalSupply": 999000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4643449",
+    "address": "0x40989c84013435ee8f7045b3d4e7cee83c921aae",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4643480",
+    "address": "0x9bcfa6e88cadd3e42e112a0a1f4327ec85808b92",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4643593",
+    "address": "0xe3cb92127426bd05e0176d812673d32c909f9a7d",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 800,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4643694",
+    "address": "0x345eb68e35b868f7bca1be77428230ebd36899a2",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 800,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4643746",
+    "address": "0x6cca9a68d64750e85d24c62dcc54658b03ecc228",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4643889",
+    "address": "0x9915162f86f44a95d4e0ce09a66666e64dadd983",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4643902",
+    "address": "0xe4ddf8809cdddd9b2c233ae1da339f5889cb213e",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4643904",
+    "address": "0x5756090a58a301a30570f86c93b65934e92b6e9c",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4643947",
+    "address": "0xdd410e5950a3e3ef6af79049712b58b161a5e46c",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4643950",
+    "address": "0x256f43f1b79125868be0f5a0cf673653967a7f3c",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4643952",
+    "address": "0x7e9915355e23846d42425f72021f2e1262bc412c",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4643954",
+    "address": "0x510214b5f388464c057d1af6e976f9714a1c80c7",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4643956",
+    "address": "0x90c4ead75b61f8528481ee2a883ac5003ef8600e",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4643960",
+    "address": "0x57e3345d9acbc589ce2107569ec00a42a58d04c8",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4643964",
+    "address": "0x044fefa120fba2ba4355ab05e425a0250be48cdd",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4645144",
+    "address": "0xd155c5205436945c31fa281e2be1a625b900460e",
+    "name": "ADToken",
+    "symbol": "ATK",
+    "totalSupply": 1247200,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4645555",
+    "address": "0x73092aff12c32fb6c5fd8f96f3514a81d80eb110",
+    "name": "ADToken",
+    "symbol": "ATK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4645667",
+    "address": "0x81c883a8c9f29e11c4635f9f7d8f961395056970",
+    "name": "ADToken",
+    "symbol": "ATK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4645725",
+    "address": "0xa6d60675f8f2f2439322187b14cab121e98f6da5",
+    "name": "ADToken",
+    "symbol": "ATK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4645745",
+    "address": "0xd1571987ca98d412cb6c49191912443f3f982650",
+    "name": "ADToken",
+    "symbol": "ATK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4646577",
+    "address": "0x1991acbb1af03f4cc37af391815463bb9c913551",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4646590",
+    "address": "0x26639a7019db97751d79c1e10b3276187996ee28",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4646729",
+    "address": "0x73443082d1cf1d5d47d29669174c451498aed5bf",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4646805",
+    "address": "0xc609c74e81139b84d87cfd6627e27c45725ec2ad",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4646814",
+    "address": "0xd6f21efba708938fdd6e312018934aabc3e44b21",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4646822",
+    "address": "0x522d0623615f72a0ce57bc86c567ff22b0640dad",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4646944",
+    "address": "0x05caa61274f245c4d52b4e13a477ba35f9b262be",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4646993",
+    "address": "0x0db44fdd7325e9868f56f3c0f7860ff9764e9f51",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4647055",
+    "address": "0xfcac29eb2b972177f2c42a7cf7b108e6b0cfc790",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4647075",
+    "address": "0x6a7e5e57134f143d42bd4269b4db21ada318a92a",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4647105",
+    "address": "0x2b85a9009f821932ebd074f4182be907d478bcdb",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4647110",
+    "address": "0x3fdafa178aa155623c628a4a1aeccde702f17bcd",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4647116",
+    "address": "0xaae9339a7ed82c5e83b9ffe5cc0ae057ba99f007",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4647120",
+    "address": "0xc29726ccbea92dddf65b88c63f80569cd842dbb7",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4647132",
+    "address": "0x4514b47b5c447384feeb29c029f8fb13499061e5",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4647137",
+    "address": "0x99534442bb038c5d4ee19379d6fe008a375f8655",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4647147",
+    "address": "0x3b4f7b8b85b32eaac363c7cb9739fd7a8a496523",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4647260",
+    "address": "0x9862b2458334421fff55734d83ba6585f962c28c",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4647355",
+    "address": "0x66a4c28f23043055b17493bcec308371b5582cfd",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 800,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4647388",
+    "address": "0xed3caef736be779515730e13c7e6b1bc70839387",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4647585",
+    "address": "0x3318624312d702d86c2d7e61ce889066c94dd944",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4647618",
+    "address": "0xde803aa9fe3847c73eb6fd9deca866624e01e31c",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 800,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4647631",
+    "address": "0xff4d272c4bd1f3b64ea95d57f09298910be4834d",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4647640",
+    "address": "0xab344261668fe0a12f242f9b852d39a26c8a04cd",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4647671",
+    "address": "0x1e362c84e0ba58a5c83f98941a367f77e082359e",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4647685",
+    "address": "0x5ec87a0d3cc7ee40df97810a1dff22c32dc54c5b",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4647699",
+    "address": "0x6cb54544aec5d22e05adfcb44d1ba65e52f1440e",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4647735",
+    "address": "0x5cfe3b9043086249e2bec4e8583b17f661bf3ff9",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4649060",
+    "address": "0x9468d1012204b3691bfff570c4b3116a28b6ea03",
+    "name": "mHnuKfcPnU",
+    "symbol": "pOTHI",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4650471",
+    "address": "0xc142bee1342e5c82ae23f3b8e1e36641c12c8eb8",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4650487",
+    "address": "0x52c4021ef6f18ac16fbcedcdce91c66751ac8dbb",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4650502",
+    "address": "0x104ba0d7f02c7d475328db2b89de1cdc0fa3ea43",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4650513",
+    "address": "0xa97c83f95500dbba54ebe7bd32cb733c87e61182",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4651757",
+    "address": "0x75bc18947811e62f72cb7c511fcd052a4966d1bc",
+    "name": "CbFRRYLiFw",
+    "symbol": "MlBpg",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4652496",
+    "address": "0x810414a101a992d9118494760d5ab876c008b95d",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4652498",
+    "address": "0xd59d481c6d1c831aaebc40586e6a79df1ebd7678",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4652500",
+    "address": "0x200c031efcb5c55e3bf5359765924b6a01e389c0",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4652502",
+    "address": "0xe649ac1f2354eb84442a599aa4d0beb519ce1ab0",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4652504",
+    "address": "0xb02458de302a680f064913dbeb46fad28b673193",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4652506",
+    "address": "0x18f5bf0a99354c4311a7f899168270ce3eb06bb4",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4652508",
+    "address": "0xf684b5afe5277a995add25bade81fb761ebe72d4",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4652588",
+    "address": "0x49d3d3f0b298690759a3d46dab2de3249a5ef79d",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4652590",
+    "address": "0xf8cea831a33b69a96d9fc953b6366d5de68ba039",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4652592",
+    "address": "0x35db5960e451f235a3042ab11a41f54fdf48155d",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4652594",
+    "address": "0x309b7f2f1ec973bae785b4b5d0d8f051d81ff6ac",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4652596",
+    "address": "0x904c73bca79fa976c87d5cbfe1fbc5b8a3ceaac5",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4652598",
+    "address": "0x5644f92a493273e98f95260fe74f42760299a3bc",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4652600",
+    "address": "0x7fd12967aca5eee104d39fd4502b50600d50d244",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4654483",
+    "address": "0xb58513e7d0d39fe5ba28e85af7930c663cedfbc3",
+    "name": "Mock Token",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4654508",
+    "address": "0x3a7f144172848e78a5d3d0ca8bd599360a1ff859",
+    "name": "Mock Token",
+    "symbol": "USDT",
+    "totalSupply": 1.02e+22,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4654637",
+    "address": "0xb5ecb39d6dd61c54bd50cdda97ea34e2cc51630a",
+    "name": "Mock Token",
+    "symbol": "USDT",
+    "totalSupply": 1.02e+22,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4654657",
+    "address": "0x27735d43b550b32aec30f162dfe772b58a0fadf5",
+    "name": "Mock Token",
+    "symbol": "USDT",
+    "totalSupply": 1.02e+22,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4654691",
+    "address": "0xd4677a6204f81415ccbf8c7891b077f8660706cd",
+    "name": "Mock Token",
+    "symbol": "USDT",
+    "totalSupply": 1.02e+22,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4654893",
+    "address": "0x88cb2246a45bf68386565537ab04c7ec73dfc856",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4655203",
+    "address": "0xdb3935a8d9523e478f4047823be982c51b4daf64",
+    "name": "gvghv",
+    "symbol": "CVFG8779",
+    "totalSupply": 30,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4655222",
+    "address": "0x4818e3634357419af7bc8b69163d9b5ed0a4c8d0",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4655298",
+    "address": "0xa8ecab0b9768fc3415649a49c120ede7b0464678",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4655304",
+    "address": "0xd0e1723859706fb629ab75e0cff91f4eac6be7f9",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4655319",
+    "address": "0xb19646e707d1f5917b3aeb035ba15a34b61a7347",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4655450",
+    "address": "0x17aaf5b00920b989e6c363ad3c234d3676efafb9",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4656888",
+    "address": "0xdbb9f0fdc2c3d0b5f9c34ccb88eae03a4e7eed8e",
+    "name": "HIRkrNeweH",
+    "symbol": "kyvBI",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4656917",
+    "address": "0xc2c522fcd2b8b6f5e3b78c811de70d6f2228f70a",
+    "name": "JCNrOSlWdE",
+    "symbol": "blVFZ",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4656922",
+    "address": "0xec8832ef741ad8ab8cc5f46eef78ad834c3c5797",
+    "name": "MDQNsACdoO",
+    "symbol": "JbpZA",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4657157",
+    "address": "0x595b3913d49516e1013c537c13c80f2e8bda0382",
+    "name": "xpHveAweJS",
+    "symbol": "FRZak",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4657269",
+    "address": "0x313947fb1e967f7dcabcc1ccd15bebfda6b96b0f",
+    "name": "UARYHxFmKA",
+    "symbol": "yXgqM",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4657311",
+    "address": "0x709279774ff41db3de6ca96cf901b1b0542a5b50",
+    "name": "pXPMbtcAVr",
+    "symbol": "vGbQU",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4657314",
+    "address": "0xe985469789207b931f218f838763d743455aef3e",
+    "name": "bXobcJbtSF",
+    "symbol": "WhORR",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4659218",
+    "address": "0x4c8473056aaeadd32d261278124306b9e160a3a5",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4659266",
+    "address": "0x6d3e26c618df2efe3ae0e19168f3f393b9e28ec7",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4659291",
+    "address": "0x338401cf4b886fca83223a5f7b1661ebdf09601b",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4659327",
+    "address": "0x1d56cbb6c5e2c8e758d7b10009cbca38edce582a",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4659343",
+    "address": "0xa6e1b992909ff78cefc5c706e20c0fec30ba5402",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4659364",
+    "address": "0xfeb9bd67b7bfcb60fc89093782a3207f0e02293d",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4659367",
+    "address": "0xf5d67c797cbd8de5e34e381e2cf70c8854d0585e",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4659391",
+    "address": "0x7eb762de462c142bafc56e4da103a79327b88ec6",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4659443",
+    "address": "0xc86b1efc17a0d4cd7617db7ee35ed5dc010e0944",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4659468",
+    "address": "0x20edcb056279199176dbb24388e13a37ae768c67",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4660900",
+    "address": "0x574620028763dbef2e915e9b40b78616de1abf81",
+    "name": "Test",
+    "symbol": "Test",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4660916",
+    "address": "0xc5ccc752cd02ed0b86216fb8be97b7c3a3dc9432",
+    "name": "Test",
+    "symbol": "Test",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4660956",
+    "address": "0xabd64002b7c09a62f0a8a9c8ea2cd5f9ab4efe19",
+    "name": "Test",
+    "symbol": "Test",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4660965",
+    "address": "0x26b473ae614edf13bd1d24239e47474407d4afc8",
+    "name": "Test",
+    "symbol": "Test",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4660971",
+    "address": "0x7a48d1ac0c57c90f5e19894504befaeed18f2192",
+    "name": "hello",
+    "symbol": "hello",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4661027",
+    "address": "0x2cc91160a34b2bafdebb3e21f6546f16e478614e",
+    "name": "Collateral Token",
+    "symbol": "CTK",
+    "totalSupply": 1e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4661028",
+    "address": "0x162b14d35a0e104b539d0946701470bdcbe9d272",
+    "name": "Loan Token",
+    "symbol": "LTK",
+    "totalSupply": 3e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4661030",
+    "address": "0xfa872f015044cb3245f995ce45ba18588e1f2e14",
+    "name": "Collateral Token",
+    "symbol": "CTK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4661032",
+    "address": "0x670c810b1987d6f328456474dbd9dd26c4db17e8",
+    "name": "Collateral Token",
+    "symbol": "CTK",
+    "totalSupply": 1e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4661033",
+    "address": "0x99515ba86598f1c45a9f02d3ad988cbf2b501b1e",
+    "name": "Loan Token",
+    "symbol": "LTK",
+    "totalSupply": 2e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4661039",
+    "address": "0x785458cd457b401f90747415abcc23c9ac132138",
+    "name": "Collateral Token",
+    "symbol": "CTK",
+    "totalSupply": 1e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4661040",
+    "address": "0xe8e94c656984d00cd95ba43a5057830180f1c95c",
+    "name": "Loan Token",
+    "symbol": "LTK",
+    "totalSupply": 2e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4661045",
+    "address": "0xd97b1399c1429f216c6318775b99c5c7dab0c8ca",
+    "name": "Collateral Token",
+    "symbol": "CTK",
+    "totalSupply": 1e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4661046",
+    "address": "0x9aa1c5144c915ddc58cb3d70ae275fd72f672327",
+    "name": "Loan Token",
+    "symbol": "LTK",
+    "totalSupply": 2e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4661062",
+    "address": "0x2c70d6d29196ee388e04fba3661160f282090c0f",
+    "name": "Collateral Token",
+    "symbol": "CTK",
+    "totalSupply": 1e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4661063",
+    "address": "0xaded0dc087af614e267e38450e270c8904747ac4",
+    "name": "Loan Token",
+    "symbol": "LTK",
+    "totalSupply": 2e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4661107",
+    "address": "0xe87bbdbd27cafe27549dbc27ce39956e47cbf47b",
+    "name": "Collateral Token",
+    "symbol": "CTK",
+    "totalSupply": 1e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4661108",
+    "address": "0x7ba4d34215ed64af9b0ff3dccc25d63377dd6eac",
+    "name": "Loan Token",
+    "symbol": "LTK",
+    "totalSupply": 2e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4661163",
+    "address": "0xd087247f3358d9bb0e0d41ab5a93e469e4025a4f",
+    "name": "Collateral Token",
+    "symbol": "CTK",
+    "totalSupply": 1e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4661164",
+    "address": "0x6fd5db95fbbdead209e27df2660d5baedaf6c392",
+    "name": "Loan Token",
+    "symbol": "LTK",
+    "totalSupply": 2e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4661169",
+    "address": "0xa89b153d457da02e1396132f5d9dc3ccf593fc77",
+    "name": "Collateral Token",
+    "symbol": "CTK",
+    "totalSupply": 1e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4661170",
+    "address": "0xed8ad722cb763c272facb3ca13fa5bb28845988d",
+    "name": "Loan Token",
+    "symbol": "LTK",
+    "totalSupply": 2e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4661179",
+    "address": "0x6eeb6f5406df58b5f26fdba4623b4a7dbbeb3795",
+    "name": "Collateral Token",
+    "symbol": "CTK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4661180",
+    "address": "0x20cb632a1706e5c7ea04a74be1ea3761239c5846",
+    "name": "Loan Token",
+    "symbol": "LTK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4661185",
+    "address": "0x23f5073d28115b77eaf3203c8dd7355c83c4f61d",
+    "name": "Collateral Token",
+    "symbol": "CTK",
+    "totalSupply": 1.0000000001e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4661186",
+    "address": "0xd4df47541de73ae50b8622c2b1627c4b7e47e46e",
+    "name": "Loan Token",
+    "symbol": "LTK",
+    "totalSupply": 2e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4661205",
+    "address": "0x388d1759314a87e322d99e14ee4c86a6e0b9a5b6",
+    "name": "0xBurn",
+    "symbol": "0xB",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4661221",
+    "address": "0x710928ef4957b4729e01e15a109bdb898a7d551a",
+    "name": "0xBurn",
+    "symbol": "0xB",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4661507",
+    "address": "0x0216ec7ed1df6203afd60ae4395cef537c4a577e",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4661595",
+    "address": "0x34c3f0fc2b57d4c61b57e3473308c54dd4e46ea0",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4666073",
+    "address": "0x4608fb6abcf7841855a8e797b7e1fc08ab9a1e67",
+    "name": "USDB",
+    "symbol": "USDB",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4666117",
+    "address": "0xcfd7fc6d664ffcc2fc74b68c321ecd6a400d2118",
+    "name": "USDB",
+    "symbol": "USDB",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4666203",
+    "address": "0x21531c13e104b7b074bee2bf56fd3a68b37b24a7",
+    "name": "USDB",
+    "symbol": "USDB",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4666278",
+    "address": "0xadbf99ad3d108220576d3b2aaf8b955de2729364",
+    "name": "USDB",
+    "symbol": "USDB",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4666693",
+    "address": "0xb19569b76d12132e58177ff8ba1c60033d16a40e",
+    "name": "0xBurn Token",
+    "symbol": "0xBurn",
+    "totalSupply": 2.1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4666695",
+    "address": "0x41fc59711f3efb8facd408e77eb1074c453b34db",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 1000000000000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4666700",
+    "address": "0xa6967d06b829f279c320eec79e9e67047ff3a0d7",
+    "name": "Wrapped HBAR",
+    "symbol": "WHBAR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4666922",
+    "address": "0x8446b52f0ce60b7ccbd9b1e715e4460c3317c9d6",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4666925",
+    "address": "0xc2ff03eec660219ec73a19347843656fba6f66cf",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4666930",
+    "address": "0x0c130bc1fc88f650aa8c91fcfe32603bba9cd515",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4666932",
+    "address": "0x1db3d6e279a0c3741fec1cd46d93fff546c70184",
+    "name": "jhgydg",
+    "symbol": "KJHUI867",
+    "totalSupply": 100,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4666936",
+    "address": "0xa234988f8fb6870071d2acb8735bb119cb2ab5e7",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4666940",
+    "address": "0x17c9768435867c1d2e2be7dd737bb4114666bbe7",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4666943",
+    "address": "0x280b7e155128774a29dc775f6e5d7316f1b01cdf",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4666946",
+    "address": "0x2d0655e3df8f254b4fbcab67a8ce3ed7698fc3a0",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4667166",
+    "address": "0x9173b40de39ed2407f2ecf1f19fb4e93eee89942",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4667210",
+    "address": "0x51ef5ccf901e872b8f23932018a3e13b8244892d",
+    "name": "TestCoin",
+    "symbol": "TEST",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4667221",
+    "address": "0xa3425730d281a5dd396c3735b07f45f7e2c6cd75",
+    "name": "TestCoin",
+    "symbol": "TEST",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4667237",
+    "address": "0x8bf00d800805fbe17b407d72d76270589a7ad364",
+    "name": "TestCoin",
+    "symbol": "TEST",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4667240",
+    "address": "0x48cb4168dc8fa45ff88e87f2f0e90006729dd344",
+    "name": "TestCoin",
+    "symbol": "TEST",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4667242",
+    "address": "0xfc16fb8addfe3aaa7f79f4f30d579dca156f4fa4",
+    "name": "TestCoin",
+    "symbol": "TEST COIN",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4667251",
+    "address": "0x4b0ffaa2534e96d88dcef9b622db55887fb6aafb",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 347850542618513,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4667273",
+    "address": "0x4d15e1f170552bf4d2b9f1b75ec26e33a44f9c34",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4667298",
+    "address": "0x4815b87b6ce72120cab463b77f85ddebe2c33960",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4667308",
+    "address": "0xba9b47d0000b3caa2eab55a9a611e55ec661ed28",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4667317",
+    "address": "0xd3d9751818c2d41550db57703a490133a045832e",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4667326",
+    "address": "0xa1af762ef2842762518b71094012e0e4d1b79094",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4667345",
+    "address": "0xb07669dc1a638145e1dbf676a2cf5479c4460bd5",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4667352",
+    "address": "0x38097f819e7cab337a4695a229dbdb39999751b6",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4667408",
+    "address": "0xc4a3797bd31fb4726c941ea58cc854b0e99c8b17",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4667426",
+    "address": "0xd70a7037a51d49cf51d311c467ee0104177ddbfc",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4667448",
+    "address": "0x21e6edf5efc687983426a8716820bcff1dd46f3d",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4671095",
+    "address": "0xc32e5533ad0d7993377255cd1ff7e28a4c8ce6a5",
+    "name": "Collateral Token",
+    "symbol": "CTK",
+    "totalSupply": 1e+52,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4671096",
+    "address": "0xb75ef6f9a1c4311cc2803c2511bfccd83d9c0ff0",
+    "name": "Loan Token",
+    "symbol": "LTK",
+    "totalSupply": 2.0000000001e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4671587",
+    "address": "0x2ddac4885da0b9cadfa9c7af6dd5bab508541bcb",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4671589",
+    "address": "0x4d5e998974a248bfdcdb88f713860f6434217ce7",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4671598",
+    "address": "0xb14fb6d53673fadf2b17f33126bf4b7c63d03ab3",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4672247",
+    "address": "0xb1eaff748efea09cd8582b115a80f6ee109528ff",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4672250",
+    "address": "0xf5d36f25bd792a000988a0bdd3c5e936974287bb",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4672253",
+    "address": "0x3252f5c54bb6c471ee723a5905509a3d94ff4f3f",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4672257",
+    "address": "0x09a0a433d584f096c09e033c84fa4899571be587",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4672281",
+    "address": "0xd5d9c6fe31e467fd9ab7561adac53c5125622f25",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4672302",
+    "address": "0x30a065d36c87f382a24c2a54ed3cf10adadd0460",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4672325",
+    "address": "0xf17b499adaec572d458c31bff172280d4225ac7e",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4672338",
+    "address": "0xc89c6db34665e01f6a27dfc1be37589c4e8b8960",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4672341",
+    "address": "0xc2f2cd9aee6aa96223f8c295a311ff38b37a48cd",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4672350",
+    "address": "0xd959ea543b0b4de301499ddcb3c99cb41cf986ff",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4672385",
+    "address": "0xcf845950e7c1b989a27305b175d7eaa52e56d049",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4672393",
+    "address": "0x8e229905cc4c2c25b1256a9f1aa67003d0af1de4",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4672402",
+    "address": "0x585345207b2ee447ee1e3cd0416c7081c2a3ea95",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4672411",
+    "address": "0xd608b97ec81b499d70f33298cc2b0bf3527e7cfa",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4672419",
+    "address": "0x7d60dc5cb6bafa6e079909a1fc34d67e49c995cd",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4674099",
+    "address": "0x3ad9b01fb369ef5dbb312d51c23ca0964d789313",
+    "name": "HBurn Token",
+    "symbol": "HBURN",
+    "totalSupply": 2.0998061260423104e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4674131",
+    "address": "0xb453d7ea87c1269a79b88154a30ae7e63ae5ad97",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 1000000000000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4674275",
+    "address": "0x3d371d3fe41ee35d366dbeb08c53379605e4895b",
+    "name": "Wrapped HBAR",
+    "symbol": "WHBAR",
+    "totalSupply": 57828644847,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4674695",
+    "address": "0xf86cc691b9432e14b3ea484559d5b2c38a0d1dd4",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4674707",
+    "address": "0xf4d9c5b4991db92604cce531924aa9c7522316ba",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4674711",
+    "address": "0xb3c9b459b9b9ec3e206230fd9616ff054ff61e9e",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4674720",
+    "address": "0x320be159b4e7f2ee2e45cc6dae5235fa75f607e0",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4674746",
+    "address": "0x8adfc86fc5e131679fd309d052a78bb717d5d66b",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4674760",
+    "address": "0x57c1c14f9c16c7bc2ad9d4911bc0f77e75ecb7c8",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4674929",
+    "address": "0x516315b31c0bfbbacc088db25a04b1c914d52058",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4675146",
+    "address": "0x5bb2078d51ab323685a723bcd84db3810b67a699",
+    "name": "USDB",
+    "symbol": "USDB",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4675177",
+    "address": "0x38be9536eeef484a6b752175874730f3d57851bd",
+    "name": "USDB",
+    "symbol": "USDB",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4675393",
+    "address": "0x1afbb1615fb208298cf3d5428bf7fd6a42aa8e58",
+    "name": "USDB",
+    "symbol": "USDB",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4675438",
+    "address": "0x5fb87ffc729b49ab25a8684add976a791e4d0e45",
+    "name": "USDB",
+    "symbol": "USDB",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4675442",
+    "address": "0xa6089469bc12b7cae28fcb78d93b94dce14e3cfa",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4675449",
+    "address": "0xc8b66e167b3cff34128c55c5adbe36769c25ca83",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4675457",
+    "address": "0x70bcef513c3f81c3e2bdac56db0d42adf6aac016",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4675463",
+    "address": "0x960e945dc15ead97cc9a448bfb23f37cd9f78b45",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4675549",
+    "address": "0x4f74fc1bd8e37436e13dc4d7e4fdd0bac335b8ec",
+    "name": "wfAUSVGDGi",
+    "symbol": "mPTQW",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4675563",
+    "address": "0x2ee1cf9a6aae9fe1c3067d990f7e501b0444c8a2",
+    "name": "HuOyqrhivo",
+    "symbol": "kHeUV",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4675573",
+    "address": "0x0747828c0b2fabf204769c923f9f3589eee335c4",
+    "name": "rwHxjSRhfp",
+    "symbol": "VnuHh",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4675706",
+    "address": "0xee2b9d69a189d9de768bf2627aceb1f9af413fdd",
+    "name": "lxjdRgJtdd",
+    "symbol": "smwWY",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4676146",
+    "address": "0xb063efadd3c861930e8df35a0364197bf818695c",
+    "name": "name_13thaugust",
+    "symbol": "symbol_13thaugust",
+    "totalSupply": 12,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4676315",
+    "address": "0x209ad6e80d09934d700052212eb9280a27c29b28",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4676562",
+    "address": "0xe9a172b8991177e7544e68c64f036a9a98d92826",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4676765",
+    "address": "0x7db6dee8404a37ce43af9b84694ad5ca5a4b4e2f",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4676787",
+    "address": "0x65cf004c267a22f76ccbe0883d2f374b27bd31d8",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4676797",
+    "address": "0x6fdf6b7ab3adadd666ebabffaec05e07b574486a",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4676805",
+    "address": "0x1731f29a3da9047b1bf98a76687ae3121b5de3b1",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4676824",
+    "address": "0xbf88c214c1053fd0073ce4917b5b8dda89db11ba",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4676876",
+    "address": "0x4957e21d8ee3d68440c408f471b54e2fdbc64772",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4676918",
+    "address": "0x34e17ef609e8206d83b76f4ae453dfbe9719c336",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4676927",
+    "address": "0x69b26a0edda2c0ce363ffd9cccf2256502f09721",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4677156",
+    "address": "0xba736d93057f9b167d7bcf22eae48d29211d5a65",
+    "name": "HBRN",
+    "symbol": "HBRN-LP",
+    "totalSupply": 198002499984215,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4677191",
+    "address": "0x94f7d70fffea881337b25743243b03e83fd8e277",
+    "name": "DAI",
+    "symbol": "DAI",
+    "totalSupply": 9.9993033996e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4677232",
+    "address": "0xc4a9d0c3ed281fbac852ba2f34b1d14de3e25f42",
+    "name": "HBRN",
+    "symbol": "HBRN-LP",
+    "totalSupply": 3996000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4677291",
+    "address": "0xa4becd9891cc5719bf98634a4e9cb0e59bd4e4b7",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4677303",
+    "address": "0x612ccdbcec084248240b6f0bf1632526771c8bfe",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4677313",
+    "address": "0xf7dae669abc4c89089c9ba69467d5258c80b8d63",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4677321",
+    "address": "0x75546226fc78ba3a7d17abb0b1b12ba073dc0047",
+    "name": "HBRN",
+    "symbol": "HBRN-LP",
+    "totalSupply": 990000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4677352",
+    "address": "0xa7c3c486ef7600becfd4d1fd6f6fe59d574c3987",
+    "name": "AToken",
+    "symbol": "AToken",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4677367",
+    "address": "0x2a70accd3a7a398d5945c995f16c1b9ca1ad29fa",
+    "name": "BToken",
+    "symbol": "BToken",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4677368",
+    "address": "0xf35a1d079bdae41021f805b21190c102642ea52a",
+    "name": "HBRN",
+    "symbol": "HBRN-LP",
+    "totalSupply": 1.9990014982524966e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4677704",
+    "address": "0x4fad32894cbae2c64fd6b386873e8218200fb18e",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4680536",
+    "address": "0xd6f3db512f940a471fd7b507bde5eb8182803a4d",
+    "name": "JtNsowDKvU",
+    "symbol": "xbUTU",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4684935",
+    "address": "0x1e0958e1c2db31a9e5ae2d52f24f3d26e142047b",
+    "name": "HBRN",
+    "symbol": "HBRN-LP",
+    "totalSupply": 994987437106620000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4684937",
+    "address": "0x7317a2f9cc8fb666ed807bd89a957d4fc1f99044",
+    "name": "HBRN",
+    "symbol": "HBRN-LP",
+    "totalSupply": 316227766016837,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4685025",
+    "address": "0x3c878c17cfc73f99d544b70342877ba9cc570cf1",
+    "name": "HBRN",
+    "symbol": "HBRN-LP",
+    "totalSupply": 3162277660168379,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4685142",
+    "address": "0x7278e5317b775aa32d5bd78e8c6f766b80732bf3",
+    "name": "TokenA",
+    "symbol": "TokenA",
+    "totalSupply": 100000000000000,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4685145",
+    "address": "0x97fbefdebf354d38147131fa4602f124fe45dd81",
+    "name": "TokenB",
+    "symbol": "TokenB",
+    "totalSupply": 100000000000000,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4685148",
+    "address": "0xbe239157e5c2d0fe87131d9b00bc1678ba02fe46",
+    "name": "HBURN",
+    "symbol": "HBURN",
+    "totalSupply": 210000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4685157",
+    "address": "0xf7f11d8baaed3d48e088d7637197d0d034c6a999",
+    "name": "HBURN",
+    "symbol": "HBURN",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4685164",
+    "address": "0xe2c5672e8f9cf2c074390fe174695b6d83ff4fbf",
+    "name": "HBRN",
+    "symbol": "HBRN-LP",
+    "totalSupply": 40465249,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4685166",
+    "address": "0xc8546df6ba77cf161332645efe6c9f743986105a",
+    "name": "HBurn",
+    "symbol": "HBurn",
+    "totalSupply": 209919878113954,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4685324",
+    "address": "0x5b15e8af60e8600a5925d7d0c97e16e2ccd1e694",
+    "name": "HBRN",
+    "symbol": "HBRN-LP",
+    "totalSupply": 99498743710,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4685357",
+    "address": "0x50b3aa42955a187591e09e13054d2a8d38bb9e0d",
+    "name": "HBURN",
+    "symbol": "HBURN",
+    "totalSupply": 209989468805126,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4685375",
+    "address": "0xc05ae5d32cc1be4563ec334443a84fa33a07af70",
+    "name": "HBRN",
+    "symbol": "HBRN-LP",
+    "totalSupply": 10000000000,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4685388",
+    "address": "0x05f9d7f5de2a5304a0e5d3e021d6ed61c0e2cb16",
+    "name": "HBRN",
+    "symbol": "HBRN-LP",
+    "totalSupply": 3160696125,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4685394",
+    "address": "0xa8abeb6ce699ee6ec3eff2b5c0a23c6599db8803",
+    "name": "HBRN",
+    "symbol": "HBRN-LP",
+    "totalSupply": 3162277660,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4685458",
+    "address": "0xb7e513dd7070a618940dcde7f572ec8c47e395af",
+    "name": "HBRN",
+    "symbol": "HBRN-LP",
+    "totalSupply": 334702653,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4685489",
+    "address": "0xcdea64f002a94bf5b81f804ea140b9c86ba2f522",
+    "name": "HBRN",
+    "symbol": "HBRN-LP",
+    "totalSupply": 99949987493,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4685520",
+    "address": "0xb2494515baba466e688aa8423724148ac6ad7a9e",
+    "name": "HBRN",
+    "symbol": "HBRN-LP",
+    "totalSupply": 9994998749,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4685615",
+    "address": "0x98510910721e54530366f278d29801315e761a1a",
+    "name": "HBRN",
+    "symbol": "HBRN-LP",
+    "totalSupply": 100000000000,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4685705",
+    "address": "0x2e087282d1c37723dff4a7a676e2c5e75986297e",
+    "name": "HBRN",
+    "symbol": "HBRN-LP",
+    "totalSupply": 126554100,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4685783",
+    "address": "0xa4f871f492f0ba27822c0b436ef8d286fd05d26e",
+    "name": "HBRN",
+    "symbol": "HBRN-LP",
+    "totalSupply": 31622776601,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4685932",
+    "address": "0xecafaf58ff8fafc621e0d9bce701f6c49f980f01",
+    "name": "HBRN",
+    "symbol": "HBRN-LP",
+    "totalSupply": 126561997,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4685935",
+    "address": "0x94da9f975522a22b4ad102051f7a69772cf2dfd0",
+    "name": "HBRN",
+    "symbol": "HBRN-LP",
+    "totalSupply": 9994998749,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4685985",
+    "address": "0x6ee35ca9dc739d2f097fae44da94f7fda935e5c6",
+    "name": "HBRN",
+    "symbol": "HBRN-LP",
+    "totalSupply": 31606961258,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4686020",
+    "address": "0x088c26d4a3be985d6f32a9a929f091e945c8c9dc",
+    "name": "HBRN",
+    "symbol": "HBRN-LP",
+    "totalSupply": 126476601,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4686024",
+    "address": "0x3dd4bb117a1f1a564ca035ff065dad8052330c37",
+    "name": "HBRN",
+    "symbol": "HBRN-LP",
+    "totalSupply": 400000000,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4686126",
+    "address": "0xcb98f7ac7ce0a0d8716ef6e31814b4c45646b230",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4686673",
+    "address": "0xd4f7afcd05cd236bf441802d4b8ec78579405734",
+    "name": "Fake USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4686678",
+    "address": "0xbac2bd494ee8b27939cd586d193d2b67e86a4e16",
+    "name": "Fake USDC",
+    "symbol": "USDC",
+    "totalSupply": 5e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4687215",
+    "address": "0x6b878ad9f178a558d532cf89f007f152a1a0e2fa",
+    "name": "USDB",
+    "symbol": "USDB",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4687269",
+    "address": "0xee67711641cd4518704dbeb255e03d93800e8cca",
+    "name": "Fake USDC",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4689623",
+    "address": "0xf4408628c28ba95820fb9c4ea38ab9b1928fd4b8",
+    "name": "HBurn Token",
+    "symbol": "Hburn",
+    "totalSupply": 209997200000000,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4689706",
+    "address": "0x0660dbc56653406af62f1cd32a9937c60bae4346",
+    "name": "HBRN",
+    "symbol": "HBRN-LP",
+    "totalSupply": 31464265445104,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4689714",
+    "address": "0x81f5f2228fdf3c815daa9b5c75f3088c4432eeb2",
+    "name": "HBRN",
+    "symbol": "HBRN-LP",
+    "totalSupply": 2213594362117,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4689959",
+    "address": "0xf8668183f786b7c43607fe5e1311917116da0032",
+    "name": "HBRN",
+    "symbol": "HBRN-LP",
+    "totalSupply": 10000000000000,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4689982",
+    "address": "0x4fb3d3401d7358a667af14e0e5d14c9caecfacb0",
+    "name": "HBRN",
+    "symbol": "HBRN-LP",
+    "totalSupply": 100000,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4690568",
+    "address": "0xb125d9e0948ca43d95167ad4e2be880513a83efe",
+    "name": "Test Tap",
+    "symbol": "TAP",
+    "totalSupply": 3e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4690936",
+    "address": "0x589802be75eee987696bd05cbcc0fbb7759f972c",
+    "name": "qsVJxMkOai",
+    "symbol": "FsVvB",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4691399",
+    "address": "0x4ef86ba75831c5181fa8f2e26a12042ccb0c7c91",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4691481",
+    "address": "0x0a6c4899ce10d6734b137e6b8ea2a2567d68d26f",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4691562",
+    "address": "0xae2bbd5989dfb26d785d78da4b5242eb6e87865d",
+    "name": "An Awesome Token",
+    "symbol": "AAT7605020164",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4691563",
+    "address": "0x5188f5cbb2ebaa83ceb429af72043eb634b56384",
+    "name": "An Awesome Token",
+    "symbol": "AAT9404687771",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4691569",
+    "address": "0x41f7ce04068dbf086a178d9d0f579bcb107a98f3",
+    "name": "An Awesome Token",
+    "symbol": "AAT2001636415",
+    "totalSupply": 3717588,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4691570",
+    "address": "0x0b0694db90d3f364cec0ced6ec693ce30c5ec797",
+    "name": "An Awesome Token",
+    "symbol": "AAT8493378607",
+    "totalSupply": 57848867,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4691584",
+    "address": "0x0091aa506e17665a07a6c09b4d9f3e1538849e53",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4699231",
+    "address": "0xe6e42a305ec1fc0db711b788a65816831bc567ec",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4699242",
+    "address": "0xa9a98fa30e3e21c9edae4b62ee5acf687c0f35cb",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4699653",
+    "address": "0xd0798f460539c30c55ecac13e4ce984b5e641040",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4699741",
+    "address": "0x606e32d7fafe24533bfa09eb5af640ef90ad2cca",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4699952",
+    "address": "0x29c460dde7382d9c11b3e85467206b35913f9419",
+    "name": "Wrapped ETH",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4699953",
+    "address": "0xf3ea197b9a972372e63666748608ef3c425884e1",
+    "name": "sFRAX",
+    "symbol": "sFRAX",
+    "totalSupply": 6e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4699954",
+    "address": "0x1ee0dcda9fa40e9456b1b5cd8ee71f4be1878f64",
+    "name": "FRAX",
+    "symbol": "FRAX",
+    "totalSupply": 6e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4699955",
+    "address": "0xc7e930b609b21516c431c2fca1afb61df2795a9e",
+    "name": "BTC",
+    "symbol": "BTC",
+    "totalSupply": 6e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4700176",
+    "address": "0x800ea7b052566b1ebbc94936265ecf4221704b00",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4700183",
+    "address": "0xb914c5372ae1d45fd977d09b424d02cdd7648fa4",
+    "name": "tokenA",
+    "symbol": "tokenA",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4700184",
+    "address": "0x629b3567145c3f1eb6e96ecc7dd22eb38ed77d2a",
+    "name": "tokenB",
+    "symbol": "tokenB",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4700194",
+    "address": "0x1ed42411f2cc6fc5a6a5c6d6fe71527ebb9809e1",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4700200",
+    "address": "0xc9355555832886953adcd8932232399d89a8ef75",
+    "name": "tokenA",
+    "symbol": "tokenA",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4700201",
+    "address": "0x1785c240f366b19867d0c0fe3be10d1cbbf689fd",
+    "name": "tokenB",
+    "symbol": "tokenB",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4700205",
+    "address": "0x4d25d54ad2aa6ea70b0f35666e3a9e423ef25ed3",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4700607",
+    "address": "0x9a9fb4074da3fc488e75b02e8efc9163653095bf",
+    "name": "An Awesome Token",
+    "symbol": "AAT9168254152",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4700613",
+    "address": "0x05e3e3beb7c4296e6e00a20a537134b30c7ba522",
+    "name": "An Awesome Token",
+    "symbol": "AAT2510294153",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4700651",
+    "address": "0x89f7a0ed6dd9115316838615fd1030a4710d91a2",
+    "name": "An Awesome Token",
+    "symbol": "AAT3866980645",
+    "totalSupply": 11528754,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4700668",
+    "address": "0xb6c65138bc86c4a1005a843d3d589eeed12951d4",
+    "name": "An Awesome Token",
+    "symbol": "AAT887035135",
+    "totalSupply": 12093447,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4700677",
+    "address": "0xca1dd24e6340f41f93a650946e33b22968746922",
+    "name": "An Awesome Token",
+    "symbol": "AAT1378582036",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4700725",
+    "address": "0xa566b4f78b20ff64b4e205e6cdb62a5650ff13ac",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 800,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4700819",
+    "address": "0x324b9c19741bb1f3c64d813c7ea10129d0a12547",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4700830",
+    "address": "0x37eaf1746f56c98e22d9f48db20939f7c1c24a8e",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4700987",
+    "address": "0x292b77200bc96043846d9e9e36ecbed46605c1cd",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4702051",
+    "address": "0xd563e4808cd6d70c6516a7aa6fadb9ef42b4a9c5",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000001012000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4702313",
+    "address": "0xb3e0cee43ab52191a993bc4b0c0b2f2172372878",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4702396",
+    "address": "0x27d447a071fcdea217fe2d37cbd2cefa8793417d",
+    "name": "Test Token",
+    "symbol": "TESTjyHzChDlDM",
+    "totalSupply": 999000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4702551",
+    "address": "0x9505c23774ac9ba34b807fe3cb636c1c2b798f89",
+    "name": "Test Token",
+    "symbol": "kYSTR0FwOZ",
+    "totalSupply": 999000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4702831",
+    "address": "0x88e0fa599acb312ce036f286fad9b451a9a355d4",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4703191",
+    "address": "0xe22d819c7bb9be0be42b3fdbbde8d3457f1376ed",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4703457",
+    "address": "0xf5bcc8116ba8347f50e89e195211669ff6494e2a",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4703671",
+    "address": "0x34d81e603992828d8137612a053b70830a1a3729",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4703792",
+    "address": "0x2dc5aa7473841272c6f6b3caf33427b4aea85356",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4703938",
+    "address": "0x613ecc22e33d6f22a5d8484070badf92239f8818",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4704179",
+    "address": "0xa7da828dfc75520cf372120627444db45fd935d8",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4704900",
+    "address": "0x7c9232a5426cc874be784fab7eba3e798462dbf0",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4705429",
+    "address": "0xdc19341edccd70be5c06a28b2bafad06ab056df0",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4705621",
+    "address": "0x4f5ba670ab5e15f6427ab7252b6bef056bb65cbe",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4705709",
+    "address": "0x4d18e516dae8cf339f4a201fb1a06634eb56d419",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4705773",
+    "address": "0x1e84ef2ce2eb8aeadad3e401aa10d14e46242a40",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4705873",
+    "address": "0x51ea15a63f1dd91dd0702f8286fb732a2af2a59b",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4705918",
+    "address": "0x97d54702217e76bc04e659d065116bbfd0b29f84",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4706046",
+    "address": "0x7800fe4f133c97f7054d4353d37a0d5306af896e",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4706124",
+    "address": "0x5e7ba3cbd17cc6ec7113bec1f5fc78d6ce28a773",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4706182",
+    "address": "0xa2eb7173ee4d60306da5892595e8a36d27d2c0d8",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4706215",
+    "address": "0xd65fb7d534901b41a5743259cc83b40df77bbc46",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4706351",
+    "address": "0x49cdf543252a554a8dcbcd66f28c03f6b239a9f4",
+    "name": "tokenA",
+    "symbol": "tokenA",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4706352",
+    "address": "0xb773e24e0a4eb79c7eebe27ed4a6b04e362c5206",
+    "name": "tokenB",
+    "symbol": "tokenB",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4706562",
+    "address": "0xb33f288eaa6ca5a5bde0d3ac7422ac693b9d01f3",
+    "name": "An Awesome Token",
+    "symbol": "AAT6598043678",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4706565",
+    "address": "0xa184052832ad5817370d09cfc050710bbec6547d",
+    "name": "An Awesome Token",
+    "symbol": "AAT4212473168",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4707793",
+    "address": "0x14e6c95cdf4da4f5b6f9998e031287ee37c57ca7",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1013000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4707857",
+    "address": "0x1980e638725c3759731544727339710cd51fc78f",
+    "name": "tokenA",
+    "symbol": "tokenA",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4707858",
+    "address": "0xffb57b9f1770c3706fcd19bc87cb739d5f1a1200",
+    "name": "tokenB",
+    "symbol": "tokenB",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4708035",
+    "address": "0x05221579c5f5a707a43c55b22dc977b5538e3218",
+    "name": "An Awesome Token",
+    "symbol": "AAT2830988100",
+    "totalSupply": 30165720,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4708043",
+    "address": "0xd9bf87628780cf24d88acb00bfe45bd9539710c7",
+    "name": "An Awesome Token",
+    "symbol": "AAT103831862",
+    "totalSupply": 40276002,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4708047",
+    "address": "0x3e8ff4457b4b566b77e9842e87e8c20323ed7bd6",
+    "name": "An Awesome Token",
+    "symbol": "AAT8160308491",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4708083",
+    "address": "0x9cc3739dafec07ed50ff0819e18014942bca83aa",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 800,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4708146",
+    "address": "0xe593edc75cf3ba5e61ec0ef9afad766e773dbca3",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4708153",
+    "address": "0x3377640c376a9365da21a8607624ae39576c22a0",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4708316",
+    "address": "0x0d6ac94ad302af03a287e07e22eba74b5d9f1532",
+    "name": "Test Token",
+    "symbol": "TESTDu9rI3W3Zl",
+    "totalSupply": 999000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4708456",
+    "address": "0x905e16ba939652add828c72c2465ad6f72fe5d68",
+    "name": "Test Token",
+    "symbol": "S4Im0Uz9BO",
+    "totalSupply": 999000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4708673",
+    "address": "0x5af3ae728e18c2264c288d5836a69ee79dd6062d",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 12000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4708779",
+    "address": "0x4eee632c8be24438f696b4efe9a8af3f7c1f8aa8",
+    "name": "tokenA",
+    "symbol": "tokenA",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4708780",
+    "address": "0xdde4bdde42422b104aa977aa1a227d3814780928",
+    "name": "tokenB",
+    "symbol": "tokenB",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4708856",
+    "address": "0x90eafdf0cab7247bb434cdf0e142170a549f9476",
+    "name": "An Awesome Token",
+    "symbol": "AAT2628560640",
+    "totalSupply": 14028762,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4708866",
+    "address": "0x17860a75ae3d18df19088637ee2f0661ae709574",
+    "name": "An Awesome Token",
+    "symbol": "AAT907837719",
+    "totalSupply": 70584661,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4708874",
+    "address": "0x0871bc05bd36bc83ee78a9476683ed45b28c25c4",
+    "name": "An Awesome Token",
+    "symbol": "AAT9886163087",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4708931",
+    "address": "0xd56f3769828f589197ee225d1050916cad7c0634",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4708939",
+    "address": "0xd56d54662fc90747a79a5fc2713077779f3cd3f5",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4709015",
+    "address": "0x7504ba1d72ff8b5971d7b40db03824e2da273b4e",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4709155",
+    "address": "0x5079d9ecc6f215617d25fbc7140fd7bb3cac5e67",
+    "name": "Test Token",
+    "symbol": "TEST71428B6mXB",
+    "totalSupply": 999000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4709307",
+    "address": "0xfed6b4c11148a938ce2429b8354b03cefb6cc930",
+    "name": "Test Token",
+    "symbol": "CJADQbiYxd",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4709516",
+    "address": "0x24a3e8d7f5abafd01b76dfbd22d91f58eddc8158",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4709579",
+    "address": "0x2fa767a0eb3bc6db07fb91c2e0358e6b02530f06",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4709602",
+    "address": "0xa56517c9acc368ca425563b94b173daec4860e4f",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4709655",
+    "address": "0x0ded310ab1b33aed55c609b9637f0cf76cf1635e",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4709664",
+    "address": "0x7f223c1fed78c297ff77420c39fae25d14fcb02d",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4711473",
+    "address": "0x0cab8c6755463d691f7e2161e1018370a6dc9805",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4711564",
+    "address": "0xd43437b6f7841e7c974df1ca30a826761e3c64ed",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4711606",
+    "address": "0x3bce104405a870643a998cf1a17e6f6721fb1925",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4711690",
+    "address": "0x00303b016f059aaf6d91b243ade0179bf87f7bb0",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4711761",
+    "address": "0xdbd3bc83fb73c63015d829087b0b776a15e75874",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4711815",
+    "address": "0x804ea4fb12be50f9127929f9e369f3254c3a4603",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4714268",
+    "address": "0x1c6fae92067f204b67eb2567720cdf563e2d4e88",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4714782",
+    "address": "0x0b9f81292d4e7dbb103abc7dace9b21275010283",
+    "name": "Apex Token",
+    "symbol": "APX",
+    "totalSupply": 10000000000,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4716461",
+    "address": "0x02c9a8efe58ed97fb7847963ad88f7d172932b44",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4716474",
+    "address": "0xc3b517f3bbf55b8e710445f075a288167f4d8729",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4716622",
+    "address": "0x47744b0b16c844ce28f6d45b59e04b7b875475f9",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4716635",
+    "address": "0xfb14c2ff19c6e5937aadfff89e42fb782ac1c123",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4716670",
+    "address": "0xfa1152162d6e90165b0063ba4f3defb933c3ce02",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4716686",
+    "address": "0x5fe86eeadf841635462b726f0f2fef16bd333bad",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4716706",
+    "address": "0xca5e81e51a0ce37bd8e85a53623775b6efe0e745",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4716722",
+    "address": "0xf5e940d00e9dd30156d10503ac95546d73b6bbc8",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4716761",
+    "address": "0x8e6effde2c7a1ef6dc43149134f6b1e7cdf4f248",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4716776",
+    "address": "0x4254ec3d76630f8827366911db3824282cbbbf46",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4718854",
+    "address": "0x32fba3b920ca8a19cc7e1d1baf97a3cb0669d4ee",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4718864",
+    "address": "0x067c19a9b6272eebaedb8364f338f9484fc0cfa7",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4718873",
+    "address": "0xb7e4be096d422be19c73ae4a7ad0da768c015944",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4718885",
+    "address": "0xc358a5a37e10efd89efca102111856ced0f74608",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4718899",
+    "address": "0x016bb0bb78593c640f5d0d625f6ec51943607797",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4718913",
+    "address": "0xbffa13f54fb01bc674d2493dd5a97e44f5e68b56",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4718927",
+    "address": "0xd472df4f01318c0b0b25d2cbc1db46c39ad93ee5",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4718943",
+    "address": "0x12d6a70a1cbcb4fda9571aa0368f195db6cacb87",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4718955",
+    "address": "0x9b17af514af809fb5e0ea104a980c81312908da2",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4718972",
+    "address": "0x7484c69220af285cf2d00bf1958e8823c8625b8d",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4718975",
+    "address": "0xe9b4197ff5b6915f5789bb6f720f2b0bcfd809e1",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4718978",
+    "address": "0x0e05309d2d22f550f232438d6957ed7735f170a9",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4718986",
+    "address": "0xff3accbdd65eed17803d4247b77d49cec979928c",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4718998",
+    "address": "0x3a2cf4cb5aba8222f9699cde0fced6b8dd43dab2",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719019",
+    "address": "0xc6b62edc08bdeda7f42eae967154da5e5e4910a7",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719058",
+    "address": "0xf3263dc3945a6567be2c7b5a153f9de8bcefbad8",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719089",
+    "address": "0xc7cf925bd64f08a3a1d8dc23fa5baecbbe3da4c2",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719101",
+    "address": "0xf2cb878e328c2c87c83517bafa6367d720239f02",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719113",
+    "address": "0x432c66fd8286021cfe7d093ca870cc6410b33ac6",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719127",
+    "address": "0xfa84fecff12089214d8871d1ccc3c2bbdbb7622b",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719134",
+    "address": "0x514c4a1a524f5e0fbb0a2b2b33f45164c61b6212",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719142",
+    "address": "0x1cbef8593b9362b8c0237444b7c129587b77d4bf",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719149",
+    "address": "0xd933a89ce5a92843a07f601fd47e429cebb1b0da",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719174",
+    "address": "0xcc1f3cf3666a3b12d25a43077ba32db3053eba8b",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719189",
+    "address": "0x7f6a56a80ae63a27b0bb72314b1f103e797e711a",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719209",
+    "address": "0x47cab47a49583ab6bcd921eabf8a4e4f493684f0",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719217",
+    "address": "0x34657eb25b6e091c8dc80169a0a44916411d5a3a",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719233",
+    "address": "0x34ee245fefce9d18fb21bb12765c39215a143d2d",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719240",
+    "address": "0x39ea0a475f3693af3b4b1a48ae686cbecdebbd91",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719249",
+    "address": "0x5b7b32e17875a7831884617b64bdb9d77a6c8616",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719257",
+    "address": "0x71dd1dbae1dcee55ee485b79fe21c33536e41bd1",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719267",
+    "address": "0xe0f87e657c986676b9c506c9726dbbb52d7d3b76",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719341",
+    "address": "0x03aed3adad8f8fa6a3f15c744d7dca18bad01613",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719350",
+    "address": "0x8f29c434a97956be5b963b1827167f2f6b17f25e",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719357",
+    "address": "0xd8a2edc0bdcc36cb54d56a3b35b1057df8fcdfb3",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719364",
+    "address": "0xfb0083473056b70370b1433e50ce69398a08ee44",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719371",
+    "address": "0x42b45eb7191da44084d22bccef0bc03340cc20b3",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719378",
+    "address": "0xf2a90ab8ab2514d9393eb6fc96446b055f7048ec",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719385",
+    "address": "0x9fae5a492ccfc2a9f1c100a4f1a6cde397072d9a",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719393",
+    "address": "0x6c5f057bf55ac165880fc8cf67102be0f48ad492",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719522",
+    "address": "0x6be00a16d8d2d066d50304b4882efe532aacb1b1",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719537",
+    "address": "0xfd02ea62cd18bf1e14d7c65b36701474679772cd",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719547",
+    "address": "0xeebf00eb723bf79934a20e5376f202ab486ca735",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719552",
+    "address": "0x705f0b942f47573794d5f310e9f51c8c20e6666f",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719559",
+    "address": "0x82248f1c5ddbc68004bf4f2a6875dbaa1bf6b13f",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719773",
+    "address": "0x90c748ebec12d5a623cc79ac992fcca274ab7093",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719819",
+    "address": "0x9543190146651d2dc14bcd17bc8758792085bd17",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719836",
+    "address": "0xa7980281ac2351a3054315b836d41e4fe7d8eff2",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719891",
+    "address": "0x154a72fb0cf8e7aab75aac76aa6407778de91b5d",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4719898",
+    "address": "0xc6ed2a740d2ebf655fd0dcd7362293f3e654ca51",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4720313",
+    "address": "0x55d67ab677104435a0ac2ca16b7e95657ce4a16e",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4720321",
+    "address": "0x59a3a9601db56396ff0a27b36a453a4e84ba0b42",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4720369",
+    "address": "0xc743f9f8437225812e36e96efa56a6b7add44fd1",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4723680",
+    "address": "0x433389362236991b8809183e61da7f6f381d7641",
+    "name": "Legend Token",
+    "symbol": "Legend",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4725795",
+    "address": "0xe8ef229efefeafe41e946bab29ac15ff33804fb8",
+    "name": "Test ERC20 token",
+    "symbol": "TERC20",
+    "totalSupply": 1e+22,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4725798",
+    "address": "0xce87bbf4fa8d2e5e08a215e0ec071526af9ac86a",
+    "name": "erc20",
+    "symbol": "erc20",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4726053",
+    "address": "0x2c68c096eb1b743de5a515be57ebb62b21bb7679",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4726065",
+    "address": "0x4266e82767ed23118a4ae6ece941b4c204c4fd75",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4726121",
+    "address": "0x3ddafc4d4fc4072391d4b0db274fefc60fc9012d",
+    "name": "erc20",
+    "symbol": "erc20",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4727434",
+    "address": "0x54c6fe25d54c5c297fa7b5ff14faabd6fdb220fd",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4727461",
+    "address": "0x25f10d5bfb8578b82b8d2b6dc0ec9aec4f3ba6e3",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4727485",
+    "address": "0x73892a33ebdd01af3a230fd499ed1a894ee6199e",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4727530",
+    "address": "0x1a5dff614903489dbe3ad69753d68a65af9952c6",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4727553",
+    "address": "0xf36754c14c07bdfecca43e6a0aef31e25adf4b6d",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4727562",
+    "address": "0x000624ae867b36d3a8d09f6e58f01677313f3b1c",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4727615",
+    "address": "0x88be8c0010c6bd4327b41ff409ee0840ad1d0237",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4727625",
+    "address": "0x640573d715332a3db3fa80b670f9bccc34cf36bb",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4727632",
+    "address": "0x6a4b49310759e6c510ab32d5ead58e814ef59b40",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4727641",
+    "address": "0x9c7fda463d8c32750c623d57b0cc2f80a87d95c0",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4727658",
+    "address": "0xb4398bf444428e918e319207306e00b1b78c3b1b",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4727674",
+    "address": "0x4febd0f9b8bfb4bb76e06e6dfdce7a030d4be8cd",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4727697",
+    "address": "0x5a48e837408eb0b84931b058affcb513938f87e5",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4727717",
+    "address": "0x27734580948d56bd4edfc4198da449f4498207a1",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4727724",
+    "address": "0x52619feddf11b6ee82dc375213ffd0c08d8570dd",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4727781",
+    "address": "0x1bf3bb80eb6f1877e96c28e9d7a9f7228e36a75a",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4727839",
+    "address": "0x451008dbb3d0f7c8afa49e1d14e012d0c0a2cbab",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4727850",
+    "address": "0x0bf8fb60c402bd46b167a8d3ab7da51174e9a632",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4727906",
+    "address": "0x57c968370b015b965d862ed5ae1f14f3aaa4ae09",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4728316",
+    "address": "0xcd23f7951f76072e3bcbc003c8198912b7efe335",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4728354",
+    "address": "0xebba83447d7b46fa7950031466f74e614c1735b4",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4728366",
+    "address": "0xe277205b0d965391ef3c59d3bd86274fadac484f",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4728383",
+    "address": "0xcf55b3fb1a42de25f05a698c8af347c270a39b0f",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4728408",
+    "address": "0xa5f4097026201dc6b9364785f96fcde5df8f5bc0",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4728446",
+    "address": "0x3be10d1c72708d08d0d08832e151b1767b0903f2",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4728458",
+    "address": "0x5be01510595193803df06ef981072c6651976ffb",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4728465",
+    "address": "0x0d70733bd5b40c82da1b16c8be33e31b56484b7b",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4728474",
+    "address": "0x5346484d011d5d5b12117412494bb56a35016682",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4728486",
+    "address": "0xf00b6c895e71f995b59d965450c3ff10c3cd5f4a",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4728504",
+    "address": "0x6f98b33c3268b0ddc2e96bd2ea0141d1a4aaff3c",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4728526",
+    "address": "0x3c0057b06bf785a208dd920303571ea9c7dc23cd",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4728544",
+    "address": "0x4fb56f3571e1e31d15c3bcb1bd973082cacf1926",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4728701",
+    "address": "0x2d3907e877317bf5a1a40707f5e49056d88432b3",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4728742",
+    "address": "0xaff16484d0b710fa7b576f0ddf7fa769c5b565d1",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4728788",
+    "address": "0xab812e948beaa2c6e8edbd40a8c8c8fa98adb475",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4728806",
+    "address": "0x10b21ac1ae568f547f944469d673dcf4f1bcaf17",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4728820",
+    "address": "0x89fd7dc8bd7ab74c1a713bcb2bb4d7e21be019ae",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4728840",
+    "address": "0xfb0d9c25fcc9ee803da04e1ffa87034995efc4c8",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4728879",
+    "address": "0x44b79108dfecc668cf65ead52f816e63e239838b",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4728887",
+    "address": "0x3f6ae42544060e856551a5f97032478c37239735",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4728894",
+    "address": "0x1bcc3592fab12a37d519d5e5a8553c76dbafd11a",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4728902",
+    "address": "0x93bb492beb7c41a916f0522d43875f27ffd92d8c",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4728922",
+    "address": "0x9774d104dfa36292b93e0a660727641bf581e726",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4728960",
+    "address": "0x6ab79545d9b046688e77e4e70360ec290e4dbf6a",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4728979",
+    "address": "0xb68ea76d4984c6598121e376dd55340f3026995c",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4729020",
+    "address": "0x933e59076cd9e91a225aac6561fa78ad8f76bc70",
+    "name": "tokenA",
+    "symbol": "tokenA",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4729021",
+    "address": "0x7788581eef1bf63390afc8cb641201ce086b15dc",
+    "name": "tokenB",
+    "symbol": "tokenB",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4729352",
+    "address": "0x4a76c2210e8263b18766d2c7e92c5d50fe78f9c9",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4729382",
+    "address": "0x4dc08aad2ac52c12e593380ea2e6cb82fcfacd6c",
+    "name": "tokenA",
+    "symbol": "tokenA",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4729383",
+    "address": "0x59ac7d7e71c8c48b3d3df4a36c256d9ad1a5a468",
+    "name": "tokenB",
+    "symbol": "tokenB",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4729554",
+    "address": "0x44cf404dfe0f64873b31275bd58ba3751bbe14e2",
+    "name": "An Awesome Token",
+    "symbol": "AAT7425988079",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4729556",
+    "address": "0xb040efdc179b7f49cda4fafa6b1519f95d37382b",
+    "name": "An Awesome Token",
+    "symbol": "AAT1456919496",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4729572",
+    "address": "0x6de002fa4cc9420be7f73c7b6115af2b6de2cac8",
+    "name": "An Awesome Token",
+    "symbol": "AAT1363485698",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4729658",
+    "address": "0x11168b0f42eb1006cc2f336cc4cbd2f9dbcbaf93",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4729724",
+    "address": "0xf7edb1760ddd2c6fe2bda080eb8c2ecb97b4db26",
+    "name": "tokenA",
+    "symbol": "tokenA",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4729725",
+    "address": "0x6a3b35087d5415971d466f392b175b83626b7005",
+    "name": "tokenB",
+    "symbol": "tokenB",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4729873",
+    "address": "0x8f1f8f7d56e4874bfbfa3f2187fe400685251031",
+    "name": "An Awesome Token",
+    "symbol": "AAT4201513622",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4729875",
+    "address": "0x8534475863b64a91653a3486a0b7fa7431a413d6",
+    "name": "An Awesome Token",
+    "symbol": "AAT6738758013",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4729883",
+    "address": "0xfea45ded89a524af9023066dadd34370399e1454",
+    "name": "An Awesome Token",
+    "symbol": "AAT2369947719",
+    "totalSupply": 627080,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4729938",
+    "address": "0xee3288eeb0a60a3d9b63d735ed5b12974e425838",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 1.01e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4729957",
+    "address": "0xe8b3f790b27028bd2639401aaf7ab1b8b9388100",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 1e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4730265",
+    "address": "0xdaf31deb63f4c1109603f9ba82ea6472936784ec",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4730328",
+    "address": "0x1da5fba7979d9dd974e661904f0c63ea158fcdb1",
+    "name": "tokenA",
+    "symbol": "tokenA",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4730329",
+    "address": "0x844960ac68fc51b05382ff729f2d29a613e5ca6c",
+    "name": "tokenB",
+    "symbol": "tokenB",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4730475",
+    "address": "0x0d217ef983d4aef2cd60284b10ec774852bbf730",
+    "name": "An Awesome Token",
+    "symbol": "AAT1419288409",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4730476",
+    "address": "0x63c322406111c1985d9d105c27e4e7f2c351ae3f",
+    "name": "An Awesome Token",
+    "symbol": "AAT6139506086",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4730483",
+    "address": "0xbc48d6011c4b2f752eba6d386a7741fad386991d",
+    "name": "An Awesome Token",
+    "symbol": "AAT2681584868",
+    "totalSupply": 24021320,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4730484",
+    "address": "0xdaa21a385d9389e3723ab9f871b5863f2e13bd4d",
+    "name": "An Awesome Token",
+    "symbol": "AAT6059691630",
+    "totalSupply": 34178533,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4730495",
+    "address": "0x4a07e594ee86c423248c9d1e49965ec4f1837c1c",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4730527",
+    "address": "0xa9f62c054b94ed30aa8a34ab54bef4c9ab2afc61",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4730558",
+    "address": "0x0c706168db849f1d846d32cddb3a58f96156b8b7",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4730590",
+    "address": "0xf16d6cfd18852e4e6f1964fcf855d0741015c217",
+    "name": "tokenA",
+    "symbol": "tokenA",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4730591",
+    "address": "0x49983c8bdf68037f68002fc5038aba5d8a752870",
+    "name": "tokenB",
+    "symbol": "tokenB",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4730737",
+    "address": "0x45b74cedca4e2407549a6680a1bd66d654d7497a",
+    "name": "An Awesome Token",
+    "symbol": "AAT451761398",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4730738",
+    "address": "0x644e890e5d82e641b32548aa24a050337b49e7c3",
+    "name": "An Awesome Token",
+    "symbol": "AAT3208281986",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4730751",
+    "address": "0x4228150df024b077c25dd084f16e8e7f46bfad38",
+    "name": "An Awesome Token",
+    "symbol": "AAT3745034197",
+    "totalSupply": 34671069,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4730845",
+    "address": "0x7e11fe02094abec1106582020e1d0cc62cfa15bb",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4730875",
+    "address": "0x8f230345bfcfebc7940f2d3aa089b9f20141788f",
+    "name": "tokenA",
+    "symbol": "tokenA",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4730876",
+    "address": "0xcab4dfd13caa61a41192758627a289934676bab2",
+    "name": "tokenB",
+    "symbol": "tokenB",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4731026",
+    "address": "0xeb8016d8f6f6efa1ff95e6c34b9f2a92a5e8eb67",
+    "name": "An Awesome Token",
+    "symbol": "AAT8686482225",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4731029",
+    "address": "0x685e74f2941e7afe56436ad8ac834e26ace9f60e",
+    "name": "An Awesome Token",
+    "symbol": "AAT2732855063",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4731043",
+    "address": "0xba737c0c8b6f3d4d91995be21b20c5d15272df2d",
+    "name": "An Awesome Token",
+    "symbol": "AAT6714991501",
+    "totalSupply": 293401,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4731047",
+    "address": "0x90a2aa4fe1621c6dbaef9e904cb01d906dcfc661",
+    "name": "An Awesome Token",
+    "symbol": "AAT3511716121",
+    "totalSupply": 96524982,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4731049",
+    "address": "0xf3e347b88b73f8551ede6313bd1429231e3519fb",
+    "name": "An Awesome Token",
+    "symbol": "AAT9696792789",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4735783",
+    "address": "0x8b643e95be39fa93241c83d03a1cb0475bfba4e9",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4742180",
+    "address": "0xbc98dfabd6704648e3ac89be4aecba3e39abba90",
+    "name": "LEGEND TOKEN",
+    "symbol": "LEGEND",
+    "totalSupply": 100000000000,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4742437",
+    "address": "0x0445702cefd4b4e1fc5c0967082a205f89869310",
+    "name": "NODE",
+    "symbol": "$ND",
+    "totalSupply": 100000000000,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4742447",
+    "address": "0x07e8406d862a42287d761f6224ead80dac251a24",
+    "name": "RR4",
+    "symbol": "RE",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4742484",
+    "address": "0x6639e4976dc8990e94207f6d581af7160e48ef85",
+    "name": "MR BOO",
+    "symbol": "MBO",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4743129",
+    "address": "0x2c0e1cd255d038d3bdd4bb3ab399b59b68da926e",
+    "name": "hcsvdjhcv",
+    "symbol": "BNHN876",
+    "totalSupply": 100,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4743834",
+    "address": "0x0204de03c5f6c5307420cc4da3a4f12d0ffeb865",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4743846",
+    "address": "0xaae4d267f11ab5ba67bcfb0a71db2936fb50162a",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4743848",
+    "address": "0x66f20aba79d471b2f45a40f9baee5846a3c5ad18",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4750553",
+    "address": "0xb67b90d5d9493e5038a048cb2c5917a81d2065a5",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4750580",
+    "address": "0x252b746f73b5d9b7f8a15f570f2d24e16804b3c5",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4753407",
+    "address": "0x0d31a712d8608f7ac21366cf95cc94ca4866ca70",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4753409",
+    "address": "0xe58c8df8049288549b2d7421129a57f87c4c345a",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4753413",
+    "address": "0x5a946b8f5111e80d981f28b5ca6d9e0c51923887",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4753418",
+    "address": "0x1072de02f2b18cf6a009d78be4fd1ff7baeb61d0",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4753421",
+    "address": "0xd2257d9922334ad4d1ed0f57f4f20a9f0efe7718",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4753426",
+    "address": "0x71c23f7934c01b9b10bdda4f33f8166a1ed16822",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4753680",
+    "address": "0x4b6d20dd2d520f6e4803033b2b6c44163f125c4d",
+    "name": "Chainscribe",
+    "symbol": "CHSCR",
+    "totalSupply": 1000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4754105",
+    "address": "0xf5e71cb34febd7b1285c59c014e1e6698bdedae6",
+    "name": "gvvghc",
+    "symbol": "KJH887",
+    "totalSupply": 100,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4754122",
+    "address": "0xc86f7298c8b02b60041e18d1621ffdec9913d37b",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4754124",
+    "address": "0x98d8932a3317f03ac5c7c1ffa48e063a76e95e07",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4754126",
+    "address": "0xc437749442848798bb78c889a311224b1986d9fb",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4754128",
+    "address": "0x06236542995c2a730a8bae82c8b36c54d5c3d716",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4754130",
+    "address": "0x5a7e4144e7138a18a0172ff0891a44f51ecb9229",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4754134",
+    "address": "0xb8418c49f1ed552e80310cab605e12ed29b6f5f1",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4754820",
+    "address": "0xb6a4e8a35aa3b902267c70b1161eb187a5163bc2",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4754823",
+    "address": "0xa4c9c40f9767606b221403c2a6061ce20ab451f9",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4754825",
+    "address": "0x80aa0426026c38c2cf21571035d59333dea36814",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4754827",
+    "address": "0x3f5e644f378915624375986f0803829d061df23f",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4754831",
+    "address": "0x2170626ba07aeca9d4a9a3e9c9e6eb2dcfda77b1",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4754836",
+    "address": "0xfe40dde11377eda577725cdd7d4905eb64265aea",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4758323",
+    "address": "0x897e32891da99c21bc6a347f6960c906c73ea26e",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4758326",
+    "address": "0xf58e3db2220ff74965f75948c52d950d14a0e671",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4758329",
+    "address": "0xae587c9be8285426f6567782f43734d33b40191b",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4758333",
+    "address": "0x1d4e0f5843adb131ff5f781350c725fbee1720d1",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4758335",
+    "address": "0x7eced0a451a67386a529e9cb09a38a5f0b0bff3e",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4758340",
+    "address": "0x1b3688f6f79495a27dcd9642f624646030e77ee5",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4758959",
+    "address": "0x1574286d8491f08efc3f0cb3e0e9e26009166d0d",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4758962",
+    "address": "0x70f0c71366d7e742112ee3c016ed140e26cb6dff",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4758966",
+    "address": "0xeeed13e9d45082ea4159168d64fe3ead68645e35",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4758968",
+    "address": "0x34db72fc43c6423d6443fbe675f046ff77cdc267",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4758970",
+    "address": "0xcda451e208844191ff6a3110f22368f15fca9df6",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4758972",
+    "address": "0xbad84c0829d5520b731ffe657a7dc131fa55e16d",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4758975",
+    "address": "0xca6f10664e6ef878e9e16e369d04855b32d28fb3",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4761314",
+    "address": "0x705e902c664adc3e9c672ca2df07067111b88451",
+    "name": "USDB",
+    "symbol": "USDB",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4761367",
+    "address": "0x3f0127987409a1c31bc327b09db743483b839147",
+    "name": "USDB",
+    "symbol": "USDB",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4784607",
+    "address": "0xa2e1fdd57bcfdfa27093b2db2718ab6a41513060",
+    "name": "pPXZEqULwz",
+    "symbol": "gAJHB",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4787237",
+    "address": "0xcb2ddb16f0af60f383c78c019045156fff327b2b",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4788642",
+    "address": "0x52c77d839ae284df83eb3358a436fe6d2824047a",
+    "name": "jlXbDDvtoD",
+    "symbol": "UNwgk",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4789399",
+    "address": "0x843068e04429a21953ca50b3d4a061c8a205faf2",
+    "name": "IguKowdwVR",
+    "symbol": "ufuxZ",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4794684",
+    "address": "0x05c5212844c801ebdbe1e761f53868678dacda36",
+    "name": "sipFeRNklD",
+    "symbol": "oLysn",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4804170",
+    "address": "0x649d8219bd169411db6544c8a12626fc208b2fd3",
+    "name": "fckfm",
+    "symbol": "sddcdk",
+    "totalSupply": 12,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4805267",
+    "address": "0x309144d1e8bb0bfb98dd51f7b3e7674f67437f7e",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4805269",
+    "address": "0x2a42290aea5bcb9b1e3d26df0214ea4cd289e8d1",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4805410",
+    "address": "0xcdefa3ca7afc7f30c7872710e75f3c0882eba8b3",
+    "name": "GlZlUuJNKf",
+    "symbol": "FPbpf",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4805720",
+    "address": "0x605267a087f335c7f9e027e216f100fb244d08b9",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 1e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4807840",
+    "address": "0x0000000000000000000000000000000000495ca0",
+    "name": "HBBurn",
+    "symbol": "HB",
+    "totalSupply": 1000000040000,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4808213",
+    "address": "0x064b99560b1dfea18caf7f38af0de8469421e5d6",
+    "name": "INV-26599",
+    "symbol": "INV-26599",
+    "totalSupply": 100,
+    "decimals": 1
+  },
+  {
+    "contractId": "0.0.4809754",
+    "address": "0x78ca5f1aa1ce51b5d37c43b174969094717e5777",
+    "name": "TST",
+    "symbol": "TST",
+    "totalSupply": 100000,
+    "decimals": 4
+  },
+  {
+    "contractId": "0.0.4810339",
+    "address": "0x39dc3af7cc5bc2b0db49829016464f251d3686db",
+    "name": "Wrapped Ether 911",
+    "symbol": "WETH911",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4810352",
+    "address": "0xc0e373c970a10faf7100eb3b734752e886f943ba",
+    "name": "Wrapped Ether 911",
+    "symbol": "WETH911",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4810361",
+    "address": "0x24047f0efdf07c0e85c91dd74d5c331e7236b3ba",
+    "name": "Wrapped Ether 911",
+    "symbol": "WETH911",
+    "totalSupply": 400000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4810593",
+    "address": "0x8a7285a15a2514442d7592545dc89454e3378cca",
+    "name": "ViralPoints",
+    "symbol": "$POINTS",
+    "totalSupply": 570000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4811087",
+    "address": "0xadff895dc05055fd76ea930859da1c1da7e85229",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4811089",
+    "address": "0x6c43ff9d0c0035035a26ad01da26bca5f0cc9e03",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4811147",
+    "address": "0xfe97a93926d6844015896381ebf42954e9a3cf29",
+    "name": "ABCD234",
+    "symbol": "ABCD",
+    "totalSupply": 100,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4811325",
+    "address": "0x08c7b56dc1fe4cd006aeaf785148f3fb7d1d354c",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4812523",
+    "address": "0x8b08f77bca83836a0bcc67dd4d8bc3be0f99b0c2",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4812527",
+    "address": "0x2c3be723205e69a9af1efcdc6fc2c2a5831e8fe1",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4812529",
+    "address": "0xc9ff953bef54cc911c0d6cb03583022c16e13718",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4812531",
+    "address": "0xb42651d0a9622e8704a2e3b3e9a2d75b43971ea6",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4812533",
+    "address": "0xe81ef9362917265076e6b43b1ff2fe892f742fa2",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4812537",
+    "address": "0x6b37e99ba235174a93253c25b40de77c41b492b4",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4812641",
+    "address": "0xf734884aaf62ca5f39e587d5179a39b969b790e1",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4812646",
+    "address": "0xe2214dd1828b03066e85751c35f3a1a2b2441e9a",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4812652",
+    "address": "0x4ef16187caed40b8a848677bae2a69abb4990520",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4812660",
+    "address": "0x8ec8fb9dac07f794b1d601225d7ce70ba2a7c1de",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4812664",
+    "address": "0xe827b64cb41e5397a2b98e15f2461997d88c638a",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4812671",
+    "address": "0xaec77dd1939168fa8ad09d465c7f441be7ca21be",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4813746",
+    "address": "0x956c44ec9cc95f290196de22f3fa79e001bef66d",
+    "name": "JfuvxMJxOI",
+    "symbol": "CVCdZ",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4813918",
+    "address": "0x56b7437c9ed2c5ec216e422fbcdbf938f7168e83",
+    "name": "njyrndcKni",
+    "symbol": "sJJwn",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4814200",
+    "address": "0xf8745981712d6ad0bb5ede8fb795bd322daf581c",
+    "name": "wMRfLbxquV",
+    "symbol": "TsZvj",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4814327",
+    "address": "0x2abac9ecaa8e6a2e947cf077e2c468a75f457bbe",
+    "name": "zgxYTqJpce",
+    "symbol": "YFXlg",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4814423",
+    "address": "0x9ca1a1bb7514e4d81e9570d8216efbc55327e8ee",
+    "name": "iuGSVwUjDu",
+    "symbol": "cxRut",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4814473",
+    "address": "0xa27a59aa5914da1db3c4ebbc2c9a5795b34831cc",
+    "name": "GWhjsppCsE",
+    "symbol": "nwTtf",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4814489",
+    "address": "0xabfb5c2be1727d92824105e2e64406a3a4045345",
+    "name": "BAjMqEFLKQ",
+    "symbol": "Ugngd",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4814583",
+    "address": "0x2fa76a4280d0482b44ae3c537213aa5f5564275a",
+    "name": "DKPoCeLdMk",
+    "symbol": "cJMKA",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4814729",
+    "address": "0x161cc18813a747d86550d7e5704918d2b0df90c0",
+    "name": "yVMvChBiAW",
+    "symbol": "QaeSn",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4814782",
+    "address": "0x7df85cff3b010929681aa15213133b7406d1f93b",
+    "name": "SZzmATWmPU",
+    "symbol": "eKAUw",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4814825",
+    "address": "0x4ab54539ba549dbab11b37527584f8cd1767bc67",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4814828",
+    "address": "0xdd53bc16d3ca3a29dee5b8c8885d2c9e4f47d7af",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4814835",
+    "address": "0x4234703d468bc909b2f60f359da71f025babb859",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4814841",
+    "address": "0xfa58dfd1f19885c1acfeba46020041989a6528a0",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4814849",
+    "address": "0x55a65a0f57d28e46fcb95ef2e9a2d9e0b1a263ed",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4814857",
+    "address": "0x623a6a102ea4b1c736918c9daee7c44c2da7e58d",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4820747",
+    "address": "0x40a4ef5318b5d88ca52db0fff8bd88dbaf6c9a56",
+    "name": "SimpleToken",
+    "symbol": "SIM",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4820817",
+    "address": "0xf963214e998462a3994c9c07e9332c3056340f38",
+    "name": "SimpleToken",
+    "symbol": "SIM",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4821032",
+    "address": "0xb7544fabf94b13a7f5859ed73211fb2f4f767d05",
+    "name": "SimpleToken",
+    "symbol": "SIM",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4821039",
+    "address": "0xcd430045bd175f5acc50acd391132c6597e52da8",
+    "name": "SimpleToken",
+    "symbol": "SIM",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4821096",
+    "address": "0x2f939f5f6f67514d4259ebb91bae7cf332be09a7",
+    "name": "SimpleToken",
+    "symbol": "SIM",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4821416",
+    "address": "0x21f03f6942a9f5f8fec3e8d5fccebd68b1e2664a",
+    "name": "BigToken",
+    "symbol": "BIG",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4821513",
+    "address": "0x76c0a94ed6477ead48c2fb7909ca9af4fb239466",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4821579",
+    "address": "0x39a5d00f3442745ae4d55818bd3fa0cc9a063b3f",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4821603",
+    "address": "0xb091d9776dcaa4bab9cc12221d496aca9c853570",
+    "name": "BigToken",
+    "symbol": "BIG",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4821612",
+    "address": "0x41e4fd4468e79e16e282c465edf070c408aaad92",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4821619",
+    "address": "0xb7ca9a4e5e1e69c67a9783dada14dd60285fc86c",
+    "name": "BigToken",
+    "symbol": "BIG",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4821640",
+    "address": "0xac01e068f6dfacbfde13875f23d722c12c43a913",
+    "name": "An External Token",
+    "symbol": "AET",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4821658",
+    "address": "0x38d8b9ce07ca3807cda9e0edafd882a49e177bac",
+    "name": "BigToken",
+    "symbol": "BIG",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4821662",
+    "address": "0x27131942c1d1948c45514e56636b3935ccbbfb3d",
+    "name": "An Awesome Token",
+    "symbol": "AAT",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4821697",
+    "address": "0xde03d5928de06c4583c201855cb31ca05e46b06c",
+    "name": "BigToken",
+    "symbol": "BIG",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4821705",
+    "address": "0xfa2ae6ff81dc3d183fe0414c6ffad07c604cb21f",
+    "name": "BigToken",
+    "symbol": "BIG",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4821735",
+    "address": "0x1c1c64407d373bcd4faa320586e1f97a56a43aec",
+    "name": "USD Token",
+    "symbol": "USDT",
+    "totalSupply": 2e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4826185",
+    "address": "0xaf6f9b29a23cc172dcc59306cbd4c55401b4aa6e",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4826195",
+    "address": "0x5ca0c11698c4ed519ca245fca44e321a47845f2b",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4826208",
+    "address": "0x88792f3b3c13b36cf7978b9e42d9f5762f496746",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4826223",
+    "address": "0x3f2f8f08598c19f7215ba144ebcc8d478f35be63",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4826232",
+    "address": "0xa79c9b328fbac50fc88f2f675aa3a74cc6104047",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4826243",
+    "address": "0x71a46295da72d029b4101d25514e1a7e614e64c7",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4826257",
+    "address": "0xdf9dd6c774c2a4ef484e4434e17f9b69a7886ff7",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4826781",
+    "address": "0x11901996ee7fe5798696f6055eb511bf2a75c49f",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4826782",
+    "address": "0x5352e0187669671ed3141539095439638de2bce3",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4828777",
+    "address": "0x608297326f859f5a9a14bb3a88ca06427bdbd8f4",
+    "name": "MockERC20",
+    "symbol": "MERC20",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4828778",
+    "address": "0x9656494437f6186ac0c268c370e838b1edddf124",
+    "name": "MockERC20",
+    "symbol": "MERC20",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4831402",
+    "address": "0x3a5d49f9f3e844c4bd58078e08cd0f3aeb0dc40b",
+    "name": "orbQScAoSm",
+    "symbol": "AjoNn",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4831974",
+    "address": "0x0906b8a1ab5ded350f7697c10144cdea4ec08902",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4832950",
+    "address": "0x885ee704370f49ea9069a5fc463533b69606a7a6",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4832967",
+    "address": "0x3a0bd5114fb2fb5a4c3d030d6cbf70a20d8895ae",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4832984",
+    "address": "0xd057cf8ab132ae72e2c47e28fd17e0d4d62aee2d",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4833000",
+    "address": "0xa008b0f86835c3305bfaa0936fe58d3e6d332736",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4833014",
+    "address": "0x96c9e96f811a1ebb66238bfbe7541e3f5106a3c8",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4833033",
+    "address": "0x891cba94d5710ce9c0b8517d7ec95b263509b459",
+    "name": "hbar",
+    "symbol": "hbarl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4833047",
+    "address": "0xd5a8fa53d003ec68ac2df0d5b000de4d5f3fef0f",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4833711",
+    "address": "0x2650874df613f796d6e49961c80c59e800035528",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4833737",
+    "address": "0x591afc3d30576b445276bbc4137c31d87893a10c",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4833770",
+    "address": "0x4a8a39e3f2d00e15536e557f2c35dd00c3dbd0b3",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4833773",
+    "address": "0x79cf2876d8be13241d9f0fb5bd95b36b79d68f83",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4833775",
+    "address": "0xe2ff95bf7766a43f2dcc316c18d99af39e77a4f3",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4833778",
+    "address": "0x3e6bfba86fdfff3cadb55858ef34cd597f99149e",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4833784",
+    "address": "0x32d0f49b6e61d00bf190f2a706672b8cd32dcf59",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4833788",
+    "address": "0x403bbeffe9da6a0b26963200a183c54ec68a852c",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4833798",
+    "address": "0xf29446ffcf124f2cb49afd56690a2cee542a5eb2",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4833913",
+    "address": "0x59509971e6a75c7cfcb8e0a85c24cf89573d2b2b",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4834106",
+    "address": "0xb4a6489a336974d1f01c98cd08bd4e553141457c",
+    "name": "trtgjcexDj",
+    "symbol": "hMCzg",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4834107",
+    "address": "0x3d29cb861f29c9b58473256efd0997f66a378fff",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4834111",
+    "address": "0xec60f7ea168fb378d9a92c99f0de2a7f0085ebde",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4834113",
+    "address": "0x661048c4c8284bad56aca24e9987d36c83fbc604",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4834119",
+    "address": "0x95c4ae70d75893af59bc8e871884f4be6eeda140",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4834126",
+    "address": "0x199f377680bee2726da64cc6418af4e147789fad",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4834137",
+    "address": "0x6678a01d4649e9140d10598bfd0a8770a0dd6ab8",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4834369",
+    "address": "0x3358d970943b18307c9b2c20a64fe2378afc7f41",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4834373",
+    "address": "0xb1583a272e1c8666fbc939df887c1a521ad7a76a",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 1000000000000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4834430",
+    "address": "0xe0112d460c99b48fbcabe6148ff3f65ac60e2497",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 1000000000000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4834444",
+    "address": "0x1bb0da3719eccc1433dd68ef13d7ad0f2e632023",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4837015",
+    "address": "0xe97c6d5ed3a6507e405298b0ff1c1bcdede5b883",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 1e+29,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4837897",
+    "address": "0x6c7e9f06f59ff90d117ba44add12f6e5797650c3",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4838291",
+    "address": "0xc4a0faffd686c4852020ed50152f6a171b2554ad",
+    "name": "Hedera Token",
+    "symbol": "HDT",
+    "totalSupply": 1e+42,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4838482",
+    "address": "0x4de326ed0f0779156f8e9eca82a8d6ced865cc7b",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 1e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4838563",
+    "address": "0xe8fb78fd7c76a3e2f500d4302e8a75e6706804f8",
+    "name": "mockUSDT",
+    "symbol": "MUSDT",
+    "totalSupply": 1000000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4839484",
+    "address": "0x000000000000000000000000000000000049d83c",
+    "name": "HBBurn",
+    "symbol": "HB",
+    "totalSupply": 210000000000000,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4840052",
+    "address": "0x44f5bfb59d781bd43e83f95c448d62fcf7d60e06",
+    "name": "MockERC20",
+    "symbol": "MERC20",
+    "totalSupply": 100000000000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4841817",
+    "address": "0x36d89db91874684a638065450ac3ecb2a8b93f65",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4841820",
+    "address": "0xc6dc228dcf98d7547498c5ada2c3cffec62b737a",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4841822",
+    "address": "0xdbff47011a2434cdecbd77f8a5e0e6a12e0a81bd",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4841837",
+    "address": "0x46461120176557aa73194392dd0261b03a1ee12c",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4841841",
+    "address": "0x0651b34c933a657d5866f243349777e1ca009866",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4841844",
+    "address": "0xd80c5360c7a5aeadb7403c27d1748c4d3a1917ac",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4841848",
+    "address": "0x252b8bb5613cc97117501d91840c613d6555358b",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4841867",
+    "address": "0x078db34af2c7e65e6b0b416cf1a208cad22e32bf",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4841881",
+    "address": "0x5f205315029c1d4f7e0c3f7ea342f4918de4c8fe",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4843473",
+    "address": "0xc27a59637a9b6b2b55249cce5e8fac090772be45",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4843505",
+    "address": "0x3cc3970c010dddedf6034c7486df561b25e752a2",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4843522",
+    "address": "0x75c38a90c3d09983f94902af4469d293fd4e0d3b",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4843554",
+    "address": "0xe457b35d6adcea601e5240245b6fefe469b90a34",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4843623",
+    "address": "0x678b7e3a2281e54aba3c60ff7b73420574294adf",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4843649",
+    "address": "0xa71749fb837c3f42b165affc71ea359e90eb369d",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4843945",
+    "address": "0x50a7c36454dfdd4b40fb1a25eae1fc7b1c0ddc4f",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4843961",
+    "address": "0xbb66f581fd342ccefc8859d6a7cc111ce0cb625e",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4843963",
+    "address": "0x75bb9d4ed108b1f1d933f2bedc81b02d4aa6ecac",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4843965",
+    "address": "0x522a1c1d418d850691ef193df31347fea2a0b516",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4843968",
+    "address": "0xc7324b4029c7d8d5ccc8309b7ce198eca2a71c9b",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4843972",
+    "address": "0x4cb891cb68674b922a5a64c3757a84936907dccc",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4844556",
+    "address": "0x56651cc93ef8a23223aeef68b70dcd22aee46f8b",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4844560",
+    "address": "0xdb3b72803898f595afe05307038528717c6ab6ed",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4844562",
+    "address": "0xd912de9b6a5257615c65b36c0214ac9d80cb0f75",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4845086",
+    "address": "0xc6804956aa5b6ccb096636c2cc04df0b344f70b4",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4845088",
+    "address": "0x30ce3df1fdc44087404af541cfa4ddc6f9efda54",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4845105",
+    "address": "0x7ad28b541cf95ab9b3087938921ff538ac273c29",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4845108",
+    "address": "0x8ad845efdb96e1217872b73346469a5dc7c1b2bd",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4845111",
+    "address": "0xd95d564a80cdc4a093256dfd47690499b5db39ff",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4845113",
+    "address": "0x1db7d426ae3b098c8cec40756985b861d56e1fa6",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4845219",
+    "address": "0xa40b49144915b7e6a478a07117e0f1524749b685",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4845221",
+    "address": "0xf62210a100a4022810cf2a87debb9e59b51f6c24",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4845223",
+    "address": "0xd0d84bc8cc1790e3a494c809ab3b157dbd422e7d",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4845225",
+    "address": "0x9cc5783765dccd5280d3c2be5a3fbad242f8997e",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4845228",
+    "address": "0xfcfe240ad6795c6b82c71052c6ee857265d0c84d",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4845233",
+    "address": "0x41fcc2ce58f963f3ebd91f9308413bcbbd2bd7f0",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4845246",
+    "address": "0x3d4cfbcb81b3e64ed7e54e855dd6590ee622c8b1",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4845250",
+    "address": "0xa357850d3768504a996e1f310d4af43d737abd20",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4845252",
+    "address": "0x055b3ae09c24b00af491034abc3318bdc70f39c2",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4845254",
+    "address": "0x6bbabde2776160f576a82347016309cec1f0f4e9",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4845256",
+    "address": "0xd599c0d6d5b05e1981e12d6e20107fccda6abfba",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4845261",
+    "address": "0x0538879abe3c8c745832cebaf3bc7e2b001b79b8",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4846178",
+    "address": "0xaf135b6b8633b55ca83c3ee116169b0cc05edc7f",
+    "name": "BigToken",
+    "symbol": "BIG",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4846183",
+    "address": "0x95735d4cc511365f9d9395e1d42c3e41f9400675",
+    "name": "BigToken",
+    "symbol": "BIG",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4846197",
+    "address": "0xfe34b59aaefd7edaa9260e2a0d64f1e08b51924a",
+    "name": "BigToken",
+    "symbol": "BIG",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4846200",
+    "address": "0x5427a44e41e51b6a9cb6ba67a5feecacf98d5680",
+    "name": "BigToken",
+    "symbol": "BIG",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4846205",
+    "address": "0x47216ad5ae2760017e6a97a5c1927ff0375a47eb",
+    "name": "BigToken",
+    "symbol": "BIG",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4846223",
+    "address": "0xa80780af8dd66dc03a0964755a3646e86e1c993f",
+    "name": "SimpleToken",
+    "symbol": "SIM",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4846228",
+    "address": "0xe9fe5f1876c11b6382ac3c2edeb49ce130864871",
+    "name": "SimpleToken",
+    "symbol": "SIM",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4846279",
+    "address": "0x73173b92c80ba352b8539a198a840a0b9fb5440d",
+    "name": "BigToken",
+    "symbol": "BIG",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4846853",
+    "address": "0xe76fea16fe9972fe215cb0ef3aba6f59c11c2ac0",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4847230",
+    "address": "0x7e59f187881a32128c9d8cad56666de03f999599",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4847509",
+    "address": "0x000000000000000000000000000000000049f795",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4848160",
+    "address": "0xf9fbf7c2846d6878e431584430245ffc37365647",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4848181",
+    "address": "0xa062686cad086a12ed3e5413d6e74bfa1e554ae2",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4848184",
+    "address": "0x07bcc46107e4eb1f4272f7f77df760ccc5c68167",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4848265",
+    "address": "0x2bf62ee8edd6334268bb5b5c6818ea39da263a16",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4848656",
+    "address": "0xb39fe31280c9f4ca23b6164c899a006eff7ccff4",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4848668",
+    "address": "0xd209320615f702b09b3c89a7a8e8164b9ca17123",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4848673",
+    "address": "0x59ec80e1553e8311807f3c36f6a0660c1c96966c",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4848709",
+    "address": "0x6b0601e96fbcceeda97eec61d123c70371afae38",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4848828",
+    "address": "0x3d13104c4f1aa187d137016c4fac5dd742bcfdf0",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4850953",
+    "address": "0xed96c890fa7a142753c997097e32360c08fb5c84",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4851116",
+    "address": "0x4c909693a125ed6a4d30dfbf7bf2fee40bace4b7",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4851183",
+    "address": "0x2667097324a9075e015720dd847441dad2c77a7f",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4851651",
+    "address": "0x236045ba42e321c8809cebd8a7f76e62b1453491",
+    "name": "pGfyEdDSFs",
+    "symbol": "GDGRS",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4854531",
+    "address": "0x3d8171f3c6b7dd9919a443a39d7be4031b4f4cb1",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4854816",
+    "address": "0xd4b3258c72bb815df04d644aba324365cc3fadee",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4854877",
+    "address": "0x3022fc2f7f0b1bede3c32c80f08ad89dde2050b1",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4860583",
+    "address": "0xadab56b6c1fee0a24f999f5884f381e37028f027",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4864479",
+    "address": "0x7421d8057b0adec57846f8b22352c5092a3affd0",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4864550",
+    "address": "0x7ea13deb8188aac90d10db8b05e0fe68af6c2b40",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4865325",
+    "address": "0x65f520c093dc1b55e722acf51717d7cf6e104a65",
+    "name": "hjvcghah",
+    "symbol": "JHKJUY45675",
+    "totalSupply": 100,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4865705",
+    "address": "0x3011af8cdc49ee2ca20cf9a13e4471019ede121f",
+    "name": "hvcahghgc",
+    "symbol": "FHJIU6756",
+    "totalSupply": 100,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4867090",
+    "address": "0x93782b191535c925d79d6263ed64dcc4e420e1b0",
+    "name": "MvHDoEpBnp",
+    "symbol": "pIgkP",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4868768",
+    "address": "0x71c509f9b83bb1d3f3a302bf1506696b9d5a6f7a",
+    "name": "hvjhgcf",
+    "symbol": "KHMKKI86",
+    "totalSupply": 100,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4869667",
+    "address": "0x1aeed29de269e3d47da42e27d40ff7f6545b675f",
+    "name": "KUpTMHsyBj",
+    "symbol": "ahaFg",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4869671",
+    "address": "0xf9f7d9452c969a9fc36a1af524596713857f39d2",
+    "name": "LmTUzcwEVq",
+    "symbol": "lhCwo",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4869726",
+    "address": "0x5aa9c3c23eac0c01304f68b521e4a28c30ef3cc6",
+    "name": "UsXgcXtiFZ",
+    "symbol": "jIRKb",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4869782",
+    "address": "0xf6f5e6ba4ec7738d2c791b6c8551069f31dd3550",
+    "name": "TsdneXvuRG",
+    "symbol": "DLFPe",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4869806",
+    "address": "0xb6d64d23cb4657cf0b9b66723796f9394427c722",
+    "name": "gnJksJjuqD",
+    "symbol": "SWSPe",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4875754",
+    "address": "0x9aede29ab0dc3ff58cbfb3ed1e03482d95d3d495",
+    "name": "JjvPiUyPwN",
+    "symbol": "jtCcp",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4875775",
+    "address": "0xa40109afce41cddd0b56aa8411ba17c0c456c383",
+    "name": "HkGCZGbuxN",
+    "symbol": "DyYUX",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4875799",
+    "address": "0x0a1d0a00088e247b677d42425e861ea7bb0e3699",
+    "name": "xcTeKyscbF",
+    "symbol": "fClNF",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4875802",
+    "address": "0xc446e89cf38262144cd3fd72746e61745ec5413b",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4875806",
+    "address": "0xb2c3b76a3b506eb1246a36815f62b0a06e41bf5b",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4875809",
+    "address": "0x075f32f7094dc5d8649f26ace0e4d8fb19d3e5d1",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4879044",
+    "address": "0x87617cef35ad0d127e79438a5ea7cb64a06e3e6c",
+    "name": "BUSD",
+    "symbol": "BUSD",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4879050",
+    "address": "0x1a8cbef705d86a2cc417aeab20b7aed1e58d9f8d",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 2e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4879524",
+    "address": "0xeb06be050443516472c088b8348c870e57b81924",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 2e+30,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4883455",
+    "address": "0x734ecc72e7f2e00f92fab0bf7aba7c14a8867c05",
+    "name": "Wrapped Ether",
+    "symbol": "WETH[hts]",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4883459",
+    "address": "0x9953fd6b2f4e35578966d30185768b4d245f5bbd",
+    "name": "Wrapped Ether",
+    "symbol": "WETH[hts]",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4883466",
+    "address": "0xfd06091045b1ded633ec5c72b887e280e6ceb321",
+    "name": "Wrapped Ether",
+    "symbol": "WETH[hts]",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4883479",
+    "address": "0x8be8755e34cf13bfe2188f8a50db706ea818929a",
+    "name": "Wrapped Ether",
+    "symbol": "WETH[hts]",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4886075",
+    "address": "0x9a2b501e9d9e88a39c24a62c1615ad4adf4dc40f",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4886077",
+    "address": "0xb07d2a2f816c2225ebed44fb94d0b98d7029d880",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4886080",
+    "address": "0x970beb9fbb39f9424a89ce9d9e0f5370bae40d2c",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4886082",
+    "address": "0xabb6adff5cd07d3e8cce863d5014ec8044f38383",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4886085",
+    "address": "0x70b7df289fee4382311f48f7b7a72bcc6e087c6a",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4886090",
+    "address": "0x3eebc7f43521205b0d207979e07ddf605637661b",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4886200",
+    "address": "0x9349e2c1125143c7ed7d7f7ea9c0c7c3a2f1b2a7",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4886204",
+    "address": "0xc4670e94d649e59e42101eb3df2be6915f1f9e82",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4886207",
+    "address": "0xe39a585b9cd442e7c18852b67022d37691330bf7",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4886210",
+    "address": "0x318a1618308cb94514142688f1cd970d99fdd09f",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4886214",
+    "address": "0xa6ef1d227904312bd294c3f97d9a7dbb07e72144",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4886218",
+    "address": "0xd99ed926253aae2db30a842bd2c4397be9e39b6a",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4887270",
+    "address": "0xcab3ac6267117cc5d4791eef1e8ba8a4d4148321",
+    "name": "asd",
+    "symbol": "asd",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4887450",
+    "address": "0x6e1bac966ba0b399b97f56ac8d06b75c5b29425f",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4887452",
+    "address": "0xd99b4951ce8307345732cadd20b96be3288e55c1",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4887454",
+    "address": "0x92b2f67e08765b8eaf2d6bbfce3a07d8a9f1e9ef",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4887456",
+    "address": "0x5f5f6c4b21fa9249080faf07e06edfb45b7cc71e",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4887460",
+    "address": "0xfebd7291d23744e2842f7cb377560ab134cfb5f1",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4887466",
+    "address": "0x64b2f5477cea7c83e1d1b41c8ebeb90a887ad2ff",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4887532",
+    "address": "0xebab06a72f7b46fd64bf9a5a986ab6703793b8a5",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4887535",
+    "address": "0x66dd3011f992c716fb9049b1b178ee2363f33837",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4887537",
+    "address": "0xe50f1feee88cff8c15858492e7fc51b1224514ee",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4887539",
+    "address": "0xfab03227f158c743229fad840aa1e4dbea493012",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4887541",
+    "address": "0xcea6d209b93f3e76b50150937c62b6fa02d9a00e",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4887545",
+    "address": "0x1eca5684fdf04ebecf43ba79eca936280048cecd",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4888183",
+    "address": "0xf8d56ca172a99cd17b9aae9de3b84c2a851a3202",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 100000000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4888304",
+    "address": "0xcab01f64bec31c891f8ad7085dacdace0ab6bd17",
+    "name": "USDT",
+    "symbol": "USDT",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4888445",
+    "address": "0xc2012a0b6ff447e84a150766d7843c2f143bb008",
+    "name": "TopupCredit",
+    "symbol": "TopupCredit",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4888581",
+    "address": "0x30bf019c1c46b020e6d7bee026e44ef582e428af",
+    "name": "TopupCredit",
+    "symbol": "TopupCredit",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4888903",
+    "address": "0xdbfa6d8ac5e5d684e4fe6b0830242d8a716e748d",
+    "name": "Ozone Bitcoin",
+    "symbol": "oBTC",
+    "totalSupply": 2000,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4889283",
+    "address": "0x0368b0a1b377e1aeab3ac5b2f2b20c8d7ec485de",
+    "name": "CSB Token",
+    "symbol": "CSB",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4889288",
+    "address": "0x60bddf538d890b7c61e4e581c4921d3011f32260",
+    "name": "CSB Token",
+    "symbol": "CSB",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4890912",
+    "address": "0x2c085c671f34e3b69dedb554a46c6ede30858514",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4890913",
+    "address": "0xd577043291ff7813dae152b1c6b96e53497e7d59",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4891729",
+    "address": "0x28fd1ccd0db80c6ff0734f63e77deea8da863aa1",
+    "name": "AUD Coin",
+    "symbol": "AUDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4891739",
+    "address": "0x72362836ca55a9e85495798064350d1c73091605",
+    "name": "AUD Coin",
+    "symbol": "AUDC",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4891741",
+    "address": "0xc7b0c073125a327e01edca906febe654bf1dbb35",
+    "name": "My Coin",
+    "symbol": "MYCN",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4892397",
+    "address": "0x360812e79517677bcf593ec052cb774949c02e9a",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4892398",
+    "address": "0xa554cabb5b04dd5ded86c05daecc562286d4f258",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4892456",
+    "address": "0x9e7011a29d732992cdf7e55f0edf4dad53be7670",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 200,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4892457",
+    "address": "0x814503d6dbb6ec5d99a1adb86f30e8e149bc2b89",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4892473",
+    "address": "0xfabf82cb242e7528aed5d8c0a8e4a89baf1f3b90",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4892474",
+    "address": "0xbe961039659284e699bbac08f0344002ee11d7c5",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4892541",
+    "address": "0xa978983caf747e8aab0ab25e2dcecac8dea4a00e",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4892542",
+    "address": "0xed2c4389b82d8c41af023b3d7984fb931eb58797",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4892731",
+    "address": "0x0d15255ff591f844596121224c71ee9d9afdffce",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4892732",
+    "address": "0xeed444b6f2ae24d5e0b87b095e4d6eac7684704d",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4892777",
+    "address": "0xe20945811580243dc0a0b543336841cb02d1cb52",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4892778",
+    "address": "0x8981692a9787ffbe7882a8f0a4220daaebc9d6c6",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4892824",
+    "address": "0x5aae2f316020325ba661602f4b7e71620202f6ca",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 100,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4892825",
+    "address": "0xf091d7474520ef8daa937417c5c593802d422b22",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4892868",
+    "address": "0x0813465f14c701c95ca140b29d19899e27b6f705",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4892869",
+    "address": "0x81e88b19a84e6f7cdb0db01afeb2959206cbf069",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4892923",
+    "address": "0x88dbd96bee3b8e9b339a6b6cbe36c5a53e8a769b",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4892924",
+    "address": "0xffd9c3fbc07266ac3876feb0d0d2c481775a9aec",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4899538",
+    "address": "0xdb9cfbd1a2d2e99600ae4b562172761007dddef0",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4899760",
+    "address": "0x591f69bc0c522160d82307dcf4c7a27a278d9a79",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4900749",
+    "address": "0xd65aafaba56ea8d51101416f49e6801323acef9e",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4900750",
+    "address": "0x94094438992a7f287a76e1e8c19476ebf0391638",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4909600",
+    "address": "0xdbb08c8d436914fe4d0e49e11a6f7434d4f37c60",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4909601",
+    "address": "0x8fa56015ad613388b3e3d481e8cd68b6206091bb",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4909932",
+    "address": "0xf80da646da3718001f8d3f2da8fe3c46f7915163",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4916252",
+    "address": "0x4809600d66fca0a49995a911a49e9531d2a82803",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4916253",
+    "address": "0x26ada32e0d9171a4e4c0452ad16e65bece01b953",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4916258",
+    "address": "0x1e82c4d52e5310289cbcccb0784141b11fa42bda",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4916259",
+    "address": "0x716d5d37936f22ab9282c6a8e22863bda712acd8",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4916268",
+    "address": "0xaeccbca333151f964b61b8561dfd5bd11c0a19e6",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4916269",
+    "address": "0x82456983c9a99f77c115e345483064ac8e3e3e9c",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4916279",
+    "address": "0x00932433a7911e9f1a83e5f1f5f4c8fbb29f5d53",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4916280",
+    "address": "0xeab408f46c0221bd2c597bf21ef6c8a1744b6ff5",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4916285",
+    "address": "0x95af2fffed963690e07163360aeb28517d041ba5",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4916286",
+    "address": "0xbf9d34cf1d87683dd69f58ab7439e5a2ab90e016",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4916355",
+    "address": "0xd4b37ac72d188228871723432989415a9f20c2d6",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4916356",
+    "address": "0x70ac2eed4e42afdc3e68e62576a8dadf8cfc8a4b",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4916401",
+    "address": "0x90708b81efd624a89d2850c3de6d1aab64c26fb4",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 100,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4916402",
+    "address": "0x9442356f0dc26fd30c2f93d18fbc782c59ccc066",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4919824",
+    "address": "0x5d78f944407e72c78d049c9f651fb12896b53d80",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4919825",
+    "address": "0x00811bbb8c5b8d87566331d14d19e86f4dfc3118",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4919834",
+    "address": "0x08d66d59ff1aa5509711120a1dbb4e807c123d3b",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4919835",
+    "address": "0x641f6dd38e109a86d1a0838f2f546f27cd7769ea",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4926389",
+    "address": "0xd3cf3291ce67cc4ec601f0b2c94eb9732419a3c5",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4926406",
+    "address": "0x26e8a671623748acc7831f4f6b57e59730d9a0fa",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4926412",
+    "address": "0xc9d8c750722543cb74bbb77592157ba80a04a627",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4926417",
+    "address": "0x7b22fe5458ae86db073f27ea1713aeea02e28ff4",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4926425",
+    "address": "0x2f63eca48b5ea9dc4d35b03c2412b0952828e59e",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4926435",
+    "address": "0x76d3e2c48be89804bad2b81bdc97a1f441cb7a38",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4927605",
+    "address": "0xfde617790a07004bcaef5cc8b43e05b7af6fe5af",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4927906",
+    "address": "0x744f4fc391aa9aa0c5d58e32a5b55f7ac78dfe16",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4929366",
+    "address": "0x6ddc207faa4784098f3630cedb561cca14f47d7a",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4929370",
+    "address": "0xc431e8e8ad43d4c3ff5e78fed851a08bcba64911",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4929373",
+    "address": "0xb947336b2c0acbcbef9e3850cc96b3db9bc4fccf",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4929378",
+    "address": "0x70d4addda18a969599617765f6c1b479385bc6ef",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4929382",
+    "address": "0x37bb40743aeddd530c172fcfea76ee407754bcbe",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4929386",
+    "address": "0x8e447c3213918cd5f42c3095d35c4c997191d52d",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4930043",
+    "address": "0x4831ef128a7168f389130115bcfe7348e6bbae87",
+    "name": "zMOEUlpCKt",
+    "symbol": "zEcHf",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4931154",
+    "address": "0xfb1dff973ca9b70e3289356f4cded2fcc2d383af",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4931155",
+    "address": "0x8a9ea8f642d797f716d0606b169da4dc41844bd8",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4931775",
+    "address": "0x91a019da62be08e2e414fd02bc52ea6d84d19337",
+    "name": "aaa",
+    "symbol": "aaa",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4931828",
+    "address": "0x06370b2dc71245c14edda08aab323a46c1e99add",
+    "name": "MMNS",
+    "symbol": "MNNS",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4931850",
+    "address": "0x6f47dffcd6dcbd3633f4ecf18b4c078f960a40d8",
+    "name": "ALEXIR TOKEN",
+    "symbol": "ALEXIR",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4932369",
+    "address": "0x7a3935a1a736dfe406295a0472c5fe09afe81516",
+    "name": "KxrJIePhCI",
+    "symbol": "Fgojy",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4936012",
+    "address": "0xa2814230f6152c9bf919509b93eda803a4f0bfc2",
+    "name": "Test Token",
+    "symbol": "TST",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4936529",
+    "address": "0x77fba0cc2d0bfe9b958cd904937a22209c8d9771",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4936530",
+    "address": "0x6f4f8b9240ce60715df6af1a6f8f70e58a2c1675",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4936685",
+    "address": "0x11b18b197277ce9481314759277bb8911e30e298",
+    "name": "Test Token",
+    "symbol": "TST",
+    "totalSupply": 1e+23,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4936717",
+    "address": "0x67f26e769957ef10fe2cbf71f26959e5849088be",
+    "name": "Test Token",
+    "symbol": "TST",
+    "totalSupply": 1e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4936731",
+    "address": "0x7fe37b70e831b1d5a23e345c9f4a6e6478a9fdec",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4936732",
+    "address": "0xf408f23aced5ec87844f9c0b763cc9612b2e659d",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4936757",
+    "address": "0x6d975296c9ee5c5472d12eb57ed09f8eea516919",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4936758",
+    "address": "0xeb16ee7393edc84fcaa8287feabdfb3e14b45ea3",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4936761",
+    "address": "0x626bcd731e7dd4ab13b61ca5349e8ae4fad571d6",
+    "name": "Staked HBARX",
+    "symbol": "sHBARX",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4937366",
+    "address": "0x01089534925bd848c5f075ac2e5b4b4d6252da17",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4937367",
+    "address": "0x89fff8763eba55949a0ec2dc875297ec43f85233",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4937374",
+    "address": "0xd04adb0b44550b8e432a5aa15a5fa08e1ec2b0a9",
+    "name": "Staked HBARX",
+    "symbol": "sHBARX",
+    "totalSupply": 10,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4937975",
+    "address": "0xd1b05c9ab0db7ac975ab5e47cd1aab5e199698fb",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4937977",
+    "address": "0x61d4cc039daf28f711564485f68537ad0ac1a9ed",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4937980",
+    "address": "0xebabd19ae8a10c9dd495a927c6533c6dac1ff895",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4937984",
+    "address": "0x58a4b0fa9521b2d45b4f61e341c9c7ec240d68bd",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4937989",
+    "address": "0xed9dba39b89d71a349a15ac68ca5c9e51b02eab5",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4937994",
+    "address": "0x8a60b55c038e59ec39559469994e8bf35a6c0ce6",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4944546",
+    "address": "0x9f6026a7cbeb15317c7020b3e35bc86d2da84dbe",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4945002",
+    "address": "0x2cf2cc5b186bec6496ab16943a68c7c807c5aee7",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4945004",
+    "address": "0x20980618c69fdbaddbf78b9a7128bfb3905cb9a1",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4945006",
+    "address": "0x1ffd673da46bf2a3233134dcb0103dc6c0178360",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4945009",
+    "address": "0x2420ad42e935d26f066cb31e41224c3a52fde4b4",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4945011",
+    "address": "0x1b441f7af1eba910c2cc96886bb3f405c437b355",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4945016",
+    "address": "0x6a6f339b9130b9d4e75c631c59a26f4a464e1a90",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4949360",
+    "address": "0xcd4509ffbd471ac2253b8410d973d1be76adf275",
+    "name": "hsvhscvh",
+    "symbol": "GHJIUt6767",
+    "totalSupply": 100,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4956557",
+    "address": "0x654b4eaf5bced000c7115ecfb30645e31b75abf4",
+    "name": "First DAO Token",
+    "symbol": "FDT",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4956568",
+    "address": "0x165668c36bc6849abfb2254a61714a8d923e0af2",
+    "name": "AAA",
+    "symbol": "AAA",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4956580",
+    "address": "0x4112ac240168bd0478ba7a0cf118b2418b94a46c",
+    "name": "First DAO Token",
+    "symbol": "FDT",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4958863",
+    "address": "0xf041f5d3687790439263d019a1067d2af16ec768",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4959016",
+    "address": "0x63435355c5d8541b10d487624a42e45a1aaa7c9d",
+    "name": "SimpleToken",
+    "symbol": "SIM",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4959026",
+    "address": "0xd1c1df7ac80faf9e2f163bbedabee3176f8ef2ab",
+    "name": "SimpleToken",
+    "symbol": "SIM",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4959051",
+    "address": "0xac2f8b8a9779f0041f1f188326232fadb1232d8d",
+    "name": "SimpleToken",
+    "symbol": "SIM",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4959057",
+    "address": "0x05eaf146bf7fbfef91a297d3161b6613b68883fc",
+    "name": "SimpleToken",
+    "symbol": "SIM",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4959063",
+    "address": "0xed18e7cb5739247e6601f8fe44c1a15a6c6dc6d7",
+    "name": "SimpleToken",
+    "symbol": "SIM",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4959067",
+    "address": "0xec5400fd7919a9512dc687bb0481e4e2f536e9db",
+    "name": "SimpleToken",
+    "symbol": "SIM",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4959072",
+    "address": "0x9b4f7ea3bea22a07ea20c5dc211cc92052c49b15",
+    "name": "SimpleToken",
+    "symbol": "SIM",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4959075",
+    "address": "0xa2047a7b44a719f3086b350f8518f2947c892f50",
+    "name": "BigToken",
+    "symbol": "BIG",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4959077",
+    "address": "0xc7d86e9e794921e27acbf9af267e06c519dfb88f",
+    "name": "SimpleToken",
+    "symbol": "SIM",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4959079",
+    "address": "0xd2b769d2214aed29630a774b54f1f5bb3e84c372",
+    "name": "BigToken",
+    "symbol": "BIG",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4959083",
+    "address": "0x72fae325f58159646f818f5935e94baa29819d1d",
+    "name": "SimpleToken",
+    "symbol": "SIM",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4959086",
+    "address": "0x069adf2e272558b3d8469ece18066b65211db8e2",
+    "name": "BigToken",
+    "symbol": "BIG",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4959094",
+    "address": "0x63383d47faf09226911592f0fd3ae8384f022817",
+    "name": "SimpleToken",
+    "symbol": "SIM",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4959096",
+    "address": "0xf00354452e8049fb3de6b9e2298223c017698f4a",
+    "name": "BigToken",
+    "symbol": "BIG",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4959100",
+    "address": "0xc2f6de88ef6326de1f1e0bac5b7d2f3154ee8634",
+    "name": "SimpleToken",
+    "symbol": "SIM",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4959104",
+    "address": "0x7ce404958215485b9ffc2f02d30922c78e0c6a1b",
+    "name": "BigToken",
+    "symbol": "BIG",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4959388",
+    "address": "0xb3d69ce6ac024b37cca4e6294cb609e034c69e49",
+    "name": "SimpleToken",
+    "symbol": "SIM",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4959396",
+    "address": "0x9727e18855d0aa34ab5406d2ac646b6c2f1a73c4",
+    "name": "BigToken",
+    "symbol": "BIG",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4959403",
+    "address": "0xec4cfdc4af45c9cda3b0b414738d3818a44d7871",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4959428",
+    "address": "0xd50c63cb0c8cb3d7641534594944e06f7bc90437",
+    "name": "SimpleToken",
+    "symbol": "SIM",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4959430",
+    "address": "0x47d656cddb8ac91bb4590d0d75a3016a54588ae4",
+    "name": "BigToken",
+    "symbol": "BIG",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4959444",
+    "address": "0x99e5eb24b7fe6ec12714c24617e47d8624f8c6c3",
+    "name": "SimpleToken",
+    "symbol": "SIM",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4959449",
+    "address": "0xe31f5ce47a53304fa77bb043f1a98faac44b37da",
+    "name": "BigToken",
+    "symbol": "BIG",
+    "totalSupply": 2e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4960843",
+    "address": "0xba46f76035d6265e3c0fee927b894ba5afbac31e",
+    "name": "GiPKzsbwdX",
+    "symbol": "TJYta",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4963401",
+    "address": "0x49c14a199295d4db90cf0a967c25a7076fa38ca5",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4963402",
+    "address": "0x35e8d1917d7fc302276a7bfeb6830eb20f3dc401",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4963531",
+    "address": "0xace399281289367b603cd2a764877a10f9ac3c91",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4963532",
+    "address": "0x477ed6b25d124a823fcb524cca493b64ffe33a63",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4963559",
+    "address": "0x418cda44e5aef27de0abcc1c959fa0b7561f711e",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4963560",
+    "address": "0x82b8c721d1f0386fbc37acf34f249c2163b4b5b4",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4963578",
+    "address": "0xb0de82285a9bfe9e835594aa58504c84ffdc0181",
+    "name": "Staked HBARX",
+    "symbol": "sHBARX",
+    "totalSupply": 10,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4963921",
+    "address": "0x6633ba5a4e9282632bf76ab70f5d0ea9f6c21e91",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4963922",
+    "address": "0x93ac06449f3203f36a0acc878847dbd41d041b4a",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4963991",
+    "address": "0x42f9c1b1fa7d6782446df4ee2248413e884bb90a",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4963993",
+    "address": "0x7f844008f2328c40f7d87906f9ce3c3dbe49a5eb",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4963995",
+    "address": "0x6dc7bcba243efd0b852046a3357f0cfb92683736",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4963998",
+    "address": "0xb1ea544f7698afd659c0c7dd594a9f3cfaa45c74",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4964000",
+    "address": "0x66460c44addf86c6686446571f6bb808e91454fd",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4964004",
+    "address": "0xd6dfbd029a19b7a08db3e7994cca1c9a20ca29e2",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4964285",
+    "address": "0xdb6eb3841b44e8fdec8e15cc4496892016f6aef3",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4964289",
+    "address": "0x55ad05a6f5f2e0b5baaecd67bc3d76ebcfbe7335",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4964298",
+    "address": "0xa5cf2a0d7397e88097550a2a0a3cdd2ab570523e",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4964302",
+    "address": "0x465b4eab432ace20a2c470db12b8744ff34a2579",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4964308",
+    "address": "0x374fae74f39c680a7529b7d5900b62a0c089a4f9",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4964323",
+    "address": "0xfecc52c0dc65af962f8c14172ccb6b8f3fe1c9bf",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4966658",
+    "address": "0x0ff2db2cfea1acdfbdedd5a872861e5ed9b33c56",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4966672",
+    "address": "0x2bc82efc6d6625895caf23e677dd7f7ce5017c70",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4966689",
+    "address": "0xabaa2e1e13b977a27d209b79269912d387169792",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4966702",
+    "address": "0x514246f560f369a55af1e710f6f45c5dc6645d48",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4966706",
+    "address": "0x1965c7b93ee87b489f955db8ec392547cdd7aa7d",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4966713",
+    "address": "0xf9504adfa4cb776a1484691e3f915acf3ac8edce",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4967360",
+    "address": "0x025e1aff9b68c3a124c76f1d1c312c9d70a9526d",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 10,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4967361",
+    "address": "0xffadde574db32b2890839ea27c008e76b3b49634",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 10,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4967368",
+    "address": "0x3dd995dfcb4fe06b319e515be4ae984572dd73c1",
+    "name": "Staked HBARX",
+    "symbol": "sHBARX",
+    "totalSupply": 10,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4967554",
+    "address": "0x8f2ae9d7ae77e7f3d3e60caf0a721e64a13b16cf",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 10,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4967555",
+    "address": "0xd4269469bd54bd70781be8f9bb85bd6abb88eeed",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 10,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4967567",
+    "address": "0x391c1e979ba4fdf5779d1f86faf483c4855fc6dd",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 10,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4967568",
+    "address": "0x4d138acd2084b58a0d48724ca15ac50eb01a9eb4",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 10,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4967621",
+    "address": "0x8f7ba7f8fed9aef465794c0dd07f84432c54f8c1",
+    "name": "Staked HBARX",
+    "symbol": "sHBARX",
+    "totalSupply": 10,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.4967758",
+    "address": "0xe8df9ab47b090ef9beb734a4fbf42b55e2495c1a",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4967759",
+    "address": "0xfe8a026c92b49b306f15b3e96f89e5257eb29dfd",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4968018",
+    "address": "0x7dd94b81873e65bb7b917f796090e42049d32465",
+    "name": "xSejigTIwc",
+    "symbol": "bQnXP",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4968198",
+    "address": "0x6c28a9898ff25989ba1de8347e1a772e4daaa26f",
+    "name": "iIPOlDWndc",
+    "symbol": "nqNXR",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4968263",
+    "address": "0xe4218ddec16ecc60da16ce5e6c1e2d81e9224e36",
+    "name": "MnVluHlETc",
+    "symbol": "xOEXR",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4968280",
+    "address": "0xca049708580a3d8c22749660a8661522db13c565",
+    "name": "uyLPQUToed",
+    "symbol": "TMdix",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4969776",
+    "address": "0x29fc23118b3e830a9fbc92838c4cf598095c8a1e",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4969777",
+    "address": "0x6b1523cf415cd66ceea4f1b1dce66541a1ac981f",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4970626",
+    "address": "0xc2184258527be9e166083e0ae4d40e1289b1117f",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4970629",
+    "address": "0x063ba854f07ff4f2110b6c8b76834b9b43ae382b",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4970632",
+    "address": "0xe4147c5b2bf453d192d7308bcc10035ab9d1165e",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4970640",
+    "address": "0x64eca899950c7472e9b8fac8b345adaa79554cd0",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4970644",
+    "address": "0xaf3c807439c0fff1fbebc9e7d3e0b406975f82b3",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4970654",
+    "address": "0x48d5b1422085a5b9c7e2911d18e57c5b2c52594e",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4972218",
+    "address": "0xb4e84087224d159a6f8b0dcb8b78482f6e7ba506",
+    "name": "Staked xSAUCE",
+    "symbol": "sxSAUCE",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4972219",
+    "address": "0x9318135c545c74971ecfa3fd7f34a908858a73f4",
+    "name": "Staked USDC",
+    "symbol": "sUSDC",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.4979840",
+    "address": "0x1ba5108844215a79c2de372588ee9bc410466ef8",
+    "name": "dfkk",
+    "symbol": "QHWY",
+    "totalSupply": 10,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4980580",
+    "address": "0x9843dd3044f4daed867efd8c75eca0c052d39283",
+    "name": "izTCWXdKhS",
+    "symbol": "jtpcF",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4981282",
+    "address": "0xa3c7adf8a350ce5496624c8b397554e302aec4be",
+    "name": "dLRpNTxVdj",
+    "symbol": "dzUgA",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4981284",
+    "address": "0x95798553735029a06eabb602c094566f9d959e90",
+    "name": "qoKhAftCzF",
+    "symbol": "kOuue",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4981381",
+    "address": "0x422d611354102b64738fa06a1055087fc188f645",
+    "name": "GxLqPXKYVv",
+    "symbol": "RDETs",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4985652",
+    "address": "0xe3949d6a43d30279489169eef91b28a08cbd082d",
+    "name": "XhZJTPLhlo",
+    "symbol": "CPpFx",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4987459",
+    "address": "0xfa72cb5d99df9eb20641ff29e39cdfc988965bf1",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4987461",
+    "address": "0xb3ee8a6dbc20234c28ec1322db21e9792ed74bd6",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4987464",
+    "address": "0x68ddf4fa2cd9c49e836d98a6fd330f4b91e09561",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4987467",
+    "address": "0xe153f65aa6a2ce33f79d4925783f2c895b094c93",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4987471",
+    "address": "0xc480d1c7c8575d5fcee7118b15615fa609dee704",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4987476",
+    "address": "0xa7a1c29247213abb705fe22f4b98b4f776650473",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4987532",
+    "address": "0xfdc041a223f655c9e33005feb99247a9c72572eb",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4987536",
+    "address": "0x8849fc501c8fae57785df721ce4b70639bfa1bac",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4987538",
+    "address": "0x358f4392f7a83ad07dfb553abda1e8aa9610b072",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4987543",
+    "address": "0xc6f8ae479a29e92c707230ef412d33882a7915f9",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4992459",
+    "address": "0x9f31c8bc1a36c8a27b93db298318d0144681a314",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4992461",
+    "address": "0xc3abc0402c31dc7826970e3f3c0cf3a62ab8e332",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4992464",
+    "address": "0x2773cd0c6535ca305fc2ed158d5fa0a492925639",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4992466",
+    "address": "0xfd99af9296d62a144745a9656be415f18fc575e6",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4992468",
+    "address": "0xc386c3704a0caf10fde952f10a931f6f10e79513",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4992474",
+    "address": "0xd5099c23c9a222854948cd0b95adacfe0f4cc769",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4992483",
+    "address": "0xf8b2b6a7f812e5b4e4a340aefa1045acd4456106",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4992485",
+    "address": "0x7df5f92da09b54c51291a5b62b340068d9e4a873",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4992488",
+    "address": "0xdf75f67fbe11d67a7a807b32baca9053bb9a2ef7",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4992491",
+    "address": "0x8c2087ce748d19c8a82ed9d5f0b6b01674946883",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4992493",
+    "address": "0x54c879b18210da802121f55b8d43cb75b8fd8466",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4992497",
+    "address": "0x924379b0625a4c8aacd98fcd9fc8f9c94f7bde4c",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4994044",
+    "address": "0x582a304be87cb74b4e3b80a0099951d3c9a3993d",
+    "name": "EnergyToken",
+    "symbol": "energy",
+    "totalSupply": 2500,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4996545",
+    "address": "0xbd4ee3637cc59fda7d802653bb0b29d6cd6a63e3",
+    "name": "LWhrgAQgEH",
+    "symbol": "ZbvfQ",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4996549",
+    "address": "0x35d4e801173c9912421e11a6c51ea117a991ae85",
+    "name": "iAmQnZAnhg",
+    "symbol": "ZWAYi",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4998812",
+    "address": "0xb4fc2e5a8d222203bf6561309e363c67a0e07c80",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4998823",
+    "address": "0x6102bcee740bcdda458e5922dd28c9db3ae0ea56",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4998890",
+    "address": "0xd7efd00b647606de883078b755e7945dba15191d",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.4999010",
+    "address": "0x67e0622f91cc1c18747463cbf817748b13b1aeca",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4999012",
+    "address": "0xb5956d7fd87722f0a686847b1580c6423245ea94",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4999014",
+    "address": "0xe19839b2119f103d6ae8524de3a2586b441f02a1",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4999017",
+    "address": "0xbc3893cac90c8eff30107046880f4d7e0717b98e",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4999019",
+    "address": "0x54ab60032bcc50e25389610170e8607491d4dd1e",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4999026",
+    "address": "0xc290b589f4e4c3d7ffa52fd7e66dc1011c4835d9",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4999699",
+    "address": "0xa03d72539aefb00cd90bc1797fa5f2ce4bc31ae9",
+    "name": "tzjccXHCqt",
+    "symbol": "akWoo",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4999803",
+    "address": "0x576d8dde21606783959b3aa6ff687495bb98ad84",
+    "name": "YsWwoAFyzI",
+    "symbol": "PwkMR",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.4999991",
+    "address": "0x9d300ae38457e165cce0f09859061294e111eb0f",
+    "name": "pBPApmykGj",
+    "symbol": "aHYgT",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5000048",
+    "address": "0xcbb04a263627eb89029776c955c2b7d34581b9e4",
+    "name": "nNFZlJetWp",
+    "symbol": "EkWfC",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5000364",
+    "address": "0x0c3a688d984786842711f69579eb9b637cf2010c",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.5001835",
+    "address": "0x34ae6654d745be7503619d13dab52d8b27cc405e",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.5001855",
+    "address": "0x783453e87152ce428261deb5f5556d5c5d86a55f",
+    "name": "ChainShare",
+    "symbol": "CST",
+    "totalSupply": 1000000000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.5001873",
+    "address": "0xa0e9d071d1b2d321dd838c02027e0cd6e453b37e",
+    "name": "ChainShare",
+    "symbol": "CST",
+    "totalSupply": 1000000000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.5001882",
+    "address": "0xe74995606d555505a881c19b16115135226965d6",
+    "name": "ChainShare",
+    "symbol": "CST",
+    "totalSupply": 1000000000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.5001883",
+    "address": "0xd235e1a785572d5c6b4d0a4cbd7416f8c10eb474",
+    "name": "ChainShare",
+    "symbol": "CST",
+    "totalSupply": 1000000000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.5001889",
+    "address": "0x1776c0ebeca2e51f03c4d0460853bde41f48309e",
+    "name": "ChainShare",
+    "symbol": "CST",
+    "totalSupply": 1000000000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.5001926",
+    "address": "0x9ded2cc489d72158c53456612db697b9ccf4b337",
+    "name": "ChainShare",
+    "symbol": "CST",
+    "totalSupply": 1000000000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.5001961",
+    "address": "0x06dbd00b17d49f6b45eeb697297536480a99131a",
+    "name": "ChainShare",
+    "symbol": "CST",
+    "totalSupply": 1000000000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.5001971",
+    "address": "0x9e7ac8a732608054254acf3562dfbfe7d2a5811f",
+    "name": "ChainShare",
+    "symbol": "CST",
+    "totalSupply": 1000000000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.5001979",
+    "address": "0xf08a9bdfb9f94a3804afedb453de344cec53c160",
+    "name": "ChainShare",
+    "symbol": "CST",
+    "totalSupply": 1000000000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.5001983",
+    "address": "0x6620aee0f98b7011425d8ba2fcca026f6e4e655f",
+    "name": "ChainShare",
+    "symbol": "CST",
+    "totalSupply": 1000000000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.5001984",
+    "address": "0x410453b045e82ed59fe013f17465f3cda0139ced",
+    "name": "ChainShare",
+    "symbol": "CST",
+    "totalSupply": 1000000000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.5002048",
+    "address": "0x705adf94f7e269a424fcc6c82848df497424db2f",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.5002358",
+    "address": "0x2e14e0f86b61669b5f57c145c8c0e4b7e4832538",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.5002386",
+    "address": "0x13319de4278c9805c1343151b748bd3da4e347b0",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.5002420",
+    "address": "0xd0c0eec9cde0c239aaa8cde3b01497ce807ee438",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.5006126",
+    "address": "0xe53f8e8a492e85e87ae553acfb676ceff50740a6",
+    "name": "Test USDC",
+    "symbol": "USDC",
+    "totalSupply": 1000000000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.5006127",
+    "address": "0xe71c57852392123bbe527a16271d2e6395c66e8b",
+    "name": "Test WETH",
+    "symbol": "WETH",
+    "totalSupply": 1e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5006132",
+    "address": "0x38288e03211fd049d9a10ec72333d121ebda8178",
+    "name": "Test USDC",
+    "symbol": "USDC",
+    "totalSupply": 1000000000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.5006133",
+    "address": "0x6d9ce2322a73d550465110c62d57018d085869f5",
+    "name": "Test WETH",
+    "symbol": "WETH",
+    "totalSupply": 1e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5006139",
+    "address": "0xe7cba446621716e949e770204c6d672c66e62ab1",
+    "name": "Test USDC",
+    "symbol": "USDC",
+    "totalSupply": 1000000000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.5006140",
+    "address": "0x7962b4470e061d82412b4112d2dab68e02ad81cf",
+    "name": "Test WETH",
+    "symbol": "WETH",
+    "totalSupply": 1e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5006577",
+    "address": "0x20e11c584e5f30bb48cbf452b20acb9e2d4a843c",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 1100,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5015607",
+    "address": "0x48ccf1bddab7cd163012e12b29d3848b63c70bbb",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5015610",
+    "address": "0x69a37e0d73887a7454e7c9a8f0a53e190feb0254",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5015613",
+    "address": "0x32ae4a54ee5556372ceea22eb3a0aa27e315d92a",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5015615",
+    "address": "0x63fcb63766a7894bec1d0e5eadbf0ca8b2f65ea7",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5015617",
+    "address": "0x58b8b28dcadcf5aa2f43e9010a14ccb12435fa74",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5015622",
+    "address": "0xb74565ec7ba8bce5a22d59f41f055aa38d1fdcec",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5016071",
+    "address": "0xf94ccae94788880d68a84386db2d4eaa3b3e0b4c",
+    "name": "qwJrcnTgay",
+    "symbol": "HEyNa",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5016213",
+    "address": "0x5ea2a0e340dc66734be75ce8fd139cdf8177928d",
+    "name": "UxrulBeOFP",
+    "symbol": "UNTTF",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5016265",
+    "address": "0xb0a8ee25b0b725175faf7ffeb63a6b3c2b0828c5",
+    "name": "AGQnHVdLzh",
+    "symbol": "qCDjF",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5016362",
+    "address": "0x206275debbe153b85df0b1043ed2d2ecfd314fe0",
+    "name": "TqvKrcBVIZ",
+    "symbol": "LFdMZ",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5016428",
+    "address": "0xebd8d98d65cedf22af197094011637c75b92dc0d",
+    "name": "lPDqmNMbEp",
+    "symbol": "yFuhL",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5018171",
+    "address": "0x758f28218db83125c3a3cd723222b76011d68dc6",
+    "name": "ChainShare",
+    "symbol": "CST",
+    "totalSupply": 1000000000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.5019240",
+    "address": "0x2cb4ecc4f90a07174bc44a22453ba512527c2754",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5019242",
+    "address": "0xf5c86fb2e683fb848371787c7e911569ab62f325",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5019246",
+    "address": "0xc4f5c5b84aa2c1fd1bdb59bdbf8e4146aa38cea1",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5019248",
+    "address": "0xea40f8959e3bb8158f3b0cb817bf6d2c992e0e9f",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5019252",
+    "address": "0x062309f36566f163cfe2eb48689f149734a6359b",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5019257",
+    "address": "0x3b63ecd5946594aa5391cd426bb534c1ce632a13",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5019277",
+    "address": "0x8c27fe8bed58fdd3c9d3a5c0a553975a10bc3c77",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5019281",
+    "address": "0x3f0147454e8d29680487694366125bd47fc9a030",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5019283",
+    "address": "0xe14a2cc2c814a37e241ee1be5a4c6c786af38146",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5019285",
+    "address": "0x735ffb03c8ccb2c1363eb41b364d64885fac1717",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5019287",
+    "address": "0x0dac8f8df42dcfc5848f36a3aa4b7aa636ea9b5b",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5019293",
+    "address": "0xe088634a10cf6c96fc7ccbde8af4561f4af44687",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5021752",
+    "address": "0x8e428d5c05811133c7ae6b60cbfc0c5732b74bfe",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5021758",
+    "address": "0x5d661ada3af3aa4ffe0e545cbd938de47097b857",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5021760",
+    "address": "0x5261dec3d2d1854d6b10c1833d2c426301f3aae9",
+    "name": "SpheraToken",
+    "symbol": "SPT",
+    "totalSupply": 2e+26,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5021761",
+    "address": "0x7db991f4884b68754ae175a0b17138c98b71986b",
+    "name": "SPoint",
+    "symbol": "SP",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5021793",
+    "address": "0xa0c0c93bf681d8fc40570b1768c3b95059534466",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5021797",
+    "address": "0xef035026dbc251226b3e84d98ac9af0d9081d632",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5022047",
+    "address": "0xab9261e2d7882f0e453209bcba1afdd99fe840c0",
+    "name": "SpheraToken",
+    "symbol": "SPT",
+    "totalSupply": 2e+26,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5022048",
+    "address": "0x48b2160edbdeac89c6a6c3d1c4cb9c7ef315777a",
+    "name": "SPoint",
+    "symbol": "SP",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5022265",
+    "address": "0x1e8653277c01d0c62d8447852bfe5662eeec4ba5",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 3000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5022291",
+    "address": "0x36f74006c55ffb83820e6e54b78eaebaac343624",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5022293",
+    "address": "0x1fdbf2233baea470dd1b646d4a9848aa9589962b",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5022298",
+    "address": "0x90fbf4af463ba422b76fac3f0c3caad9ca4f084b",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5022302",
+    "address": "0x9529e3008419e3e7372ac3b0918d56dc5482f530",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5022317",
+    "address": "0x3b5dcacca23894a20e170cfb2e5d9174d2d292d0",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5022346",
+    "address": "0xb2e5dce8fd1236363977b91bfb01d5b53bd1d29d",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5022356",
+    "address": "0x749dca5e85d6100ccbeac819a954ae84646a1446",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5022360",
+    "address": "0x53b77901e968c359772c1c96a913933f5688382f",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5022362",
+    "address": "0xd0eec02a78146098c0e3a200d6856bef64cbd2e1",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5022363",
+    "address": "0xec9d8e3c14392cbf255dcde3e0108be90e1d396c",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5022370",
+    "address": "0x9aeac4b1ebfeda077166bd0a81b60c129baf7cdf",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5022372",
+    "address": "0xa7cefed87cde3e432e391f89e511dcca298fcc15",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5022379",
+    "address": "0xb607e5258d5a341f734c0221a5986aa1c6bd949d",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5025518",
+    "address": "0xd7ef44e6892448a6ef7150fc84a0b66c5b53030a",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5025520",
+    "address": "0x711f6244b717590266da9f741fcffdd9773db9f2",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5025522",
+    "address": "0x286a643643a46df3e25d4cfbcd610a083282f44a",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5025524",
+    "address": "0x1a5b55ff8de33a53e866a2c368efa71004533baf",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5025529",
+    "address": "0xf4fd62ee66a057cfec65f24a1c76cf72f96bd895",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5025534",
+    "address": "0xe956be071d146fad9f505afe2939dc9338f19a9e",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5025765",
+    "address": "0x483ed5ea215ae812d214ba91f9ab67f54ddf12da",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5031046",
+    "address": "0xe1f4e90b6f61be6ad7e12992e73ff72c74756b70",
+    "name": "ERC20Mock",
+    "symbol": "E20M",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5031063",
+    "address": "0x72b006a818707f23230a3290beb9dfbb053879c5",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5031064",
+    "address": "0xd892df9f0a70288470d1fc6366ce85ab63cbb304",
+    "name": "tokenName",
+    "symbol": "tokenSymbol",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5032410",
+    "address": "0x3dfc1758a061bdbf3c2c850e13be7fdb43e2ca01",
+    "name": "Hedera",
+    "symbol": "HBAR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5032522",
+    "address": "0x8d05457158adf56545a81c5bd2eea068399439b7",
+    "name": "TestToken",
+    "symbol": "TEST",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5038587",
+    "address": "0xcc8e473692e11e95c5b252e04e01fa654fca9520",
+    "name": "TestCoin",
+    "symbol": "TECO",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5038688",
+    "address": "0xcef4d2ef99ea5d1935b4f64aea92db642a5de2af",
+    "name": "Hedera2",
+    "symbol": "HBAR2",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5038730",
+    "address": "0x79fb71d599fec95ce924efe337b40647b4fae002",
+    "name": "Hedera",
+    "symbol": "HBAR",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5039129",
+    "address": "0x137356d00692b44d4ac9b6468573744f4a7a54ed",
+    "name": "TestCoin2",
+    "symbol": "TSCO",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5048977",
+    "address": "0xd75b2304f534fa9e7d1fdd3cc423f14f714fca34",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5065023",
+    "address": "0xf7406f9220ff5ea7fcaf679548657443ac05f96b",
+    "name": "TLNVKBsHod",
+    "symbol": "wsdXD",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5065184",
+    "address": "0x0c265e4587056de0f49713e07c8716f6945dc636",
+    "name": "TXbeIgrBUQ",
+    "symbol": "sIIzd",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5065205",
+    "address": "0x493b009dab2959744b6677ad9f065619f3590686",
+    "name": "DICxhVexHE",
+    "symbol": "aOasU",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5065213",
+    "address": "0x9b45935b3376d7859bd64f44b31ab9cc3b480715",
+    "name": "EGHxURTWuK",
+    "symbol": "wjKDd",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5065855",
+    "address": "0x0d893fb055aa373cf857c062a211362da40b65db",
+    "name": "xdohTUmQES",
+    "symbol": "ZRksE",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5065968",
+    "address": "0xe6cd295e846157e6969eed093738b6c5b51a5651",
+    "name": "uWdxWYqCCJ",
+    "symbol": "fahlg",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5070502",
+    "address": "0x3ad59aab081413ed9330c1e0bb7dc98397af2f3c",
+    "name": "GVplMBnDxq",
+    "symbol": "UFvYo",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5073320",
+    "address": "0xc618ac389a172535b589fdd4ac127971166fbbe3",
+    "name": "iJVopORTZG",
+    "symbol": "IXEyP",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5079210",
+    "address": "0xf2d93cb6962a4a3ab7e3829c62a0498d6c0548b1",
+    "name": "cWFYDuEZMl",
+    "symbol": "vgwQF",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5079583",
+    "address": "0x528d0f52e613c076cf230153917f1126f1a6eb77",
+    "name": "fjacExyjvV",
+    "symbol": "uNmeY",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5079772",
+    "address": "0xc779e66d89113f8a01a4bad20731e4acd7cb2980",
+    "name": "WOnSfkBFia",
+    "symbol": "VDMix",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5079943",
+    "address": "0xf40165e2ee17520822f53fa7d0b462d4cd540576",
+    "name": "AHiZjnCHEB",
+    "symbol": "HMMAW",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5079957",
+    "address": "0x558f09cdae329591faacc9d0fd9ab1010099ddec",
+    "name": "gjZwFOaReg",
+    "symbol": "hakOb",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5080475",
+    "address": "0xa28e57f34681771fb1b394013eb39f9779b96f2a",
+    "name": "CbUOmbFqLP",
+    "symbol": "coSAX",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5081041",
+    "address": "0xa16b1a5d44b9ca4b183321e17119b5b107374cf5",
+    "name": "QZvAXtIbvX",
+    "symbol": "NKeXA",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5081452",
+    "address": "0x596854c38ab09053eb35b349ff05662ab6c0c6af",
+    "name": "zwUROqALiI",
+    "symbol": "QOtpH",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5081716",
+    "address": "0x9e6aef9906656c3a7dabe8f64cdc5e3773e539ab",
+    "name": "vQHyKBjEEN",
+    "symbol": "ycEFo",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5082662",
+    "address": "0x883345d8dec3224d1475f38b2bdeda6f82092dfd",
+    "name": "EkmOMrnbHD",
+    "symbol": "qSbSl",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5082921",
+    "address": "0x7b9bb79fda65ba7464ad50d866bb05f04e120287",
+    "name": "KmKYXYLNKX",
+    "symbol": "EAQYT",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5083498",
+    "address": "0xc81398703e3073afcf3c6bec0970fdfe9bfdb6c3",
+    "name": "szPBXFhctm",
+    "symbol": "GWOQg",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5083578",
+    "address": "0x51fe1027c8323647310844c3db4944f88a114360",
+    "name": "MuBjaIRAvW",
+    "symbol": "HckFw",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5089076",
+    "address": "0x35ec5503504b210c0b2eb9b6e6ce0b1951f5beaa",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5089079",
+    "address": "0x948a17c8283e6ce1aefdde089364cf67b9406812",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5089082",
+    "address": "0x7ab1d42363d9908d82509251f6f9417a8c2e8984",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5089084",
+    "address": "0xec556ae5d35754854d89c4f1389c9ecdd0e73256",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5089086",
+    "address": "0xa156277c99f26a25f4d8339a83446edeed916402",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5089090",
+    "address": "0x5c25d07a5a4d12d07d812fd44b77cf085e28b922",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5090853",
+    "address": "0x2ee250af32b2e8cfc0e1ec2574de6bcb0ae5e9b8",
+    "name": "iiyLIbFbpz",
+    "symbol": "CoHHJ",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5091221",
+    "address": "0x185e4e47e6ce8c0f9d22e7ef84ca3bb23d871c32",
+    "name": "zEALRIVath",
+    "symbol": "cKIql",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5091232",
+    "address": "0x89387bc7d26b1c541a018c01ed1bc8e30dd04b95",
+    "name": "OHgBaDOOcB",
+    "symbol": "jBAkI",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5091296",
+    "address": "0x68539642ab27f7aed798f5127dfde0bd54da5c44",
+    "name": "kyAfSQeJsa",
+    "symbol": "TAGMD",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5091644",
+    "address": "0xbeb10d525665f8606caf760b6a77a2a84439fbb6",
+    "name": "XHgqPxlRtl",
+    "symbol": "kZlea",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5091688",
+    "address": "0xb79a5f5fec439891744ea4b4171c7610a9d3554d",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5091692",
+    "address": "0xc2713ed656251a6a502d6c98d7d5a2bb4f5ee248",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5091696",
+    "address": "0xa3734eca2a3e712178102b15bbdebd302ffd8161",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5091700",
+    "address": "0xb230f8ca49b47349d88114995a62182efc557e78",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5091704",
+    "address": "0xc0754a09f6621eba399a37c8d77027fce46de995",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5091710",
+    "address": "0x85993ae003edf395050bb28315d4107bcdb4a9d9",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5091754",
+    "address": "0x70cf35d40939161d9058869c2f8eb4476bfa63c1",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5091758",
+    "address": "0x4144c8c6aa34919673fda80642a301c63cbb5682",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5091760",
+    "address": "0x3f34357ff0b8b2ee6eddbed96abcc1a0834a8122",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5091762",
+    "address": "0xf8260abac71057b24eddf2123b996d3ed0a56b92",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5091779",
+    "address": "0x9c4e2aae3ee3810f8e806ddc02d94f3059d6e624",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5091781",
+    "address": "0xa893de28280942646edf0f464971b633f779fdfc",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5091825",
+    "address": "0x83ca66201c7df6e3b69493cc10f9f83dd77435cd",
+    "name": "wHKKgBWiVC",
+    "symbol": "mvNQW",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5091863",
+    "address": "0x6ed9604ec63602ee81795f9b1dfbf1e56b21ab99",
+    "name": "TDXRKlxoEc",
+    "symbol": "zKGzM",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5092000",
+    "address": "0x35c1e7c1a27c98fb5d4c85ce93986bea41d0ed3d",
+    "name": "YYIYUPPMzI",
+    "symbol": "nLDlu",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5092143",
+    "address": "0xaddab6a77326dfc4f7ec34af30cbd9218b1f0439",
+    "name": "SFCaDLbDTN",
+    "symbol": "LKjvo",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5092371",
+    "address": "0x898656b4362ee310a3d0b9ac60d41ae8f4528805",
+    "name": "PlOZsxXRkR",
+    "symbol": "kFwzr",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5092438",
+    "address": "0xf5faced1bdd5788c743d1f4ed9a5bb837f8ab912",
+    "name": "NQALEpzVuZ",
+    "symbol": "RVCUk",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5092534",
+    "address": "0xe8076c216d165d551d31a9c035dd0750c549adb4",
+    "name": "EqujsvTwqt",
+    "symbol": "GCBcp",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5094936",
+    "address": "0x682c5c4aeb91e03b7b0b5b4d555ee9171ef61ce9",
+    "name": "ChainShare",
+    "symbol": "CST",
+    "totalSupply": 1000000000,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.5096711",
+    "address": "0x00000000000000000000000000000000004dc507",
+    "name": "My Token",
+    "symbol": "MTK",
+    "totalSupply": 50000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5098919",
+    "address": "0x94f9b44f1c06c27ac2a51159b65a47fbec2967de",
+    "name": "kHKPzZwgzJ",
+    "symbol": "ADdhw",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5099474",
+    "address": "0x4fa0e1e7f6aec479fe72a7d1a2e63dafe1860b40",
+    "name": "mirqFiOxNB",
+    "symbol": "vGgyS",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5099639",
+    "address": "0x6631dfa7a03a67acbb5efd876db543db2799726c",
+    "name": "QqyOyBiSfU",
+    "symbol": "WswTY",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5099718",
+    "address": "0xd2e919aec2cfae82e443fe7a3bed01560f6ed282",
+    "name": "lZaoJKuhgy",
+    "symbol": "UoNLX",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5099723",
+    "address": "0x2402df306f1f8b6f0efc37d8534c4c4f5e094589",
+    "name": "isgtqsTwKC",
+    "symbol": "rskUZ",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5099735",
+    "address": "0x7012cd531b8bcc6a42662ddd18c8c63ad70a0e0a",
+    "name": "BBxYzfQQsi",
+    "symbol": "umOLz",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5100290",
+    "address": "0x00000000000000000000000000000000004dd302",
+    "name": "Test",
+    "symbol": "TED",
+    "totalSupply": 1.1125468718515986e+77,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5101901",
+    "address": "0x2c0f22e1d4a00993fb25f41a0e399c0ce1de69ea",
+    "name": "EnergyToken",
+    "symbol": "energy",
+    "totalSupply": 700000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5102612",
+    "address": "0xb3b92169c98c9c15cf0d94e68b672bf33c45cd73",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5102620",
+    "address": "0x9c83db5826b2efb5f62a9a5598278baaa70a68a7",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5102621",
+    "address": "0x0bdc33bd4fdbf1e3a6d2ab4be45b5595326a03c0",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5102627",
+    "address": "0x64cc9fb74d4615bb69e11a9e93e858a8f33902b7",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5104594",
+    "address": "0x1efa560fa0d3ac45c6b0f7632f86e850d3741886",
+    "name": "imivDzaDCx",
+    "symbol": "xqQCL",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5104686",
+    "address": "0x00dd1cc4fd2a1d782471e8df053647bf6201e089",
+    "name": "VNVNAmPwJC",
+    "symbol": "NveBB",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5104793",
+    "address": "0x6a0da64b2dbd42541d48982159ec097b2b55356f",
+    "name": "FeeAmyGUQe",
+    "symbol": "NyyaD",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5105607",
+    "address": "0xee5b1bba00f294bc508c1c9c4f4858b921dd2ac4",
+    "name": "RVFPninPHF",
+    "symbol": "LVKUY",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5105650",
+    "address": "0x7ae8a1de3f8b79e37ac629e312edfe5ecb6b5aa6",
+    "name": "BgyXzVeuKy",
+    "symbol": "CZEWf",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5105763",
+    "address": "0xecdff491117890ac2ff5306a58b6185ba656abfc",
+    "name": "raNQgfeILW",
+    "symbol": "bjLaO",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5105818",
+    "address": "0x8278765b77006ec4ca4fb33782fb3481f3a4b8fc",
+    "name": "AUATSOQlRw",
+    "symbol": "oigaT",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5105964",
+    "address": "0x7187e8750529becc77b37e609e7bafb4a17c0cf2",
+    "name": "iCXeDOyXPE",
+    "symbol": "iWOFR",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5106151",
+    "address": "0xd1bd0b35c11012bc80d5a7cf73ca5f2200e2f0d6",
+    "name": "zauXWJSHcc",
+    "symbol": "zQoMr",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5106209",
+    "address": "0xdecfb8ab5b3b868288db11b8403e5525a5bdf93f",
+    "name": "EpOSeGYybL",
+    "symbol": "ffvBp",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5107373",
+    "address": "0x1449fcf9792a2aadb63638174d38bc1037b4aaa1",
+    "name": "OWlTeTuIXj",
+    "symbol": "ZVMHF",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5107441",
+    "address": "0x55bb49317f5ed68ea6da70a75554dc11a3a0cd1f",
+    "name": "AYwaaVEOtZ",
+    "symbol": "vIVJe",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5107533",
+    "address": "0x311d2072ad358f0c4d6422255eb4b6ad0e0ae715",
+    "name": "ZiDaDvlBQh",
+    "symbol": "RAovl",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5107679",
+    "address": "0x340319f9365bf4a509c2f42b9169902d8732f636",
+    "name": "xzEayloMzR",
+    "symbol": "uVFDt",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5107879",
+    "address": "0x02e4168562e4120ce365b940f2523b80265c92b4",
+    "name": "JEKOTTxwoY",
+    "symbol": "CPkde",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5107915",
+    "address": "0xbd1ce9778be1aaaef1bdae05c6319559fb81eb0c",
+    "name": "dZeWIBMfPk",
+    "symbol": "ueJry",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5107954",
+    "address": "0x8e74ec727bcbefc931ab1a833aecc52ca7b63c5f",
+    "name": "fFEeQPyxYR",
+    "symbol": "lcfQG",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5108252",
+    "address": "0xabb6131549993618cf4ea6888f79905206af0f74",
+    "name": "eNdTphDviY",
+    "symbol": "nbOCb",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5108334",
+    "address": "0xb1bb9a104b40a09077d4290473076e2bc142a728",
+    "name": "mBUWiPKdRw",
+    "symbol": "oEsfc",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5108424",
+    "address": "0xa1e368a47776f19b843a07c970df744203bcb7f2",
+    "name": "ClwCzpwehl",
+    "symbol": "psJsl",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5108501",
+    "address": "0x80e2c7140d3d0fb08939ca2cbcc27ce2c22c311e",
+    "name": "rSVadMIArH",
+    "symbol": "gLTkd",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5108542",
+    "address": "0x5fcf31c0bfabe90bd199c35d5c4be8d8210aaeed",
+    "name": "moRKCcCSsd",
+    "symbol": "UQbKP",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5108598",
+    "address": "0xd67449708aa6e43cb7b16e9e54e855322b1f77a3",
+    "name": "AcyhsnhXWl",
+    "symbol": "gSIHh",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5108663",
+    "address": "0x6df0b80fb4474fb7258ecf5f822c6fe8a0a03116",
+    "name": "rglacNssLv",
+    "symbol": "BguZs",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5108713",
+    "address": "0x3de237efbe2ace2cc7fab0338bebb715a5b4fdcb",
+    "name": "ysoBfltfjy",
+    "symbol": "BuUBy",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5110857",
+    "address": "0x3a56997d5be01d0cddfef038c31cfaf52ec9ad7e",
+    "name": "TSPPuuIXum",
+    "symbol": "ynBVp",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5111384",
+    "address": "0x08bb22ebc72ca33a0e7e2b427d2d830c787dc31c",
+    "name": "EvenTestToken",
+    "symbol": "ETT",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5112637",
+    "address": "0xa66b943967748a0bee663a290f1fdb47ae1062fa",
+    "name": "gvhbh",
+    "symbol": " mmmmm",
+    "totalSupply": 12,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.5114716",
+    "address": "0xdea1a560e8cbc447a87c62a4dd54cc646a54c21c",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5114730",
+    "address": "0xbf873f81bdcf07e00cbc932b334af41b32ca820b",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5114746",
+    "address": "0xcb089864a55840271fabc85c77f65744c9ee26ee",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5114992",
+    "address": "0x00000000000000000000000000000000004e0c70",
+    "name": "SimpleToken",
+    "symbol": "SIM",
+    "totalSupply": 50000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5117473",
+    "address": "0x82fb5ea0a46b42bbd76aabf2855eb147875f45e3",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5117555",
+    "address": "0xe5128308ce2229003282547f20a5b444c346897a",
+    "name": "",
+    "symbol": "",
+    "totalSupply": 0,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.5130248",
+    "address": "0x7b90f7a093c007dd5df756bdebf8fea6c5810d8b",
+    "name": "QNgIDDWsjf",
+    "symbol": "uuAdU",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5130640",
+    "address": "0x82ba3fa5b187d7c8769d1eea49262b6dbe850a74",
+    "name": "Kkrzkditij",
+    "symbol": "GEjbn",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5130652",
+    "address": "0xa9b633e254d58be53c9dfd4b0746cb06ba91d6e7",
+    "name": "QARLjAygUo",
+    "symbol": "JwYMm",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5130751",
+    "address": "0x35e2d448976d2a932ee088689c53b6c815b6062e",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5130753",
+    "address": "0x0ec268b4f114dfd27072623b5197ebae42e8a748",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5130755",
+    "address": "0x5346b88309389e68c114f023dcbf05dccccaf758",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5130758",
+    "address": "0xccd251da482b3d9e636a6528d625fe3af9f8044d",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5130760",
+    "address": "0x529f6f1f818875b97eef0f44110a361ca9756969",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5130770",
+    "address": "0x91e4fa6f9fdc07f362f671541a554d92009cd821",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5130776",
+    "address": "0x467b413ce848fc3139ad1fcc2434703b22f6bfe1",
+    "name": "AkZIkGdvWb",
+    "symbol": "pmHFc",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5130862",
+    "address": "0x85a18ebedd7e83fa229c6bfdda1b2401ef57acba",
+    "name": "COVZXAzACQ",
+    "symbol": "yOkVT",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5131349",
+    "address": "0x999d7c1d92584c4c83f2a5801467a35c72e5f162",
+    "name": "MFlPAVxxza",
+    "symbol": "rOSHv",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5134747",
+    "address": "0x3a86f02af05f6d5588f431244177ce3983be5014",
+    "name": "Mock Token",
+    "symbol": "MTK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5136211",
+    "address": "0x35496bdd1f86fa6bf0888af292a03d4448cbb53a",
+    "name": "hedera",
+    "symbol": "hbar",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5136835",
+    "address": "0x2622d2b15b2bd49110509ef53afa5ca53e1707a8",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5136838",
+    "address": "0x219a71afe5987e0eb7ba4b6e9b55d942b7ab4838",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5136840",
+    "address": "0xa6858dc5414016b0ff5ce529a45e6a759412d63e",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5136843",
+    "address": "0x9a5dc5323a21d44d797dfe6c34a14c5bcc846312",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5136845",
+    "address": "0x8e886282deb95f2fb588e0973b105e6f9e4f5392",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5136849",
+    "address": "0x676aa49b2c49616ee3e0f7c99570a8d28fa76800",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5136918",
+    "address": "0x40bcdfbc37a3b31131699fbd41068c61bc28ae6f",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5136920",
+    "address": "0x3c935cb3c2c8c229c37228205667db665b7f0bd8",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5136923",
+    "address": "0xe77d59618814a13dc999782959f703bb936c1f34",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5136925",
+    "address": "0x76d005679671c592f31f7c0ba8f037d34cf48fa2",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5136927",
+    "address": "0x0610c9cee6748d7bdb2130d7fa9845be3fb577d7",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5136935",
+    "address": "0x6f425ddc5bcb53b61a530592a536f81f5be36019",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5136957",
+    "address": "0x233581f46b6d91903e0ad1280c416fc425f5161c",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5136961",
+    "address": "0x75491dc121ec96b034f4a1fe83ed565c3074808c",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5136963",
+    "address": "0x10703a92f0d77a6659dcbcef5614881644e420f6",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5136965",
+    "address": "0xea97f3d4297c68d18d4c6ca54bc8261251beacac",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5136967",
+    "address": "0xf3aa61b12b2fec97b71784506080375499d97881",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5138401",
+    "address": "0xf663b68e92160ab87578e5998e64c6607667e26f",
+    "name": "USDC",
+    "symbol": "USDC",
+    "totalSupply": 2e+22,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.5141888",
+    "address": "0xfbdfb9f7aa811defcccd8223b0731adc2f2ea590",
+    "name": "SPoint",
+    "symbol": "SP",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5141890",
+    "address": "0xc77c1a62622576933d059b49320b8b089a8b85ef",
+    "name": "SPoint",
+    "symbol": "SP",
+    "totalSupply": 2450,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5143372",
+    "address": "0x00000000000000000000000000000000004e7b4c",
+    "name": "VRJAM Red",
+    "symbol": "VRJAM(RED#0)",
+    "totalSupply": 1e+27,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5150702",
+    "address": "0xa250aea16b9aed0996dd33d70d91536e523a9fc2",
+    "name": "aToken",
+    "symbol": "aToken",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.5150714",
+    "address": "0x0746891ca72d108ae51a3a01a4092e1e3761a4d9",
+    "name": "aToken",
+    "symbol": "aToken",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.5152307",
+    "address": "0x3e661b0e4f7c710b86ec8882747670c36add4c7b",
+    "name": "USDCMock",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5152319",
+    "address": "0x133aeccd2a77331c44d3e851aebcdcd25329d243",
+    "name": "USDCMock",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5152322",
+    "address": "0x3171ecdb31bd82e6bb33a47b9ecbb33f06bdb53c",
+    "name": "USDCMock",
+    "symbol": "USDC",
+    "totalSupply": 25000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5152370",
+    "address": "0x74e70297cac5496a9b467dac7aa30206e86b27f1",
+    "name": "USDCMock",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5152381",
+    "address": "0xf986fb2ae9407e4524bafd53d0f1df8da4d6d5ad",
+    "name": "USDCMock",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5155542",
+    "address": "0x47d15cb4fdf692c8adc1028c762a79f420e9a31c",
+    "name": "USDCMock",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5155558",
+    "address": "0xf444aea3e5505dbb6d6b301319db9d279516e20a",
+    "name": "USDCMock",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5155722",
+    "address": "0x276bab94cd3acdde0c5d05844fdde9b1327aad91",
+    "name": "USDCMock",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5155756",
+    "address": "0x23f6051ba0ea1800ee65cffdf0876c78262602c6",
+    "name": "USDCMock",
+    "symbol": "USDC",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5156224",
+    "address": "0xc5007507805aed33a405029deebbcdf2f567accd",
+    "name": "VRJAM Mock Token",
+    "symbol": "VRJAMMT",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5157521",
+    "address": "0xf38008465d951289b9607a170f60d56140eaad57",
+    "name": "hvcjdvjfh",
+    "symbol": "CBNMJHG9876",
+    "totalSupply": 100,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.5159314",
+    "address": "0xf09e72e3f562a141d5e24eaf7e90974d7727759d",
+    "name": "AToken",
+    "symbol": "AToken",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.5159742",
+    "address": "0x6031fd90c7ea5f2bf1638934c28c43eaf9fdb36b",
+    "name": "ERC20Mock",
+    "symbol": "ERC20",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5159861",
+    "address": "0x3dfb2a4a21410158a9493d8aa3532f6c13e45554",
+    "name": "AToken",
+    "symbol": "AToken",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.5159886",
+    "address": "0x87ce85553128057a7616b3d369b3670e29b9d22a",
+    "name": "ERC20Mock",
+    "symbol": "ERC20",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5159915",
+    "address": "0xbf8e1592da69a0a1cd8750b11bbf1c3415def401",
+    "name": "AToken",
+    "symbol": "AToken",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.5159929",
+    "address": "0xc0670a0f77c035db3f1b03ade68e1b754c588514",
+    "name": "AToken",
+    "symbol": "AToken",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.5160246",
+    "address": "0x0182e6f7bd487b7543fffca05fb8a69e0885ab93",
+    "name": "AToken",
+    "symbol": "AToken",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.5160271",
+    "address": "0xb258d29c50113fdc002cea49509d7c61028ebf01",
+    "name": "AToken",
+    "symbol": "AToken",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.5160311",
+    "address": "0xf014b970414602df2b293ef4f2d6b6f306cf2c1d",
+    "name": "AToken",
+    "symbol": "AToken",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.5162555",
+    "address": "0xd44ab223d637c2f681b57bea516c68590721c8de",
+    "name": "NextPad",
+    "symbol": "NXP",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5162562",
+    "address": "0x3245e1126960c926f06684fa6c3e4984ef0fa498",
+    "name": "NextPad",
+    "symbol": "NXP",
+    "totalSupply": 1.1e+25,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5166785",
+    "address": "0x9186f9becd750bdbc0f1e0cf2c6a4a4d70f646f3",
+    "name": "MyToken",
+    "symbol": "MTK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5166867",
+    "address": "0x08b3a952120c6490353e33d487a2ceb0bf235898",
+    "name": "MyToken",
+    "symbol": "MTK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5167488",
+    "address": "0x609f53f2688370f77270451ecf231b2539abe7bf",
+    "name": "AToken",
+    "symbol": "AToken",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.5168039",
+    "address": "0xdac8ab18a6f91ffccccc2a7b946bb8b347958483",
+    "name": "NextPad",
+    "symbol": "NXP",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5168042",
+    "address": "0xc6028afdedb9b7fa2eec03612d5f0d317bfbac15",
+    "name": "NextPad",
+    "symbol": "NXP",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5168044",
+    "address": "0x4b60d10995b658179e4d3fb18b5be5dfb0aa91bd",
+    "name": "NextPad",
+    "symbol": "NXP",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5168503",
+    "address": "0x090d12ad18584f08d54e3507ce5f549c5f740dae",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5170176",
+    "address": "0xa65b8d57665833514dd6a80757e6aff4e97f01b7",
+    "name": "EvenTestToken",
+    "symbol": "ETT",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5170180",
+    "address": "0x16b358250b4906ac3688e4a4434757f8248b61b3",
+    "name": "EvenTestToken",
+    "symbol": "ETT",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5170538",
+    "address": "0x7a39e4bf44de37206e615b35a08dd42bf1adb37e",
+    "name": "EvenTestToken",
+    "symbol": "ETT",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5170551",
+    "address": "0x40d19478ecb3812bcb81655533f767c9710fa1ae",
+    "name": "EvenTestToken",
+    "symbol": "ETT",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5172261",
+    "address": "0x6cc98aef6d83f418eeaa990723ef3806fb89739b",
+    "name": "aToken",
+    "symbol": "aToken",
+    "totalSupply": 0,
+    "decimals": 8
+  },
+  {
+    "contractId": "0.0.5178567",
+    "address": "0x0e38704205fcf15ec69ffa3225d9326acf166576",
+    "name": "Web3AdvertisingToken",
+    "symbol": "WAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5181400",
+    "address": "0x8476f6a77a8d044fc7fd497f0bcd8efbbbe92b34",
+    "name": "CDWhOEqeCB",
+    "symbol": "ZXKCp",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5181533",
+    "address": "0x6d0d8cc04e31ce00981bbdc1a3aaf96e3356222f",
+    "name": "RzcSONnivg",
+    "symbol": "BnSXR",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5182231",
+    "address": "0xba34d2cbc991b7e272add10339805c60274860e0",
+    "name": "yhVraIyofm",
+    "symbol": "ierJR",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5187568",
+    "address": "0x4ef1b4dda0cf222db21116473274ced9010030fe",
+    "name": "Web3AdvertisingToken",
+    "symbol": "WAT",
+    "totalSupply": 10000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5187573",
+    "address": "0x70e5e3cbe011dda5f48b42b2720a797674a6fc12",
+    "name": "Web3AdvertisingToken",
+    "symbol": "WAT",
+    "totalSupply": 10000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5187593",
+    "address": "0xdbd6c462ab91bf2524f0d2f59cac2cc0ebab5a9c",
+    "name": "Web3AdvertisingToken",
+    "symbol": "WAT",
+    "totalSupply": 10000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5187600",
+    "address": "0xb003363204584266f96fb136ba1148882ed58c3b",
+    "name": "Web3AdvertisingToken",
+    "symbol": "WAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5187607",
+    "address": "0x27d0643570e960d64b993225e1bd5c7b0a9e0895",
+    "name": "Web3AdvertisingToken",
+    "symbol": "WAT",
+    "totalSupply": 10000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5187616",
+    "address": "0xe4ae45ac396ceb2641b6c90aaf0cb0c7ac9bcd04",
+    "name": "Web3AdvertisingToken",
+    "symbol": "WAT",
+    "totalSupply": 10000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5187629",
+    "address": "0xeb3ecb1ad01173c500477d332b068cbb2201d0ee",
+    "name": "Web3AdvertisingToken",
+    "symbol": "WAT",
+    "totalSupply": 10000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5187636",
+    "address": "0x9050ce9cfc401f766c348c39723f73f93316bb0c",
+    "name": "Web3AdvertisingToken",
+    "symbol": "WAT",
+    "totalSupply": 10000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5187645",
+    "address": "0x6bd3d2b2ec66946852debc625e552eae5285a24f",
+    "name": "Web3AdvertisingToken",
+    "symbol": "WAT",
+    "totalSupply": 10000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5187649",
+    "address": "0x9d433d6fd0dc0a7e282b2c8afedb1251d17bdd40",
+    "name": "Web3AdvertisingToken",
+    "symbol": "WAT",
+    "totalSupply": 10000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5193306",
+    "address": "0x3c74f6c614ff2d76c40645f0a884d3c57871b532",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5193324",
+    "address": "0x6c5dc8d7a3eadc79c7ba970ec676a92ac8fc6e05",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL",
+    "totalSupply": 1000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5196807",
+    "address": "0x0e412120ee1c66000127563c36c6d6eb0e3518f8",
+    "name": "OFBZzGwnhw",
+    "symbol": "bepul",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5197017",
+    "address": "0x54d37a19b79c70b4bb605a7b948592b49cbcd15f",
+    "name": "puAatHXWnf",
+    "symbol": "SXbwI",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5197108",
+    "address": "0x4f92a9b2f0064bb8d21838b16b4af97d1aa73967",
+    "name": "WYxYdtZprK",
+    "symbol": "gQcDP",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5197201",
+    "address": "0xd7efa9e3ad0f23ebc07086f6f45b543dcbbe84e7",
+    "name": "ouBOqrnfUn",
+    "symbol": "FtAZE",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5197217",
+    "address": "0xd1fe977b2185c20d478b53f4f49d789ed9d076c5",
+    "name": "fOnCXdpKlG",
+    "symbol": "fdETv",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5197482",
+    "address": "0x404d805596f385264414823ae0ec237a780d961d",
+    "name": "mwLjLxKYiY",
+    "symbol": "zqdGG",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5197497",
+    "address": "0x9b7103c80e08326c1da848be5ccc5acc038cc201",
+    "name": "WFtYCrSEjC",
+    "symbol": "jjHMp",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5197503",
+    "address": "0x65e7093ef732035c2cacc73843b3cc4004e98a5f",
+    "name": "rJCgRGMpUb",
+    "symbol": "ghTUV",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5197512",
+    "address": "0x1287645efeed9440c73265ad160c524908d0116f",
+    "name": "MsWEMICYOv",
+    "symbol": "ePdbk",
+    "totalSupply": 10000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5199271",
+    "address": "0xabf174aefd6f20e872960673c544d683a0a40b98",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5199275",
+    "address": "0xc0053143cd0894a926eeb8b514b8afbc8f29eafd",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5199277",
+    "address": "0xdb3352ebc1f982d3e9d2c189d612203b50e60219",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5199280",
+    "address": "0x61149292b40f8094ffdb0a8a83b3d68e226930d7",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5199282",
+    "address": "0x9e386915e77b1ac8720ce7f2428993ddf32f24b9",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5199288",
+    "address": "0x566e96dec49602d74e925e406d8d6fd436139787",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5199890",
+    "address": "0xf293654bf273c38fdf22cae43459cffa13f93461",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5199893",
+    "address": "0xdf4bd47794b9bb3fd141c2845db4e688107274bf",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5199895",
+    "address": "0xbe25099b1bfbf522b2505467965125a13566ff3d",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5199898",
+    "address": "0x48e8465bcfd14ea3b4c8bc6e82153dbaec087d97",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5199900",
+    "address": "0x8ff9bf09f3b5805ff689baf493ab1505e5d26bcc",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5199905",
+    "address": "0xbc6820402b0ebedf7f820a14c3c0239ef3b72ddb",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5201455",
+    "address": "0x31ad28b141f35d66fa47a4405635f8c32f9edb6e",
+    "name": "EnergyToken",
+    "symbol": "energy",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5201522",
+    "address": "0x65226034d9e5b23c15649f4855880d2e8990fcd2",
+    "name": "EnergyToken",
+    "symbol": "energy",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5202614",
+    "address": "0x2e12182abcd151f8c65ed3a62e9a650211e7f863",
+    "name": "cfkm",
+    "symbol": "cnfjnc",
+    "totalSupply": 2,
+    "decimals": 0
+  },
+  {
+    "contractId": "0.0.5205695",
+    "address": "0x3d98a2f7dfdab3c09a28e95f5e49f26be87f7f95",
+    "name": "GreenToken",
+    "symbol": "GTN",
+    "totalSupply": 1.02e+21,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5206912",
+    "address": "0x66c51d4b514a4bc6a05b7fe3d827949ad9fe7ccd",
+    "name": "EnergyToken",
+    "symbol": "energy",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5206913",
+    "address": "0xb955ed01086fbe0a4b689704360406c80d5af985",
+    "name": "EnergyToken",
+    "symbol": "energy",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5207105",
+    "address": "0x9d4d5bc4b163703d6b5462b7b801220df66470fc",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5207107",
+    "address": "0xd382a1be132813d6402ed55e7905cb67121aecd3",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5207110",
+    "address": "0xe43c6412dba13b689b2bfa1191f4e461b9760319",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5207115",
+    "address": "0xb0304ebb54f595c0f0fea2c312366d8306a2e229",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5207118",
+    "address": "0x5e85dae125481012ce88fd99f04695fe037d3d50",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5207130",
+    "address": "0x2de764ee2ae42be445bc5c39f29a4bcbe6ebbf65",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5207147",
+    "address": "0x208c63c8524715c8620701218e3e83722c4745d1",
+    "name": "MockERC20",
+    "symbol": "MERC20",
+    "totalSupply": 0,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.5207178",
+    "address": "0xb9d847132998ab18855083fce275a6d0ee9cd642",
+    "name": "MockERC20",
+    "symbol": "MERC20",
+    "totalSupply": 66000000000000,
+    "decimals": 6
+  },
+  {
+    "contractId": "0.0.5207690",
+    "address": "0x3bfe80aaaba2093f432d5bdf8d7a280f92164985",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5207694",
+    "address": "0x11cdd1548a3a700d386b727a956c3304fdf32940",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5207697",
+    "address": "0x3067609cf3a2134ec9c0223f8802fe5d448b0e20",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5207700",
+    "address": "0x61a222cd7bbe5a284ab57ca12402c35af497c2ea",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5207705",
+    "address": "0xbec3e0a2f912df96c494f4f350d47219e27a9ccc",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5207718",
+    "address": "0x2ece801c22f6cafbb771284766a49c542f7b531e",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5214785",
+    "address": "0xedf92f2bbbd156e7ec0a0feeaa15ae32771b423f",
+    "name": "USD Coin",
+    "symbol": "USDC",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5214790",
+    "address": "0x03faaefdb9f29481ae097836eca53bbdf3a67742",
+    "name": "USD Coin",
+    "symbol": "USDC",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5215150",
+    "address": "0x12488dab6e53e767217567c8263ed79937f499ed",
+    "name": "USD Coin",
+    "symbol": "USDC",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5215151",
+    "address": "0xebcfafac45ccf888b635515144d72ea49d5f6c44",
+    "name": "Building Token",
+    "symbol": "BT",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5215474",
+    "address": "0xf0e9dee90913905aa59dcce506512f8c4f7b111a",
+    "name": "EnergyToken",
+    "symbol": "energy",
+    "totalSupply": 21000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5215597",
+    "address": "0x3f6cd8166510c2adc44bc32c6724183c6bdfd9c6",
+    "name": "USD Coin",
+    "symbol": "USDC",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5215601",
+    "address": "0xab1bd5af1b0be933a408430dd16505cfdfbb5c49",
+    "name": "Building Token",
+    "symbol": "BT",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5215686",
+    "address": "0x5d0fb7644a53c322813f27c1996b743d2239b4e1",
+    "name": "USD Coin",
+    "symbol": "USDC",
+    "totalSupply": 1000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5215688",
+    "address": "0x986b3163f9eda37e20bd1ee81fd0d9c0ed82088c",
+    "name": "Building Token",
+    "symbol": "BT",
+    "totalSupply": 1e+24,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5218155",
+    "address": "0x95b8eadeba7cde2bc89985d63f1995b8c1073402",
+    "name": "Buildings R US",
+    "symbol": "BRUS",
+    "totalSupply": 100000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5218204",
+    "address": "0xf0b1fcc74ff4091a1b99801538829e6729beed49",
+    "name": "Buildings R US",
+    "symbol": "BRUS",
+    "totalSupply": 100000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5218232",
+    "address": "0x0b04e8f5b8976c0cea71683d5bd381dba07d33d2",
+    "name": "Buildings R US",
+    "symbol": "BRUS",
+    "totalSupply": 100000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5218283",
+    "address": "0x64c9382f2827df37821e3894ba11bc01a524245b",
+    "name": "Buildings R US",
+    "symbol": "BRUS",
+    "totalSupply": 100000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5218336",
+    "address": "0x344df26401a0616b65aa41a34614c667143a822f",
+    "name": "Buildings R US",
+    "symbol": "BRUS",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5218338",
+    "address": "0xc672bb5251aac8a0bb15c9c7c7bee2019e91701e",
+    "name": "Buildings R US",
+    "symbol": "BRUS",
+    "totalSupply": 100000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5218557",
+    "address": "0x8fab902c6561513f271e4c700a734dc58ccf374b",
+    "name": "Buildings R US",
+    "symbol": "BRUS",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5218591",
+    "address": "0x31c2446de6fc0675b7bd3573bb8db7abd2c3f360",
+    "name": "Buildings R US",
+    "symbol": "BRUS",
+    "totalSupply": 100000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5218683",
+    "address": "0xe046b359fd6cdb5e3963388ea768b6c5c681a40f",
+    "name": "Buildings R US",
+    "symbol": "BRUS",
+    "totalSupply": 100000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5218707",
+    "address": "0x43c5014e7d28c3e549ba136fbb89d9a8f91455be",
+    "name": "Buildings R US",
+    "symbol": "BRUS",
+    "totalSupply": 100000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5218726",
+    "address": "0x08205daa6554f1ade85b359957a104822714884f",
+    "name": "Buildings R US",
+    "symbol": "BRUS",
+    "totalSupply": 200000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5218736",
+    "address": "0x0faa06ea94371500ee99360af14c679a76ad8570",
+    "name": "Uniswap V2",
+    "symbol": "UNI-V2",
+    "totalSupply": 20000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5219934",
+    "address": "0x352dd824833e82536778675e9ddaa7a2e5e7998a",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5223053",
+    "address": "0x28206dba10697e1e43730eac56f8c8b858beb7a8",
+    "name": "Dimension native token",
+    "symbol": "@Dimens",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5223059",
+    "address": "0x313a1b5ba28533f59edd45928981119c999f33c3",
+    "name": "Dimension native token",
+    "symbol": "@Dimens",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5229276",
+    "address": "0xf1e70338be01d939a05638450225477ace732084",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5229282",
+    "address": "0x6bdc8761f0a2f8f4ebcb62ae801d884c2eb155c0",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5229287",
+    "address": "0x50eedcb0963adf9c60252766499f4584fa774df4",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5229291",
+    "address": "0x04d7ae90043459e1dc13a3f87f9774352ebb3873",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5229315",
+    "address": "0xf3e57ddd56d9a386501dfa1fb181c573013537af",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5229317",
+    "address": "0x6b24816130b314a2f4be25b00dfdbb0f26f229dc",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5229341",
+    "address": "0x9df26fecf38e7891d405a9876336cc343a2acd07",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5229345",
+    "address": "0x9ebdd41d22806cf56dc322c24542a442038b4cf7",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5229352",
+    "address": "0x4c9fd794bcb813fddb4cfeeb7c01fd22bda6ddfe",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5229358",
+    "address": "0xfd4938ed9c1a077252c978ff014dc15aea450c2f",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5229360",
+    "address": "0x84389d3b3ddbddb31aa925734dd8521c603ef33c",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5232173",
+    "address": "0xb6fb788b2793cc542942cb908c8c864c5bcd86b0",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5232175",
+    "address": "0x88d40a78371e1d634d85e120a94bce38bc8c52f1",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5232177",
+    "address": "0x349a03d1b4c54bc9526707125b7f3740b5fea219",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5232179",
+    "address": "0x0075a05f6ab3d357d1ce001d08d27c51dda0a9eb",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5232182",
+    "address": "0xd7093a3c2ffd75235ca9fceb879396545986d3a6",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5232187",
+    "address": "0x75aba41cbddde0e544012440824d97e46eca2e30",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5234987",
+    "address": "0x0e9fb116b25e1eae87d50b4657955879712d04fc",
+    "name": "Hbarbarian",
+    "symbol": "HBB",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5234994",
+    "address": "0xd6428c24a6ebd9d9723eb68b142d31b09a51b226",
+    "name": "Hbarbar",
+    "symbol": "HBB",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5235093",
+    "address": "0xfb3b8de81edf2c35cfc99719e5c3b18a99b664f8",
+    "name": "usdc",
+    "symbol": "usdcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5235096",
+    "address": "0xd09586fb636c5ddb4ad8ef65cc0deeea4e54e23c",
+    "name": "wbtc",
+    "symbol": "wbtcl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5235098",
+    "address": "0x7f88585efa06737b78815254e10af3887a4abfd6",
+    "name": "weth",
+    "symbol": "wethl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5235100",
+    "address": "0x60c7a5b6ce0b8e83611803000d03d0f4ec18489e",
+    "name": "hbarx",
+    "symbol": "hbarxl",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5235103",
+    "address": "0x5d7491d5878e52896f023fb778b7ffc0e2b44c85",
+    "name": "xsauce",
+    "symbol": "xsauce",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5235109",
+    "address": "0xeb83e799b36d8e0dc1609717b2366c6a70a1b0ba",
+    "name": "hsuite",
+    "symbol": "hsuitel",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5237678",
+    "address": "0xc5aca5617f4e354a7af81db0a94de734643ffc2a",
+    "name": "ERC20Mock",
+    "symbol": "E20M",
+    "totalSupply": 1000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5237696",
+    "address": "0xebbdd6ff4f310fb4ba5717024413b0ed6351186d",
+    "name": "ERC20Mock",
+    "symbol": "E20M",
+    "totalSupply": 1000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5238680",
+    "address": "0x76b0fdc3c01ec50ee62418ea28683a49daa66d0d",
+    "name": "ERC20Mock",
+    "symbol": "E20M",
+    "totalSupply": 10000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5238736",
+    "address": "0x3a04e0b89704aed113631aeb83fbb18e2a741ee2",
+    "name": "ERC20Mock",
+    "symbol": "E20M",
+    "totalSupply": 10000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5238763",
+    "address": "0x1dd8113b6a410eaaac4f1541376420ae66063618",
+    "name": "Token A",
+    "symbol": "TKA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5238764",
+    "address": "0xf9d098ee003032b5e19bba83f46d0ac1ef3dae1e",
+    "name": "Token B",
+    "symbol": "TKB",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5239065",
+    "address": "0xe8336c425e66a596ec8b5efa926f94164878f72e",
+    "name": "Token A",
+    "symbol": "TKA",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5239067",
+    "address": "0xf47e070ccfbf97a2fcd546d45fb9ef8fa441286d",
+    "name": "Token B",
+    "symbol": "TKB",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5239114",
+    "address": "0xe224913cf8000aa27b7921098f43a0c6befefde2",
+    "name": "Buildings R US",
+    "symbol": "BRUS",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5239146",
+    "address": "0x258e387209c1dad478ca8f529f0785cce22e6b37",
+    "name": "Buildings R US",
+    "symbol": "BRUS",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5239365",
+    "address": "0x27648d06b0117fdd63b60411da18c9109325d3f9",
+    "name": "Web3AdvertisingToken",
+    "symbol": "WAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5239383",
+    "address": "0x137f1e528291522094dad8f266ecbedfc9de0a1e",
+    "name": "Web3AdvertisingToken",
+    "symbol": "WAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5239479",
+    "address": "0xe24db1b811b726d2c84a56f95d3c638ae44998ff",
+    "name": "Buildings R US",
+    "symbol": "BRUS",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5239481",
+    "address": "0xf8dc917ea027e95074641a1a23e8dfd9c5372b5c",
+    "name": "Web3AdvertisingToken",
+    "symbol": "WAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5239523",
+    "address": "0x520feb7180c1d845e26b9dc3788ae9ad67feee8c",
+    "name": "Web3AdvertisingToken",
+    "symbol": "WAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5239552",
+    "address": "0xa4b58b51e84cc4e651c2dfc98d5ef3c0f67482f4",
+    "name": "Web3AdvertisingToken",
+    "symbol": "WAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5239737",
+    "address": "0xdff48b0b92a36756036f04370bd571565c957afc",
+    "name": "Web3AdvertisingToken",
+    "symbol": "WAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5239761",
+    "address": "0x7d0543cf3103491e8a9c09858c64f2859ec9a515",
+    "name": "Web3AdvertisingToken",
+    "symbol": "WAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5239790",
+    "address": "0x5c82173f318beef3b0bf6846f71667466541e5a9",
+    "name": "Web3AdvertisingToken",
+    "symbol": "WAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5240231",
+    "address": "0x431bd4ad5b8c799fda8c490ae5b8a53b6791e830",
+    "name": "Web3AdvertisingToken",
+    "symbol": "WAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5240257",
+    "address": "0x2a8e4410fe559be6b20bd879096f513442082c01",
+    "name": "Web3AdvertisingToken",
+    "symbol": "WAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5240279",
+    "address": "0xef2f81f6ea6ddd9320a4d1884cbe2854ceb8c3a1",
+    "name": "Buildings R US",
+    "symbol": "BRUS",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5240303",
+    "address": "0x9e8cc8220e44b82dae13c94342a5198c721fe72f",
+    "name": "Buildings R US",
+    "symbol": "BRUS",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5240330",
+    "address": "0xff062851313bdf7b221f8a34380ec39d6ae78f10",
+    "name": "Buildings R US",
+    "symbol": "BRUS",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5240360",
+    "address": "0x707d74288d618e7c95055276a2a7fb920b05ab2e",
+    "name": "Web3AdvertisingToken",
+    "symbol": "WAT",
+    "totalSupply": 0,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5240740",
+    "address": "0x9fcc959285458848b82f1731463c7bc112becf65",
+    "name": "Test Token",
+    "symbol": "TST",
+    "totalSupply": 10000000000000000000,
+    "decimals": 18
+  },
+  {
+    "contractId": "0.0.5242180",
+    "address": "0x68ff7eb885f8682033c8eaa1c042d31bdeda53ba",
+    "name": "Web3AdvertisingToken",
+    "symbol": "WAT",
+    "totalSupply": 0,
+    "decimals": 18
+  }
+]

--- a/tools/erc-repository-indexer/erc-contract-indexer/erc-registry/testnet/erc-721.json
+++ b/tools/erc-repository-indexer/erc-contract-indexer/erc-registry/testnet/erc-721.json
@@ -1,0 +1,1826 @@
+[
+  {
+    "contractId": "0.0.2253617",
+    "address": "0x711f71190fb21163ac8805984815670c35ca87b7",
+    "name": "ERC721Mock",
+    "symbol": "E721M"
+  },
+  {
+    "contractId": "0.0.2953667",
+    "address": "0xeceea4dcd3bfc9e67f9ea04576f88d6eef9c97d0",
+    "name": "bguiz non fungible token",
+    "symbol": "BGZNFT"
+  },
+  {
+    "contractId": "0.0.3040443",
+    "address": "0x3564c7ff47d2ccfc63f2a8fa41d8b9732acf8b66",
+    "name": "bguiz non fungible token",
+    "symbol": "BGZNFT"
+  },
+  {
+    "contractId": "0.0.3040449",
+    "address": "0x07a3f68dba40e39d489a417078c15a484b782cc9",
+    "name": "bguiz non fungible token",
+    "symbol": "BGZNFT"
+  },
+  {
+    "contractId": "0.0.3541456",
+    "address": "0xf337004cc8bd87c04dbc4d5af6a2d3f2d2e9d4ba",
+    "name": "Hedera",
+    "symbol": "HBAR"
+  },
+  {
+    "contractId": "0.0.3568598",
+    "address": "0xb4fa5b4c84d11169b1764c1940d6a4559ae1c9a1",
+    "name": "Verify Me Please",
+    "symbol": "VMP"
+  },
+  {
+    "contractId": "0.0.3568600",
+    "address": "0xa3d45d51a8587c816270c128839cdb360ab7ad0f",
+    "name": "Verify Me Please",
+    "symbol": "VMP"
+  },
+  {
+    "contractId": "0.0.3571714",
+    "address": "0x0dd6b685e9e5b247cda688bc844935c2ba6c9bb9",
+    "name": "Verify Me Please",
+    "symbol": "VMP"
+  },
+  {
+    "contractId": "0.0.3571724",
+    "address": "0x9f75abb1f68cc85f29dc583ecece3e2c1715e31b",
+    "name": "Verify Me Please",
+    "symbol": "VMP"
+  },
+  {
+    "contractId": "0.0.3571726",
+    "address": "0xdc55e4bd2c01ea7ce4bc551f2ab8ec68d0e4ce9f",
+    "name": "Verify Me Please",
+    "symbol": "VMP"
+  },
+  {
+    "contractId": "0.0.3573243",
+    "address": "0xd73717eed14a54a0490fbc39bd48c121ad9011ad",
+    "name": "Verify Me Please",
+    "symbol": "VMP"
+  },
+  {
+    "contractId": "0.0.3573359",
+    "address": "0x6b1898484e6ec7e7123e747e0eab6fc50aaff4f5",
+    "name": "Mock Collection",
+    "symbol": "MCK"
+  },
+  {
+    "contractId": "0.0.3573393",
+    "address": "0xba5c6ab7e72025c82e7171a829b911c31e473c61",
+    "name": "Mock Collection",
+    "symbol": "MCK"
+  },
+  {
+    "contractId": "0.0.3575140",
+    "address": "0x3e0d8e5ad68d1fbd0574e5f7d3ef8fd078d609e8",
+    "name": "Test721",
+    "symbol": "TST721"
+  },
+  {
+    "contractId": "0.0.3575201",
+    "address": "0xaf472be92f956aa13a9f983e8b8b6100278d7ec2",
+    "name": "Test721",
+    "symbol": "TST721"
+  },
+  {
+    "contractId": "0.0.3678280",
+    "address": "0x0000000000000000000000000000000000382048",
+    "name": "FSW",
+    "symbol": "FSW"
+  },
+  {
+    "contractId": "0.0.3739398",
+    "address": "0xa9efd1253a630780522fad89099d780a19abcba4",
+    "name": "ERC721Mock",
+    "symbol": "E721M"
+  },
+  {
+    "contractId": "0.0.3832913",
+    "address": "0xba0838eaacfc7c196f86f0ef03a4318254442422",
+    "name": "AriConditionsCertificate",
+    "symbol": "AIR"
+  },
+  {
+    "contractId": "0.0.3981487",
+    "address": "0xed3bf24b602942c9890e85ba634bfbeab6d4af58",
+    "name": "ERC721Mock",
+    "symbol": "E721M"
+  },
+  {
+    "contractId": "0.0.4228634",
+    "address": "0x364d2f1d9f4860e554ccd2d8365670fd3b2e923a",
+    "name": "DEVICE_AIR_PURIFIER",
+    "symbol": "AIR_PURIFIER"
+  },
+  {
+    "contractId": "0.0.4228635",
+    "address": "0xdc928d513f3f93772d3806361c5a1cd53fe90069",
+    "name": "DEVICE_DRYER",
+    "symbol": "DRYER"
+  },
+  {
+    "contractId": "0.0.4228636",
+    "address": "0x9af0e9c4b2b3ba6f68d4c3cc93bfc92598cba03f",
+    "name": "DEVICE_REFRIGERATOR",
+    "symbol": "REFRIGERATOR"
+  },
+  {
+    "contractId": "0.0.4228637",
+    "address": "0xc701f6f2b9750fc3b3c5997e086d65abd7de372a",
+    "name": "DEVICE_WASHER",
+    "symbol": "WASHER"
+  },
+  {
+    "contractId": "0.0.4228670",
+    "address": "0x203d1dea8d2a041fe041e0b88d6698163088b7fa",
+    "name": "DEVICE_AIR_PURIFIER",
+    "symbol": "AIR_PURIFIER"
+  },
+  {
+    "contractId": "0.0.4228671",
+    "address": "0x0139f2d0a9dbe5d089d2b74b44296d40c73e1961",
+    "name": "DEVICE_DRYER",
+    "symbol": "DRYER"
+  },
+  {
+    "contractId": "0.0.4228672",
+    "address": "0xacbf9a2685e4452e2963f0672e3f3657d3ca2698",
+    "name": "DEVICE_REFRIGERATOR",
+    "symbol": "REFRIGERATOR"
+  },
+  {
+    "contractId": "0.0.4228673",
+    "address": "0x56f8ae4e83f40968933cb61114a26a5610dfc275",
+    "name": "DEVICE_WASHER",
+    "symbol": "WASHER"
+  },
+  {
+    "contractId": "0.0.4228803",
+    "address": "0x48f882d022cfa82cb85c347dcfda8ac6c682576d",
+    "name": "DEVICE_AIR_PURIFIER",
+    "symbol": "AIR_PURIFIER"
+  },
+  {
+    "contractId": "0.0.4228804",
+    "address": "0x209ec10b7f3bd9249af910b0d8a0ded0e30e293e",
+    "name": "DEVICE_DRYER",
+    "symbol": "DRYER"
+  },
+  {
+    "contractId": "0.0.4228805",
+    "address": "0x4559c1f8294806b764cdfee1b4214d8f3a566502",
+    "name": "DEVICE_REFRIGERATOR",
+    "symbol": "REFRIGERATOR"
+  },
+  {
+    "contractId": "0.0.4228807",
+    "address": "0x8fa66cae2809ce4acd73a75a811e2ffffaab144f",
+    "name": "DEVICE_WASHER",
+    "symbol": "WASHER"
+  },
+  {
+    "contractId": "0.0.4330140",
+    "address": "0xc507994046eba0d0f2d427c985086b3d6c98e067",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4338502",
+    "address": "0xea7f16d6af7e4b5d67469224d6e1e631c039c8ee",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4338559",
+    "address": "0x1899585e78222bdd5d5a28ecbd0d0ab0b6106be7",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4338579",
+    "address": "0xc0c3bb506249d0173ac691ecb32219cb20852336",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4338771",
+    "address": "0x4123313a5fa692677d0651ec6bd5a27fbfa94ac9",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4338776",
+    "address": "0x685881f728cc4213815fde40a0de087e5ffa00e8",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4338781",
+    "address": "0x4fa72347c70596d7f0cde48b02f55d7c2ab31ae1",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4339628",
+    "address": "0xe1e2325a800356742cc1b6cb76a1c99457ebacd2",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4384178",
+    "address": "0xf9dc3bf62df25c464f0cc3ca45b7db9e8c6b7d49",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4384341",
+    "address": "0x8854414be250d11d5d254be448139a0fe33cf86d",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4384436",
+    "address": "0x2d0af431a5e95e8f89523178d8781bdf30ba298b",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4384549",
+    "address": "0x5d577ca1b2630eb89476fce869dfd1c431a94e9e",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4386032",
+    "address": "0xc5a9d63fece1351aa8b78303736b2f5fe9480303",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4386074",
+    "address": "0x20eefd37ed7933fc749c0113f0df77e7ee58fd88",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4387804",
+    "address": "0x4c0b40e04e24b291eb2b1d1a98ad01ac77f4d7d8",
+    "name": "DUCND",
+    "symbol": "DUC"
+  },
+  {
+    "contractId": "0.0.4388503",
+    "address": "0xd3c024b04a55dad3c6fff0316310d92d68059471",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4388532",
+    "address": "0xf42b5300ebbe858a0819a52ad780fdd26fa80472",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4388626",
+    "address": "0xf3b50fe5a39c2933a648affdc075f1c2318c9913",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4388659",
+    "address": "0xd99940265fda9c38686eb206b567fba53708a61f",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4391005",
+    "address": "0x853721ba89f0fb85a29475a47625765a7fb2a73e",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4391110",
+    "address": "0x9e8be7d9cb95ada02801fa8696be876322adc70f",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4391246",
+    "address": "0x9af9036a8b94afbbeb7b359f47276bc47a7deea4",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4391306",
+    "address": "0x48899cf12217b302944762514d2aeb35311b1ea9",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4393715",
+    "address": "0x3a552f9a2972d8c309d78515b17be9890a705861",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4395618",
+    "address": "0xd6d4295b9555fccd530ba4f3dee21007ebeb8ebb",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4408269",
+    "address": "0x017004b19df19a85a76cb75c64c58015b9a62ccc",
+    "name": "VMO Group",
+    "symbol": "VMO"
+  },
+  {
+    "contractId": "0.0.4425184",
+    "address": "0x1a2e5201eedf887fbea0739234e03a03962f1ca3",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4425192",
+    "address": "0x5a1f226b8773c2e04b0e8318fbe6fa1783ed3104",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4425238",
+    "address": "0x7ca05d26475ccbf428a3b1793a103a129fcc40e7",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4425397",
+    "address": "0x7e50c825561a58501379517adb8adfe2fe5381a5",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4431592",
+    "address": "0xfabcc406d83b1d07e8e0e59660fa8b309003ca67",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4447066",
+    "address": "0xfad53dc4ef93baa4e3bbc5f2e437344894a71bee",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4447110",
+    "address": "0xe36def622d7315aa921dab70238d606f843822ae",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4447128",
+    "address": "0x4a798fd8683066668e59f3c453dd29804c703800",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4452162",
+    "address": "0xb75370bf228c2fbb6cadcdfe4f4fb9d7b75a5fbb",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4452232",
+    "address": "0xbf9b3aa9953b9525f38d9e764778a38f7b9d45d3",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4452304",
+    "address": "0xff3cbde4547b12027fba6c685f1b7640b9a25eb4",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4452404",
+    "address": "0xb6a50b15b7b0fa9000d19e199f41d7eacaddd85a",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4452513",
+    "address": "0xd33147c7eea071a920a9268fed5b5a9058b56131",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4452625",
+    "address": "0x0de36958bb113718f011f503d905d77804488fa6",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4452631",
+    "address": "0xe8254106c47fdabd402d2684ce217c02799f9d4c",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4452652",
+    "address": "0x05fe9925b03a7ece2bc635b9a9dfd317eb05873f",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4452669",
+    "address": "0x071f98f06c0c912d8d768c3290338ccb85f2925f",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4452721",
+    "address": "0xdd77d1dfac34e4ccc8093f950901f537106b0c57",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4452726",
+    "address": "0x9c0932879d2f4b255c3395b1a05de40fbb23a60e",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4452806",
+    "address": "0xba04719c4429999d95ec246e317eb839535e203b",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4452995",
+    "address": "0xe667a472780539ad2ed5e73686d837bfed97115f",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4453185",
+    "address": "0x7278c5408b52dcb1e66b740542b5e0170651690a",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4454895",
+    "address": "0x0b948d96b21f5f0eb7b692a11f642bb152690bd0",
+    "name": "erc721sbt",
+    "symbol": "sbt"
+  },
+  {
+    "contractId": "0.0.4457585",
+    "address": "0xfe47c153a8c27eaa5992197a70d7a367a462c3d7",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4457610",
+    "address": "0x0bfbdaec71382997b53273cdfccd36b0550f6acb",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4457622",
+    "address": "0xc0674f404b4780e8485cb73cf0d5011106d2c8ab",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4458118",
+    "address": "0x9636868f4d20d2ab1d9d55cf0b8be11604ad7f0e",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4458128",
+    "address": "0x4801da8928381f0ff16731d17bcbb23472ee7c41",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4458345",
+    "address": "0xc32d4b33b2c90cee95c08c8b7a6e73bd0d8dc94a",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4458365",
+    "address": "0x174b7135810789802fa8f1c325393c40965d3962",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4458506",
+    "address": "0x87521e5c6ca668633187364cb7d10e240dbbb728",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4458542",
+    "address": "0xb3278ba29bac52b174b3f135c2f6cc6384cf81f7",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4458624",
+    "address": "0x512803c26d52ab19b0bdafd543b04bbd1ab9e892",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4458740",
+    "address": "0x63b3086e2d9f93345c8830a137e59dfd058a05c4",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4459194",
+    "address": "0x4f73241845bc2f6f3e1fbcaca89b4b84eb3ef813",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4459233",
+    "address": "0x5d8be95cc70420ab10b1511495cd8bea8ab503de",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4461500",
+    "address": "0x33cadd94aa7755339eaec1534522fd9cc18cdba4",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4461558",
+    "address": "0x567bd2fbeaa27b1d250c74481dd636365d5a8fef",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4461600",
+    "address": "0x44cb8440e60a51266a5b52463d334dc6948400e0",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4469536",
+    "address": "0x58f792b9a02ed32294396b2ee7d4589cab7b3cd9",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4470495",
+    "address": "0x41e38b0a593d8b0dd7342fbe71e656a632540ce3",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4470518",
+    "address": "0x0270613d4e00bed4e9df987fda50d51d86cc6f0c",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4482657",
+    "address": "0x393a74eecccb201b4b20903bb9c7c89dbd8fa50c",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4487304",
+    "address": "0x6026a2bb5cd83496140912421f667f7358c42b0d",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4497032",
+    "address": "0xd32faeaa94e7015eaee0713a39551814c1a6d832",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4497075",
+    "address": "0xdca9b77f4b5d52ef216bec0eb0b47592a698c862",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4500147",
+    "address": "0xa7f68a2342881ac98e69997218e1c5d29184d9bd",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4500178",
+    "address": "0x3d532d0dd04b9d29476986dcb8f1c78d8cdf7e91",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4500200",
+    "address": "0x78c51633cfcaae5bb3e7455f9243fc8e848fff00",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4500246",
+    "address": "0x8a5fbc061eb607251cc48e5ba4056a1ec7d17823",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4500290",
+    "address": "0x196b5a1f36e94452d46423254fe2587d718c7fcf",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4500311",
+    "address": "0x62858d2766650875e12fa5b1482e52183dcfca59",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4512153",
+    "address": "0x3abd2e436c87b2ecc11604134761bdff0bebdf9b",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4521432",
+    "address": "0x0c813f64af07ea8bd489316b3add8a9a874f3df6",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4521696",
+    "address": "0x80c85b450d613087e5b908e55c9562475584142a",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4521735",
+    "address": "0xae29ce678c8b05c6f55ddd7b7a9aeb521604f0a7",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4559640",
+    "address": "0x22aa3197fcd37fdf25240f40c41b35008710bd0c",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4559822",
+    "address": "0x5fb1eb4eb896b95ec53a8275f4a3cc1e7d3bcc6e",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4559983",
+    "address": "0x16a0cafb0dcc6b6bbb0513f23fcc00721f41eb18",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4566624",
+    "address": "0xbe67b6d30a5f844360f119eb3ca98412fad834a4",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4566631",
+    "address": "0x382ad4a23df34b70155932368a22c05c8e432ddc",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4566652",
+    "address": "0x59c63b8bb4a5b0141e379f5556ae8e8fc363179b",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4566681",
+    "address": "0x8e86a53860886f90d874988ca2b9b639446127f9",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4569421",
+    "address": "0x34429d4211051910fe3c5e13b35d6013f2519d88",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4571281",
+    "address": "0x92fcc16f7d5bcf827260c75c9f6f9afcd93a235b",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4571286",
+    "address": "0xacaeb65728849c5ed245b3221c596eacc6dfd6fb",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4571398",
+    "address": "0xe3299156c33f0d1370b339bc1d4243955ce43fae",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4603076",
+    "address": "0x5f67524432be8c4bc27378904780ecb6e47ad14a",
+    "name": "Mock NFT",
+    "symbol": "MNFT"
+  },
+  {
+    "contractId": "0.0.4616056",
+    "address": "0x852d0f9905264ff3a2a198a410ccfca870b1c25f",
+    "name": "IvayloNFT",
+    "symbol": "IVZ"
+  },
+  {
+    "contractId": "0.0.4616079",
+    "address": "0x74f2c0dfb439d822c35cabcc374dcd89c07533a8",
+    "name": "IvayloNFT",
+    "symbol": "IVZ"
+  },
+  {
+    "contractId": "0.0.4622397",
+    "address": "0x6450e6dfe7631b73d3c114f2f25e439145d9dd37",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4622422",
+    "address": "0x3c3a7fe1f989078a6585222f6f066ee4565548a6",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4622445",
+    "address": "0x3525ca74c438f1773f4a832a69014d1a6b7cdcb1",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4622466",
+    "address": "0x000449a42ffd702b81acb2034b54122bd5bcd231",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4622506",
+    "address": "0xb050cefc67c3a44e7dcc8cb8a76b7934919581eb",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4622537",
+    "address": "0x64f1148e9a11ddf6ab2af8c71c5db1c20c16057a",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4622591",
+    "address": "0x3fb80a0872205d81beec4f573896df93160b8c13",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4622604",
+    "address": "0x8f6f2a06a4e3ac82d6ed1f505204bf2d38e3aa79",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4634218",
+    "address": "0xfab638a804c02dae72750ceeb7c8f34de2b541d5",
+    "name": "ERC721Mock",
+    "symbol": "E721M"
+  },
+  {
+    "contractId": "0.0.4638223",
+    "address": "0xf158f9bf9f4da624f03aaea615820c5a3f876afb",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4638259",
+    "address": "0xad3721ce44e7f113e9c9e1b0fbd8bf73eb770ed6",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4638279",
+    "address": "0x0d8cbc47e194a2dacc9912d3ff9a0c18e024d490",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4638299",
+    "address": "0x02ce5c8c4a4875283a8167c971158f6585a0114a",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4638322",
+    "address": "0x892b414f22ad051a9bc6b332e00c6eef0cc00f73",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4638355",
+    "address": "0x98e6c5d28a02dcf2e36f733cbe4c53ee619c5505",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4638382",
+    "address": "0xcdb7584ec4ff4c2765d5a8fdc2195c486bdd9197",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4638394",
+    "address": "0x7aa9c4bf2c8727353c6542963cccd4966d4659cd",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4638445",
+    "address": "0x068f52b847878edd7220b54c859b04e7ad1e4829",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4638509",
+    "address": "0x70e31134071465bba66b6de5e4872138dc886d6e",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4638534",
+    "address": "0x6c3b2bd4daf0662f843a60d9574b7502e735dc0d",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4640831",
+    "address": "0xa286e63090131dbf112ecd7c94a90f16cdbdd6d0",
+    "name": "Green Certificate NFT",
+    "symbol": "G-cert"
+  },
+  {
+    "contractId": "0.0.4640835",
+    "address": "0xab6c6e97177f48acfb6b8006d7e66316aa189d9a",
+    "name": "Green Certificate NFT",
+    "symbol": "G-cert"
+  },
+  {
+    "contractId": "0.0.4640838",
+    "address": "0x1aeb6dc7b475541434cce26e252fb0ba2a1392cd",
+    "name": "Green Certificate NFT",
+    "symbol": "G-cert"
+  },
+  {
+    "contractId": "0.0.4640840",
+    "address": "0xd59ac5425a916ddd97ca27104cdcc8373a3ceef0",
+    "name": "Green Certificate NFT",
+    "symbol": "G-cert"
+  },
+  {
+    "contractId": "0.0.4640845",
+    "address": "0x1b09e3fdf67c2e58ff8de1d646c84ba0e24b218c",
+    "name": "Green Certificate NFT",
+    "symbol": "G-cert"
+  },
+  {
+    "contractId": "0.0.4640848",
+    "address": "0x1e1218e99780a786cae931c1313825a11b5d0db1",
+    "name": "Green Certificate NFT",
+    "symbol": "G-cert"
+  },
+  {
+    "contractId": "0.0.4640857",
+    "address": "0x00d7a971088e43534830c33f4e07884e6379e8a0",
+    "name": "Green Certificate NFT",
+    "symbol": "G-cert"
+  },
+  {
+    "contractId": "0.0.4640859",
+    "address": "0x84f03411f93b1e275929105e4c8428597f63d66d",
+    "name": "Green Certificate",
+    "symbol": "G-cert"
+  },
+  {
+    "contractId": "0.0.4640863",
+    "address": "0x2f7b6edccd979caad6ff1477303285f73ad944c8",
+    "name": "Green Certificate",
+    "symbol": "G-cert"
+  },
+  {
+    "contractId": "0.0.4641870",
+    "address": "0xcc1c9b8b11c6304bace72c732943b63c0633d4a0",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4641899",
+    "address": "0x0cb95417c8d280e45f60b07bb7dc308c276357ca",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4641920",
+    "address": "0xab23d0434b0cf27b70a5aa7822ae409a7cfc7dbc",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4641932",
+    "address": "0xe3c2285043c9b42840570a6bb1a9c0d0168b54bf",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4641962",
+    "address": "0xe03445894fa46c7cd767dfa1b697a757f90a051f",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4642177",
+    "address": "0x96fdf630dde8f8a4b7dae736a39eaca94930eb76",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4642211",
+    "address": "0xf462c52edfc551086bd70f787ddf722caf21ce5d",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4642247",
+    "address": "0x7f27e4f7c32790f90ebb1a7c603fdf0faaf3a4ba",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4642257",
+    "address": "0x2c1f629c74bf3030d015bd985411cae4914f2097",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4642306",
+    "address": "0x6eaaf64cb6257eb77a4db87f238cf245fa8f5eb4",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4642332",
+    "address": "0x1bf1a4718c49c13e49957c706b98a3a2ff625157",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4642381",
+    "address": "0x464ae51951b24e37097ffe2764a54e8340721795",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4642447",
+    "address": "0x2bc7b2a5c535d1e81e6b99700c270676c495e427",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4642494",
+    "address": "0x353a4fa3a6f48d7bf565372363599f2aa4f88191",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4642506",
+    "address": "0x9b591f71ea1e09de03a0c764857867baed45acf7",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4642529",
+    "address": "0xaa4347428e964264a46201da36bb5e5a6d27d23a",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4642587",
+    "address": "0xee42b4c7de2e77c9bbc6ed732fcf2e7dfd90df82",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4642599",
+    "address": "0x2ab7b2f02d51b2ca62b2a5ef7bdf87ea63363360",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4642620",
+    "address": "0xc8ee7634cc5455101623dc5b051b7def54ef6541",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4642688",
+    "address": "0x757c7ce9cc34cc21859c63e9a7dcc5c0fba8abf7",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4642773",
+    "address": "0x70712a592b6484d9444adeda0ce4efc51f84c7d3",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4643898",
+    "address": "0x2c72b38fd3af5921cab6d1c93b4eb14bf2d62d2c",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4643942",
+    "address": "0x580759c3c98774850cafb318b252f644c4c82d68",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4646715",
+    "address": "0x237821d9372eb5003b0a25fffd79980acccc4a57",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4646766",
+    "address": "0x56753415acfd17f2956096163bbf0c71b58c4ab8",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4646938",
+    "address": "0x3992a15e915291bfa37203e8042b5235adf35e74",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4646976",
+    "address": "0x0aa47fc0a97d186b81ecf56961e17c8fdcbd2a19",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4647041",
+    "address": "0xb64fb56d5fad57ba4c3765f980f7d6c607df8af1",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4647090",
+    "address": "0xe7f387f7453b577d53fcb95289b0cecc7f59e20d",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4647093",
+    "address": "0x6599048d048998077ebd41aaed6fccb514942125",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4652490",
+    "address": "0x2f83a65a5ec22249f28102d4ce14f62f79fad7d0",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4652584",
+    "address": "0xcbfce2ded7f2765bba7a983f9d67c970ad3457e4",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4685319",
+    "address": "0x4f26dc37f009e3b9a3cfcef54ecc8b9064950156",
+    "name": "Tripera Coin",
+    "symbol": "TRIPER"
+  },
+  {
+    "contractId": "0.0.4743827",
+    "address": "0xeab3f4af681a9ff32f546225ae5a4d839766676c",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4743842",
+    "address": "0xd5be82bc2e9600fce21155d84aeb0b8fa647c967",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4753400",
+    "address": "0x2c5b486e09ff16ce00391dfce2f3b6d7726a3f59",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4754117",
+    "address": "0x2d6a5eea0790f90dbed7ab039ab214356acaea0a",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4754811",
+    "address": "0x76151e586ca0c2ea0927576696e1ebdd64520ad3",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4758308",
+    "address": "0x6f886d9711367a16b1400114018e5109a032e543",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4758955",
+    "address": "0xc0352a2a7b7723c4e3b0317fbce62d47efb77f59",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4759745",
+    "address": "0xcc3f0c4d11b69781bc54f7d621a658724745cc33",
+    "name": "ZkDNS",
+    "symbol": "ZDNS"
+  },
+  {
+    "contractId": "0.0.4801020",
+    "address": "0x856451302ebf8a35cd28dbcdcd4f57323d4f592d",
+    "name": "ZkDNS",
+    "symbol": "ZDNS"
+  },
+  {
+    "contractId": "0.0.4812512",
+    "address": "0x681308eeeaaf739a8ed2e27d20f4cf5a6c3d9866",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4812634",
+    "address": "0xe1fae71cfbcf6d9b02b9a2d75046aa5ac41c2934",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4814817",
+    "address": "0x1dfc13cecfd461ffb8e0ef1b69cf64954dabc7c2",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4826123",
+    "address": "0x7a6be9036e38e26f4fada636780dc6549146a0e0",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4826164",
+    "address": "0x07393919f015d921aaac94710e01c7b7d1cc4328",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4832926",
+    "address": "0xa7d31d3af7f670abac054f6421ec1e801236c6e1",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4833764",
+    "address": "0x1f76cb6abbe66ce773bb8e493d77f1a44abca3dd",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4834095",
+    "address": "0x1eb965f3d61aaada25836b94feafaeed5567090b",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4838139",
+    "address": "0x041dabc6ab2e573ebf823e0d0b1b60a4a683f40a",
+    "name": "DALL-E",
+    "symbol": "DLE"
+  },
+  {
+    "contractId": "0.0.4841797",
+    "address": "0xfbde160923b237cbd3b41fad6b33fdf7a86b1b13",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4841829",
+    "address": "0x360cf9b4eb92d338a3709fc265f799c318c67794",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4843932",
+    "address": "0x89646727d51d1412e67f190c99acf3450af4b9a3",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4843955",
+    "address": "0xd4e23f0ddcd9c5e44ea09e722402a4a2fc392440",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4844548",
+    "address": "0xfa3a4fef9ea3ae1ea71a6461f2be9116af3cd755",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4845077",
+    "address": "0xcf226b0a8ee81b5302e0d095c0847dea0fe25c9e",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4845099",
+    "address": "0x549333006d9a07869cfe8782ec7c8d12bc7c7b06",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4845133",
+    "address": "0xe0ca9cac22192e925c7d81a9002f924a4b1c7660",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4845141",
+    "address": "0xf6018fb719916054065682870e1c511c58dce58a",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4845146",
+    "address": "0xf4a2847e85b508f6eb5b1f0b575236fae8222f17",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4845161",
+    "address": "0x29a47c0de4544facb3ae73f9831d60550dd5dd89",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4845174",
+    "address": "0x98b067c145a1afd1731bee1a7e65e389b22c24b4",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4845213",
+    "address": "0x67e5ea8fef516dfccc097becd4a7d5231cfbd165",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4845239",
+    "address": "0xcade2dbcc2eff900b58d915ca83c8189f0a583ca",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4860418",
+    "address": "0x00000000000000000000000000000000004a2a02",
+    "name": "HBurn Dragon NFT",
+    "symbol": "HBurnDragonNFT"
+  },
+  {
+    "contractId": "0.0.4860422",
+    "address": "0x00000000000000000000000000000000004a2a06",
+    "name": "HBurn Viking NFT",
+    "symbol": "HBurnVikingNFT"
+  },
+  {
+    "contractId": "0.0.4860425",
+    "address": "0x00000000000000000000000000000000004a2a09",
+    "name": "HBurn Viking NFT",
+    "symbol": "HBurnVikingNFT"
+  },
+  {
+    "contractId": "0.0.4860457",
+    "address": "0x00000000000000000000000000000000004a2a29",
+    "name": "HBurn Dragon NFT",
+    "symbol": "HBurnDragonNFT"
+  },
+  {
+    "contractId": "0.0.4860461",
+    "address": "0x00000000000000000000000000000000004a2a2d",
+    "name": "HBurn Viking NFT",
+    "symbol": "HBurnVikingNFT"
+  },
+  {
+    "contractId": "0.0.4872107",
+    "address": "0xac3f8de7307a523c9e1e343cb5429a611cf5d30b",
+    "name": "Hederagon Access NFT",
+    "symbol": "HEDGon"
+  },
+  {
+    "contractId": "0.0.4875810",
+    "address": "0x2161ce4d28d757610c5a58b5eb8afda3cbd34434",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL"
+  },
+  {
+    "contractId": "0.0.4884155",
+    "address": "0x2f736f188a89dd0152ad17d5957774813aa58abb",
+    "name": "Hederagon Access NFT",
+    "symbol": "HEDGon"
+  },
+  {
+    "contractId": "0.0.4886060",
+    "address": "0x44ac076ad58b270d4f9a4dcf4b0b1105c107f0f4",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4886192",
+    "address": "0x4c703cd532be87875c30e9a9a394ce5ab6348a0c",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4887425",
+    "address": "0xa41bb31818236684c07baa44d100da40e3586857",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4887431",
+    "address": "0xe8e0e61ca6be799c9e478916a79243a6ab2ffdc0",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4887443",
+    "address": "0x40db7ebde0b56c0e0c78b7f72a1a1bbaa8e19016",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4887526",
+    "address": "0x1a78682bac67992502e40751a9755bd94ca23085",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4891796",
+    "address": "0xbb29f9fe45f598151608b79f992204f3d8f84abc",
+    "name": "asd",
+    "symbol": "ASDA"
+  },
+  {
+    "contractId": "0.0.4924252",
+    "address": "0xec297eb339825fb9ec9066013ff67b3c29b3bd24",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4926261",
+    "address": "0x6cebfdf4ecbd9f3fb5aacf97555b3cfc5451c2d0",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4926313",
+    "address": "0xb2050e6df92e9dd1422962ae107f27924533ea39",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4926353",
+    "address": "0xd9646ba2d49938b02a4c439ccf76dc04d4af1d2e",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4929356",
+    "address": "0x23798e1c2694af7043ec648c08732f7e1e654ce4",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4937870",
+    "address": "0x14d217a5199bb892f5319963d5613998d6423836",
+    "name": "nrih",
+    "symbol": "bruh"
+  },
+  {
+    "contractId": "0.0.4937872",
+    "address": "0xd32a25e5d3eb617fa26338d5c5893e3d70340653",
+    "name": "nrih",
+    "symbol": "bruh"
+  },
+  {
+    "contractId": "0.0.4937963",
+    "address": "0xf2479f551b9b8665c0731ad2ba769a0ebb83b774",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4944994",
+    "address": "0x7723afe244f887190bb21a41a17a83bdefdfa1b5",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4963983",
+    "address": "0x3c7b149ccec5b1776992e061716c77bb9461d689",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4964271",
+    "address": "0x3bca4f2128b3222f30ef40f4379620dd27a17db8",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4966025",
+    "address": "0x2c8967faa1addcce5d0fb6ee1d1e602246931bb7",
+    "name": "mishonft",
+    "symbol": "MNFT"
+  },
+  {
+    "contractId": "0.0.4966628",
+    "address": "0xec00a8fcbe2a0873bd18b822256f3a454bfae054",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4970619",
+    "address": "0x8d435061f53959897bc3358debba4279370b3944",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4987454",
+    "address": "0xed555bf46e8be6df12731a630c2173eccacdeb8c",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4987528",
+    "address": "0x6e4e517cbbd4520d7cdd4c789631cde0d2c6a655",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4992450",
+    "address": "0xebeadb299cb56138e53d7673be7ee42b0a31b79f",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4992479",
+    "address": "0x008249ac7cb1b53fc83bcf0c453243f6da7d357f",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.4999006",
+    "address": "0xbd023dc2c6ff20b582b8250e25f57f9f9afad3d0",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5015598",
+    "address": "0x131e9e6b9d64b93bd0a822827d81f8566fb13988",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5019229",
+    "address": "0x2f31bba800f417cfea132eb5eaa9836413c6c97e",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5019271",
+    "address": "0xc00741c393d756401f3032cf703813fb088b729a",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5025514",
+    "address": "0xde96dde39992b2f5cb9782641a680ffc9f49f9e4",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5031050",
+    "address": "0xff9b9bc5f9a2fd26d99faf8f8472211196c6d6f3",
+    "name": "ERC721Mock",
+    "symbol": "E721M"
+  },
+  {
+    "contractId": "0.0.5089038",
+    "address": "0x5a7d1a8c0fbe5669bb0ce39d416286bc8d644e11",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5089049",
+    "address": "0x7e4f902f99337f3125bdf2e7a2fe5eb99f1a5826",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5089057",
+    "address": "0xbf56a599ea06c69bb903ef0f42f25b3eb2c4933b",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5089064",
+    "address": "0x771c2697543d708d633bdbac03f1e2b46bf329a2",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5091677",
+    "address": "0xc9e84cf580bf370970f8b906ba20cc559edc98b3",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5091747",
+    "address": "0x04c74c14e307f2babcbfc04ee69a607cef67a8b9",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5091775",
+    "address": "0x385915b363c84161e8bf296978c71fe274a71039",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5112854",
+    "address": "0x606c607bf98f9ce24ff9802f91e4489c7c81bb98",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5117013",
+    "address": "0xd7296803564e66c794414e1238e2e65a3bed94a0",
+    "name": "tokenName",
+    "symbol": "TOKENSYMBOL"
+  },
+  {
+    "contractId": "0.0.5117019",
+    "address": "0xfb0949db562b3107b5eea15855bf951945c2fcac",
+    "name": "Token",
+    "symbol": "T"
+  },
+  {
+    "contractId": "0.0.5117732",
+    "address": "0xccb88b2468e0236f84182bd43fcb4c5af1bc466b",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5117763",
+    "address": "0x0971963dcb1e8e33a22936436a510a46e5f5afea",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5117784",
+    "address": "0x58ccbc0e44f77c41604ffc3cbb376bbb53755a75",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5117799",
+    "address": "0xa74de73e4d532961ebeeae2828fd008bade5a1e6",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5117941",
+    "address": "0x89cd118282d79f45c09be73d2c42c444e55514ab",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5117953",
+    "address": "0x512adbdf3f3f1f1cc53a0f15316982f21b54fc20",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5117978",
+    "address": "0x7fe480cb4c9e27f452366622df1631feeb7307d1",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5121179",
+    "address": "0x5cc75d1c5aff2f27d90d76503f7d49dc57080128",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5121191",
+    "address": "0x8c22751b11f53ccf91a508e33559d029097ee7c2",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5121221",
+    "address": "0xb90d82774d0c63734465c50955689b51928e0118",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5121555",
+    "address": "0xe02637eeffff4cbe51948b94a252e3b395863f88",
+    "name": "HandsonTestNFT",
+    "symbol": "HTNFT"
+  },
+  {
+    "contractId": "0.0.5130747",
+    "address": "0xd62779e879e1d6aab21f05d02912f0e8f679faf2",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5136829",
+    "address": "0xe2640d41c47817a1be23eb8543f0c8f0dce75d5a",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5136913",
+    "address": "0x03979c832453e54beaeb3699f08d9863077aa406",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5136950",
+    "address": "0x3074581c5fa5b684c1f8d7d6e9b7be8794472df9",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5182907",
+    "address": "0xb4777327bc008f26787ede8fd762c0357ea14c33",
+    "name": "FSCO | Declaration",
+    "symbol": "FSD"
+  },
+  {
+    "contractId": "0.0.5182911",
+    "address": "0x9e61ec619010e7fd6031c39d53d5d395a9cdb7b0",
+    "name": "FSCO | Proofs",
+    "symbol": "FSP"
+  },
+  {
+    "contractId": "0.0.5182914",
+    "address": "0x3a51ec1dbcbea82671c9ae11b3d627ac0a61ed56",
+    "name": "FSCO | Proof Links",
+    "symbol": "FSPL"
+  },
+  {
+    "contractId": "0.0.5182994",
+    "address": "0xd9490a80b0e4f47b8f12ca0c62684cbaacef0799",
+    "name": "FSCO | Declaration",
+    "symbol": "FSD"
+  },
+  {
+    "contractId": "0.0.5182996",
+    "address": "0x8f14099a2bfe155f50f0d5fe487f1b31065a1e55",
+    "name": "FSCO | Proofs",
+    "symbol": "FSP"
+  },
+  {
+    "contractId": "0.0.5199262",
+    "address": "0xb043892402bbe5c1e9246920ece6d9eadfe37a1c",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5199885",
+    "address": "0xe461689189e6ea5a3fc760ad19e89c726c28e9de",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5204933",
+    "address": "0x7f54a319b8fd39eb9914841af66c2ff98045e14b",
+    "name": "hedera",
+    "symbol": "HBAR"
+  },
+  {
+    "contractId": "0.0.5207096",
+    "address": "0xd2c8ed9c66feafa49cfc0f3bd57fabfc72bb3730",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5207684",
+    "address": "0xe6f73e349b2321797bd4aa961c1239e855ff197c",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5229271",
+    "address": "0x9333b458cab851aedccbe523fa530fde3533ba76",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5229308",
+    "address": "0x8055260874d74c054cbb020fd30295873dba7a57",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5229336",
+    "address": "0xafc4272b737cf15f8cc77eb4423a20c317da9d62",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5230766",
+    "address": "0x0a18c7c12710078164316cfff562b25c3c768837",
+    "name": "FSCO | Declaration",
+    "symbol": "FSD"
+  },
+  {
+    "contractId": "0.0.5230771",
+    "address": "0xdae85ad624b79a78540366940a6f160b27661f65",
+    "name": "FSCO | Proofs",
+    "symbol": "FSP"
+  },
+  {
+    "contractId": "0.0.5230778",
+    "address": "0x0b84b0b638facd6171df5f406579355800124088",
+    "name": "FSCO | Proof Links",
+    "symbol": "FSPL"
+  },
+  {
+    "contractId": "0.0.5232169",
+    "address": "0x6dd4cac261a4a9d39743ecc3fb91ffc77c47e120",
+    "name": "MyToken",
+    "symbol": "MTK"
+  },
+  {
+    "contractId": "0.0.5233269",
+    "address": "0x82004f2500f7af39139a38ffba03a039516283c8",
+    "name": "NON-FUNGI",
+    "symbol": "NF"
+  },
+  {
+    "contractId": "0.0.5235083",
+    "address": "0xc9414ef5aafce4bd7e3f1bf2d2b280105859af4d",
+    "name": "MyToken",
+    "symbol": "MTK"
+  }
+]

--- a/tools/erc-repository-indexer/erc-contract-indexer/erc-registry/testnet/next-pointer.json
+++ b/tools/erc-repository-indexer/erc-contract-indexer/erc-registry/testnet/next-pointer.json
@@ -1,0 +1,1 @@
+"/api/v1/contracts?limit=100&order=asc&contract.id=gt:0.0.5241396"


### PR DESCRIPTION
**Description**:  
This PR includes a collection of files containing token information for ERC-20 and ERC-721 tokens on the Hedera networks. It represents the final outcome of the ERC Registry project, which aims to index the entire network to identify ERC-20 and ERC-721 token contracts. The project also performs contract calls to the mirror node to retrieve detailed information about these tokens.  

Currently, this PR includes ERC contract data for both testnet and mainnet, up to 10/12/2024.

**Related issue(s)**:

Fixes #1074 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
