### PR TITLE
feat: added support for ERC Registry tool to dynamically configure the number of contracts to scan per operation

### DIFF
--- a/.github/workflows/erc-registry-indexer.yml
+++ b/.github/workflows/erc-registry-indexer.yml
@@ -12,6 +12,9 @@ on:
       STARTING_POINT:
         description: 'Starting Point (e.g., a contractId, a contract address, ect.). Leave empty to start from the beginning or from last saved starting point.'
         required: false
+      SCAN_CONTRACT_LIMIT:
+        description: 'The maximum number of contracts to scan per operation, with a default value of 100. Accepts only numeric values between 1 and 100.'
+        required: false
 
 jobs:
   index-and-update:
@@ -41,6 +44,7 @@ jobs:
           echo "HEDERA_NETWORK=${{ github.event.inputs.HEDERA_NETWORK }}" >> ${{ env.INDEXER_PATH }}/.env
           echo "MIRROR_NODE_URL=${{ github.event.inputs.MIRROR_NODE_URL }}" >> ${{ env.INDEXER_PATH }}/.env
           echo "STARTING_POINT=${{ github.event.inputs.STARTING_POINT }}" >> ${{ env.INDEXER_PATH }}/.env
+          echo "SCAN_CONTRACT_LIMIT=${{ github.event.inputs.SCAN_CONTRACT_LIMIT }}" >> ${{ env.INDEXER_PATH }}/.env
 
       - name: Install Dependencies
         run: |

--- a/tools/erc-repository-indexer/docs/registry_design.md
+++ b/tools/erc-repository-indexer/docs/registry_design.md
@@ -53,6 +53,7 @@ The **ERC Contract Indexer** will:
   - `MIRROR_NODE_URL`: API URL for the Hedera mirror node.
   - `STARTING_POINT`: Starting contract ID or contract EVM address (or a `next` pointer from a previous run).
   - `ENABLE_DETECTION_ONLY`: A configuration flag that enables the detection of ERC contracts while bypassing registry updates, designed for analysis-only scenarios.
+  - `SCAN_CONTRACT_LIMIT`: Defines the maximum number of contracts to scan per operation, with a default value of 100. Accepts only numeric values within the range of 1 to 100. This setting overrides the `limit` parameter in the `next` link if one exists in storage. For example, if the `next` link in storage is `/api/v1/contracts?limit=100&order=asc&contract.id=gt:0.0.5294198` and `SCAN_CONTRACT_LIMIT` is set to 30, the link will be updated to `/api/v1/contracts?limit=30&order=asc&contract.id=gt:0.0.5294198`.
 
 ### Class Diagram
 

--- a/tools/erc-repository-indexer/erc-contract-indexer/README.md
+++ b/tools/erc-repository-indexer/erc-contract-indexer/README.md
@@ -42,6 +42,7 @@ The ERC Contract Indexer is a tool designed to facilitate the indexing and manag
 | `MIRROR_NODE_URL_WEB3`  | The URL for the Hedera Mirror Node Web3Module API, required only when `HEDERA_NETWORK` is set to `local-node`. | Any value                                                                                                                                                                                                                       |
 | `STARTING_POINT`        | The starting point for contract indexing.                                                                      | A Hedera contract ID (e.g., `0.0.369`), an EVM 20-byte address (e.g., `0x0000000000000000000000000000000000000369`), or a get contract list next pointer (e.g., `/api/v1/contracts?limit=100&order=asc&contract.id=gt:0.0.369`) |
 | `ENABLE_DETECTION_ONLY` | Enable detection of ERC contracts without updating the registry.                                               | Any                                                                                                                                                                                                                             |
+| `SCAN_CONTRACT_LIMIT`   | Specifies the maximum number of contracts to scan per operation. Defaults to 100.                              | Accepts numeric values ranging from 1 to 100.                                                                                                                                                                                   |
 
 Example configuration:
 

--- a/tools/erc-repository-indexer/erc-contract-indexer/example.env
+++ b/tools/erc-repository-indexer/erc-contract-indexer/example.env
@@ -1,6 +1,7 @@
 HEDERA_NETWORK=
 MIRROR_NODE_URL=
 ENABLE_DETECTION_ONLY=
