### PR TITLE
test: validate contract and admin key in hollow account finalized as contract

### DIFF
--- a/test/contract-admin-id/contractAdminId.js
+++ b/test/contract-admin-id/contractAdminId.js
@@ -1,3 +1,23 @@
+/*-
+ *
+ * Hedera Smart Contracts
+ *
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 const { expect } = require('chai');
 const { ethers } = require('hardhat');
 const utils = require('../system-contracts/hedera-token-service/utils');

--- a/test/contract-admin-id/contractAdminId.js
+++ b/test/contract-admin-id/contractAdminId.js
@@ -1,0 +1,38 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+const utils = require('../system-contracts/hedera-token-service/utils');
+const Constants = require('../constants');
+
+describe('Admin Key and Contract ID Validation', function () {
+  let signers;
+  let sdkClient;
+  let hollowWallet;
+
+  before(async function () {
+    signers = await ethers.getSigners();
+    sdkClient = await utils.createSDKClient();
+    hollowWallet = ethers.Wallet.createRandom().connect(ethers.provider);
+
+    await (
+      await signers[0].sendTransaction({
+        to: hollowWallet.address,
+        value: ethers.parseEther('100'),
+        gasLimit: 1_000_000,
+      })
+    ).wait();
+  });
+
+  it('should ensure that the admin key matches the contract ID after deploying the contract with the hollow account', async function () {
+    const factory = await ethers.getContractFactory(
+      Constants.Contract.Base,
+      hollowWallet
+    );
+    const contract = await factory.deploy();
+    const info = await utils.getContractInfo(contract.target, sdkClient);
+
+    const adminkey = info.adminKey.num;
+    const contractId = info.contractId.num;
+
+    expect(adminkey.equals(contractId)).to.be.true;
+  });
+});

--- a/test/contract-admin-id/contractAdminId.js
+++ b/test/contract-admin-id/contractAdminId.js
@@ -55,4 +55,15 @@ describe('Admin Key and Contract ID Validation', function () {
 
     expect(adminkey.equals(contractId)).to.be.true;
   });
+
+  it('should ensure that the admin key matches the contract ID after deploying a contract without finalizing a hollow address', async function () {
+    const factory = await ethers.getContractFactory(Constants.Contract.Base);
+    const contract = await factory.deploy();
+    const info = await utils.getContractInfo(contract.target, sdkClient);
+
+    const adminkey = info.adminKey.num;
+    const contractId = info.contractId.num;
+
+    expect(adminkey.equals(contractId)).to.be.true;
+  });
 });

--- a/test/contract-admin-id/contractAdminId.js
+++ b/test/contract-admin-id/contractAdminId.js
@@ -59,6 +59,9 @@ describe('Admin Key and Contract ID Validation', function () {
   it('should ensure that the admin key matches the contract ID after deploying a contract', async function () {
     const factory = await ethers.getContractFactory(Constants.Contract.Base);
     const contract = await factory.deploy();
+    
+    await contract.waitForDeployment();
+
     const info = await utils.getContractInfo(contract.target, sdkClient);
 
     const adminkey = info.adminKey.num;

--- a/test/contract-admin-id/contractAdminId.js
+++ b/test/contract-admin-id/contractAdminId.js
@@ -2,7 +2,7 @@
  *
  * Hedera Smart Contracts
  *
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ describe('Admin Key and Contract ID Validation', function () {
     expect(adminkey.equals(contractId)).to.be.true;
   });
 
-  it('should ensure that the admin key matches the contract ID after deploying a contract without finalizing a hollow address', async function () {
+  it('should ensure that the admin key matches the contract ID after deploying a contract', async function () {
     const factory = await ethers.getContractFactory(Constants.Contract.Base);
     const contract = await factory.deploy();
     const info = await utils.getContractInfo(contract.target, sdkClient);

--- a/test/system-contracts/hedera-token-service/utils.js
+++ b/test/system-contracts/hedera-token-service/utils.js
@@ -33,6 +33,7 @@ const {
   TokenUpdateTransaction,
   TokenAssociateTransaction,
   AccountBalanceQuery,
+  ContractInfoQuery,
 } = require('@hashgraph/sdk');
 const Constants = require('../../constants');
 
@@ -711,6 +712,14 @@ class Utils {
   static async getAccountInfo(evmAddress, client) {
     const query = new AccountInfoQuery().setAccountId(
       AccountId.fromEvmAddress(0, 0, evmAddress)
+    );
+
+    return await query.execute(client);
+  }
+
+  static async getContractInfo(evmAddress, client) {
+    const query = new ContractInfoQuery().setContractId(
+      ContractId.fromEvmAddress(0, 0, evmAddress)
     );
 
     return await query.execute(client);


### PR DESCRIPTION
**Description**:
Added test for admin key and contract id validation (should be the same) after deploying a contract with hollow account.

**Related issue(s)**:

Fixes #1007
