### PR TITLE
fix: updated .github/release.yaml to include internal and github_action labeled PRs 

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -10,3 +10,5 @@ changelog:
       labels: ['documentation']
     - title: 'Dependency Upgrades'
       labels: ['dependencies']
+    - title: 'Internal Changes'
+      labels: ['internal', 'github_action']


### PR DESCRIPTION
**Description**:
This PR modified the .github/release.yaml to include `internal` and `github_action` labeled PRs

**Related issue(s)**:

Fixes #1137

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