+SCAN_CONTRACT_LIMIT=
 MIRROR_NODE_URL_WEB3= # only necessary for local-node
 SDK_OPERATOR_ID= # only necessary for acceptance test
 SDK_OPERATOR_KEY= # only necessary for acceptance test

--- a/tools/erc-repository-indexer/erc-contract-indexer/src/runner.ts
+++ b/tools/erc-repository-indexer/erc-contract-indexer/src/runner.ts
@@ -31,7 +31,8 @@ export const ercRegistryRunner = async () => {
   const registryGenerator = new RegistryGenerator();
   const contractScannerService = new ContractScannerService(
     configService.getMirrorNodeUrl(),
-    configService.getMirrorNodeUrlWeb3()
+    configService.getMirrorNodeUrlWeb3(),
+    configService.getScanContractLimit()
   );
   const byteCodeAnalyzer = new ByteCodeAnalyzer();
 

--- a/tools/erc-repository-indexer/erc-contract-indexer/src/services/config.ts
+++ b/tools/erc-repository-indexer/erc-contract-indexer/src/services/config.ts
@@ -60,16 +60,26 @@ export class ConfigService {
    */
   private readonly detectionOnly: boolean;
 
+  /**
+   * @private
+   * @readonly
+   * @property {number} scanContractLimit - The maximum number of contracts to scan per operation.
+   */
+  private readonly scanContractLimit: number;
+
   constructor() {
     this.network = process.env.HEDERA_NETWORK || '';
     this.mirrorNodeUrl = process.env.MIRROR_NODE_URL || '';
     this.mirrorNodeUrlWeb3 = process.env.MIRROR_NODE_URL_WEB3 || '';
     this.startingPoint = process.env.STARTING_POINT || '';
     this.detectionOnly = process.env.ENABLE_DETECTION_ONLY === 'true';
+    this.scanContractLimit = process.env.SCAN_CONTRACT_LIMIT
+      ? parseInt(process.env.SCAN_CONTRACT_LIMIT)
+      : 100;
     this.validateConfigs();
 
     console.log(
-      `Indexing process initiated: network=${this.network}, mirrorNodeUrl=${this.mirrorNodeUrl}, mirrorNodeUrlWeb3=${this.mirrorNodeUrlWeb3}, detectionOnly=${this.detectionOnly}`
+      `Indexing process initiated: network=${this.network}, mirrorNodeUrl=${this.mirrorNodeUrl}, mirrorNodeUrlWeb3=${this.mirrorNodeUrlWeb3}, detectionOnly=${this.detectionOnly}, scanContractLimit=${this.scanContractLimit}`
     );
   }
 
@@ -102,6 +112,16 @@ export class ConfigService {
     ) {
       throw new Error(
         `STARTING_POINT Is Not Properly Configured: startingPoint=${this.startingPoint}`
+      );
+    }
+
+    if (
+      isNaN(this.scanContractLimit) ||
+      this.scanContractLimit <= 0 ||
+      this.scanContractLimit > 100
+    ) {
+      throw new Error(
+        `SCAN_CONTRACT_LIMIT Is Not Properly Configured (should be a number from 1-100): scanContractLimit=${this.scanContractLimit}`
       );
     }
   }
@@ -158,7 +178,8 @@ export class ConfigService {
   private async resolveFromEvmAddress(): Promise<string> {
     const contractScanner = new ContractScannerService(
       this.mirrorNodeUrl,
-      this.mirrorNodeUrlWeb3
+      this.mirrorNodeUrlWeb3,
+      this.scanContractLimit
     );
     const contractResponse = await contractScanner.fetchContractObject(
       this.startingPoint
@@ -206,5 +227,13 @@ export class ConfigService {
    */
   getDetectionOnly(): boolean {
     return this.detectionOnly;
+  }
+
+  /**
+   * Retrieves the maximum number of contracts to scan per operation.
+   * @returns {number} The configured contract scan limit.
+   */
+  getScanContractLimit(): number {
+    return this.scanContractLimit;
   }
 }

--- a/tools/erc-repository-indexer/erc-contract-indexer/src/utils/helper.ts
+++ b/tools/erc-repository-indexer/erc-contract-indexer/src/utils/helper.ts
@@ -36,16 +36,28 @@ export class Helper {
   }
 
   /**
-   * Constructs a URL based on the provided `next` parameter. If `next` is null,
-   * it returns a default URL with query parameters for fetching contracts.
+   * Constructs a URL based on the provided `next` parameter. If `next` is not null,
+   * it updates the value of the `limit=` parameter in the URL using the provided `scanContractLimit`.
+   * If `next` is null, it returns a default URL with query parameters, including `scanContractLimit`
+   * and an ascending order for fetching contracts.
    *
-   * @param {string | null} next - The pagination token for the next set of results, or null to use default endpoint
-   * @returns {string} The complete URL to query the mirror node API
+   * @param {string | null} next - The pagination token for the next set of results, or null to use the default endpoint.
+   * @param {number} scanContractLimit - The limit for the number of contracts to fetch, used to update or construct the URL.
+   * @returns {string} The complete URL to query the mirror node API.
    */
-  static buildUrl(next: string | null): string {
+  static buildUrl(
+    next: string | null,
+    scanContractLimit: number = 100
+  ): string {
     return next
-      ? next
-      : `${constants.GET_CONTRACT_ENDPOINT}?limit=100&order=asc`;
+      ? // Replace the value of the 'limit=' parameter in the URL with the given scanContractLimit.
+        // Regex explanation:
+        // - (limit=): Captures the exact string 'limit=' using a capture group.
+        // - \d+: Matches one or more digits following 'limit='.
+        // - `$1${scanContractLimit}`: Replaces the matched pattern with 'limit=' (from capture group) and the new value of scanContractLimit.
+        next.replace(/(limit=)\d+/, `$1${scanContractLimit}`)
+      : // If 'next' is null, construct a new URL with the scanContractLimit and order.
+        `${constants.GET_CONTRACT_ENDPOINT}?limit=${scanContractLimit}&order=asc`;
   }
 
   /**

--- a/tools/erc-repository-indexer/erc-contract-indexer/tests/unit/services/byteCodeAnalyzer.test.ts
+++ b/tools/erc-repository-indexer/erc-contract-indexer/tests/unit/services/byteCodeAnalyzer.test.ts
@@ -36,12 +36,14 @@ describe('ByteCodeAnalyzer', () => {
   const mockContractCallResponse = testConstants.MOCK_CONTRACT_CALL_RESPONSE;
   const mockValidMirrorNodeUrl = 'mock-mirror-node.com';
   const mockValidMirrorNodeUrlWeb3 = 'mock-mirror-node-web3.com';
+  const mockScanningLimit = 39;
 
   beforeEach(() => {
     byteCodeAnalyzer = new ByteCodeAnalyzer();
     contractScannerService = new ContractScannerService(
       mockValidMirrorNodeUrl,
-      mockValidMirrorNodeUrlWeb3
+      mockValidMirrorNodeUrlWeb3,
+      mockScanningLimit
     );
   });
 

--- a/tools/erc-repository-indexer/erc-contract-indexer/tests/unit/services/config.test.ts
+++ b/tools/erc-repository-indexer/erc-contract-indexer/tests/unit/services/config.test.ts
@@ -205,4 +205,40 @@ describe('ConfigService', () => {
     const configService = new ConfigService();
     expect(configService.getDetectionOnly()).toEqual(false);
   });
+
+  it('should return default value, 100, if SCAN_CONTRACT_LIMIT is undefined', async () => {
+    process.env.HEDERA_NETWORK = mockValidHederaNetwork;
+    process.env.MIRROR_NODE_URL = mockValidMirrorNodeUrl;
+    delete process.env.SCAN_CONTRACT_LIMIT;
+
+    const configService = new ConfigService();
+
+    expect(configService.getScanContractLimit()).toEqual(100);
+  });
+
+  it('should return dynamic SCAN_CONTRACT_LIMIT value', async () => {
+    process.env.HEDERA_NETWORK = mockValidHederaNetwork;
+    process.env.MIRROR_NODE_URL = mockValidMirrorNodeUrl;
+
+    const expectedLimit = 36;
+    process.env.SCAN_CONTRACT_LIMIT = expectedLimit.toString();
+
+    const configService = new ConfigService();
+
+    expect(configService.getScanContractLimit()).toEqual(expectedLimit);
+  });
+
+  it('should throw an error if SCAN_CONTRACT_LIMIT is set to invalid values', async () => {
+    process.env.HEDERA_NETWORK = mockValidHederaNetwork;
+    process.env.MIRROR_NODE_URL = mockValidMirrorNodeUrl;
+
+    const invalidLimits = ['-3', '369', 'not a number'];
+    invalidLimits.forEach((limit) => {
+      process.env.SCAN_CONTRACT_LIMIT = limit;
+
+      expect(() => {
+        configService = new ConfigService();
+      }).toThrow(/SCAN_CONTRACT_LIMIT Is Not Properly Configured/);
+    });
+  });
 });

--- a/tools/erc-repository-indexer/erc-contract-indexer/tests/unit/services/contractScanner.test.ts
+++ b/tools/erc-repository-indexer/erc-contract-indexer/tests/unit/services/contractScanner.test.ts
@@ -42,6 +42,7 @@ const mockedHelper = Helper as jest.Mocked<typeof Helper>;
 describe('ContractScannerService', () => {
   const mockValidMirrorNodeUrl = 'mock-mirror-node.com';
   const mockValidMirrorNodeUrlWeb3 = 'mock-mirror-node-web3.com';
+  const mockScanningLimit = 39;
 
   let contractScannerService: ContractScannerService;
 
@@ -53,7 +54,8 @@ describe('ContractScannerService', () => {
 
     contractScannerService = new ContractScannerService(
       mockValidMirrorNodeUrl,
-      mockValidMirrorNodeUrlWeb3
+      mockValidMirrorNodeUrlWeb3,
+      mockScanningLimit
     );
   });
 

--- a/tools/erc-repository-indexer/erc-contract-indexer/tests/unit/utils/helper.spec.ts
+++ b/tools/erc-repository-indexer/erc-contract-indexer/tests/unit/utils/helper.spec.ts
@@ -1,0 +1,50 @@
+/*-
+ *
+ * Hedera Smart Contracts
+ *
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { Helper } from '../../../src/utils/helper';
+
+describe('Helper', () => {
+  describe('buildUrl', () => {
+    const mockNext =
+      '/api/v1/contracts?limit=100&order=asc&contract.id=gt:0.0.5294198';
+    const mockScanningLimit = 39;
+
+    it('Should build a default next url', () => {
+      const expectedDefaultNext = '/api/v1/contracts?limit=100&order=asc';
+      const defaultNext = Helper.buildUrl(null);
+      expect(defaultNext).toEqual(expectedDefaultNext);
+    });
+
+    it('Should return next link if provided', () => {
+      const nextLink = Helper.buildUrl(mockNext);
+      expect(nextLink).toEqual(mockNext);
+    });
+
+    it('Should return next link modified with scanningLimit if provided', () => {
+      const expectedNextLink = mockNext.replace(
+        '100',
+        mockScanningLimit.toString()
+      );
+
+      const nextLink = Helper.buildUrl(mockNext, mockScanningLimit);
+      expect(nextLink).toEqual(expectedNextLink);
+    });
+  });
+});


### PR DESCRIPTION
**Description**:
This PR introduces a new configuration parameter, `SCAN_CONTRACT_LIMIT`, to enhance the flexibility of the ERC Registry tool. Users can now dynamically configure the number of contracts scanned per operation, with a default value of 100 and a customizable range of 1 to 100.

Additionally, this setting overrides the `limit` parameter in the `next` link if one exists in storage or composed from `STARTING_POINT`. For example, if the `next` link is `/api/v1/contracts?limit=100&order=asc&contract.id=gt:0.0.5294198` and `SCAN_CONTRACT_LIMIT` is set to 30, the link will be updated to `/api/v1/contracts?limit=30&order=asc&contract.id=gt:0.0.5294198`.

**Related issue(s)**:

Fixes #1131

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
