### PR TITLE
fix: modified `isErc` for better performance in ERC Registry tool

### DIFF
--- a/tools/erc-repository-indexer/erc-contract-indexer/package-lock.json
+++ b/tools/erc-repository-indexer/erc-contract-indexer/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "ahocorasick": "^1.0.2",
         "dotenv": "^16.4.5",
         "ethers": "^6.13.4"
       },
       "devDependencies": {
         "@hashgraph/sdk": "^2.55.0",
+        "@types/ahocorasick": "^1.0.0",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.10.1",
         "jest": "^29.7.0",
@@ -1673,6 +1675,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/ahocorasick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ahocorasick/-/ahocorasick-1.0.0.tgz",
+      "integrity": "sha512-FNLE6B+9Px4LfRX2bZHSSTFa8Du8RznF5fNX915Ovf+K+g0SljmcmO5u7SH+c3LmeCZwP03NgMb7p82c0+Vbrg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1843,6 +1852,12 @@
       "version": "4.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
       "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
+    },
+    "node_modules/ahocorasick": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ahocorasick/-/ahocorasick-1.0.2.tgz",
+      "integrity": "sha512-hCOfMzbFx5IDutmWLAt6MZwOUjIfSM9G9FyVxytmE4Rs/5YDPWQrD/+IR1w+FweD9H2oOZEnv36TmkjhNURBVA==",
       "license": "MIT"
     },
     "node_modules/ansi-escapes": {

--- a/tools/erc-repository-indexer/erc-contract-indexer/package.json
+++ b/tools/erc-repository-indexer/erc-contract-indexer/package.json
@@ -13,6 +13,7 @@
   "description": "ERC Contracts Indexer",
   "devDependencies": {
     "@hashgraph/sdk": "^2.55.0",
+    "@types/ahocorasick": "^1.0.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.1",
     "jest": "^29.7.0",
@@ -21,6 +22,7 @@
     "typescript": "^5.7.2"
   },
   "dependencies": {
+    "ahocorasick": "^1.0.2",
     "dotenv": "^16.4.5",
     "ethers": "^6.13.4"
   }

--- a/tools/erc-repository-indexer/erc-contract-indexer/src/utils/constants.ts
+++ b/tools/erc-repository-indexer/erc-contract-indexer/src/utils/constants.ts
@@ -69,10 +69,10 @@ export default {
       sighash: '0x95d89b41',
     },
   ],
-  ERC_STANDARD_SIGNATURE_REGEX: {
+  ERC_STANDARD_SIGNATURES: {
     /**
-     * The regex pattern for identifying an ERC-20 bytecode.
-     * Built on top of the following method and event signatures:
+     * The pattern for identifying ERC-20 bytecode, based on a set of method and event signatures
+     * as defined in the ERC-20 standard interface.
      *
      * Selectors (Methods):
      * - 'dd62ed3e': allowance(address _owner, address _spender) view returns (uint256 remaining)
@@ -87,16 +87,21 @@ export default {
      * - 'ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef': Transfer(address indexed _from, address indexed _to, uint256 _value)
      *
      * source: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.1.0/contracts/token/ERC20/IERC20.sol
-     *
-     * note: The `(?=...)` (positive lookahead operator) is used here to ensure that ALL the necessary selectors and topics exist at least once in the bytecode.
-     *       It doesn't consume characters but asserts that the given pattern (selector or topic) can be found somewhere in the bytecode.
      */
-    ERC20:
-      /(?=.*dd62ed3e)(?=.*095ea7b3)(?=.*70a08231)(?=.*18160ddd)(?=.*a9059cbb)(?=.*23b872dd)(?=.*8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925)(?=.*ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef)/,
+    ERC20: [
+      'dd62ed3e',
+      '095ea7b3',
+      '70a08231',
+      '18160ddd',
+      'a9059cbb',
+      '23b872dd',
+      '8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925',
+      'ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+    ],
 
     /**
-     * The regex pattern for identifying an ERC-721 bytecode.
-     * Built on top of the following method and event signatures:
+     * The pattern for identifying ERC-721 bytecode, based on a set of method and event signatures
+     * as defined in the ERC-721 standard interface.
      *
      * Selectors (Methods):
      * - '095ea7b3': approve(address _approved, uint256 _tokenId) payable
@@ -116,11 +121,21 @@ export default {
      * - 'ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef': Transfer(address indexed _from, address indexed _to, uint256 indexed _tokenId)
      *
      * source: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.1.0/contracts/token/ERC721/IERC721.sol
-     *
-     * note: The `(?=...)` (positive lookahead operator) is used here to ensure that ALL the necessary selectors and topics exist at least once in the bytecode.
-     *       It doesn't consume characters but asserts that the given pattern (selector or topic) can be found somewhere in the bytecode.
      */
-    ERC721:
-      /(?=.*095ea7b3)(?=.*70a08231)(?=.*081812fc)(?=.*e985e9c5)(?=.*6352211e)(?=.*42842e0e)(?=.*b88d4fde)(?=.*a22cb465)(?=.*01ffc9a7)(?=.*23b872dd)(?=.*8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925)(?=.*17307eab39ab6107e8899845ad3d59bd9653f200f220920489ca2b5937696c31)(?=.*ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef)/,
+    ERC721: [
+      '095ea7b3',
+      '70a08231',
+      '081812fc',
+      'e985e9c5',
+      '6352211e',
+      '42842e0e',
+      'b88d4fde',
+      'a22cb465',
+      '01ffc9a7',
+      '23b872dd',
+      '8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925',
+      '17307eab39ab6107e8899845ad3d59bd9653f200f220920489ca2b5937696c31',
+      'ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+    ],
   },
 };


### PR DESCRIPTION
**Description**:
This PR replaces the inefficient regex-based approach in the `isErc` method with the [**Aho-Corasick** algorithm](https://en.wikipedia.org/wiki/Aho%E2%80%93Corasick_algorithm), significantly improving performance when analyzing large bytecodes. Aho-Corasick is a string searching algorithm that builds a finite state machine for matching multiple patterns simultaneously. It processes the bytecode in linear time relative to the input size, ensuring drastically faster and more scalable analysis compared to the previous regex-based method.

### Performance Comparison

- **Regex-based approach**: 20 KB bytecode takes more than 3600 ms.
- **Aho-Corasick**: The same bytecode processed in under 3 ms.

[A unit test](https://github.com/hashgraph/hedera-smart-contracts/pull/1121/files#diff-d0b505661019f6658e9c6294d7078b9654c2a192c417fbe87180056f41fb8881R369-R391) has been added in this PR to verify the performance improvements.

**Related issue(s)**:

Fixes #1118

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
