### PR TITLE
feat: split up hip 904 tests into 3 batches

### DIFF
--- a/.github/workflows/manual-testing.yml
+++ b/.github/workflows/manual-testing.yml
@@ -197,11 +197,29 @@ jobs:
       mirrorTag: ${{inputs.mirrorNodeTag}}
       relayTag: ${{inputs.relayTag}}
 
-  HIP904:
-    name: HIP904 Contract Test Suite
+  HIP904-Batch-1:
+    name: HIP904 Contract Test Suite Batch 1
     uses: ./.github/workflows/test-workflow.yml
     with:
-      testfilter: 'HIP904'
+      testfilter: 'HIP904-Batch-1'
+      networkTag: ${{inputs.networkNodeTag}}
+      mirrorTag: ${{inputs.mirrorNodeTag}}
+      relayTag: ${{inputs.relayTag}}
+
+  HIP904-Batch-2:
+    name: HIP904 Contract Test Suite Batch 2
+    uses: ./.github/workflows/test-workflow.yml
+    with:
+      testfilter: 'HIP904-Batch-2'
+      networkTag: ${{inputs.networkNodeTag}}
+      mirrorTag: ${{inputs.mirrorNodeTag}}
+      relayTag: ${{inputs.relayTag}}
+
+  HIP904-Batch-3:
+    name: HIP904 Contract Test Suite Batch 3
+    uses: ./.github/workflows/test-workflow.yml
+    with:
+      testfilter: 'HIP904-Batch-3'
       networkTag: ${{inputs.networkNodeTag}}
       mirrorTag: ${{inputs.mirrorNodeTag}}
       relayTag: ${{inputs.relayTag}}

--- a/.github/workflows/manual-testing.yml
+++ b/.github/workflows/manual-testing.yml
@@ -197,29 +197,29 @@ jobs:
       mirrorTag: ${{inputs.mirrorNodeTag}}
       relayTag: ${{inputs.relayTag}}
 
-  HIP904-Batch-1:
+  HIP904Batch1:
     name: HIP904 Contract Test Suite Batch 1
     uses: ./.github/workflows/test-workflow.yml
     with:
-      testfilter: 'HIP904-Batch-1'
+      testfilter: 'HIP904Batch1'
       networkTag: ${{inputs.networkNodeTag}}
       mirrorTag: ${{inputs.mirrorNodeTag}}
       relayTag: ${{inputs.relayTag}}
 
-  HIP904-Batch-2:
+  HIP904Batch2:
     name: HIP904 Contract Test Suite Batch 2
     uses: ./.github/workflows/test-workflow.yml
     with:
-      testfilter: 'HIP904-Batch-2'
+      testfilter: 'HIP904Batch2'
       networkTag: ${{inputs.networkNodeTag}}
       mirrorTag: ${{inputs.mirrorNodeTag}}
       relayTag: ${{inputs.relayTag}}
 
-  HIP904-Batch-3:
+  HIP904Batch3:
     name: HIP904 Contract Test Suite Batch 3
     uses: ./.github/workflows/test-workflow.yml
     with:
-      testfilter: 'HIP904-Batch-3'
+      testfilter: 'HIP904Batch3'
       networkTag: ${{inputs.networkNodeTag}}
       mirrorTag: ${{inputs.mirrorNodeTag}}
       relayTag: ${{inputs.relayTag}}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -123,11 +123,23 @@ jobs:
     with:
       testfilter: HAS
 
-  HIP904:
-    name: HIP904 Contract Test Suite
+  HIP904-Batch-1:
+    name: HIP904 Contract Test Suite Batch 1
     uses: ./.github/workflows/test-workflow.yml
     with:
-      testfilter: HIP904
+      testfilter: HIP904-Batch-1
+
+  HIP904-Batch-2:
+    name: HIP904 Contract Test Suite Batch 2
+    uses: ./.github/workflows/test-workflow.yml
+    with:
+      testfilter: HIP904-Batch-2
+
+  HIP904-Batch-3:
+    name: HIP904 Contract Test Suite Batch 3
+    uses: ./.github/workflows/test-workflow.yml
+    with:
+      testfilter: HIP904-Batch-3
 
   WHBAR:
     name: WHBAR Contract Test Suite

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -168,7 +168,9 @@ jobs:
       - PrngSystemContract
       - BLSSignatureVerification
       - HederaAccountService
-      - HIP904
+      - HIP904Batch1
+      - HIP904Batch2
+      - HIP904Batch3
       - WHBAR
 
     runs-on: smart-contracts-linux-large

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -123,23 +123,23 @@ jobs:
     with:
       testfilter: HAS
 
-  HIP904-Batch-1:
+  HIP904Batch1:
     name: HIP904 Contract Test Suite Batch 1
     uses: ./.github/workflows/test-workflow.yml
     with:
-      testfilter: HIP904-Batch-1
+      testfilter: HIP904Batch1
 
-  HIP904-Batch-2:
+  HIP904Batch2:
     name: HIP904 Contract Test Suite Batch 2
     uses: ./.github/workflows/test-workflow.yml
     with:
-      testfilter: HIP904-Batch-2
+      testfilter: HIP904Batch2
 
-  HIP904-Batch-3:
+  HIP904Batch3:
     name: HIP904 Contract Test Suite Batch 3
     uses: ./.github/workflows/test-workflow.yml
     with:
-      testfilter: HIP904-Batch-3
+      testfilter: HIP904Batch3
 
   WHBAR:
     name: WHBAR Contract Test Suite

--- a/test/system-contracts/hedera-token-service/hrc-904/AirdropContract.js
+++ b/test/system-contracts/hedera-token-service/hrc-904/AirdropContract.js
@@ -5,7 +5,7 @@ const { ethers } = require('hardhat');
 const utils = require('../utils');
 const Constants = require('../../../constants');
 
-describe('HIP904 AirdropContract Test Suite', function () {
+describe('HIP904-Batch-1 AirdropContract Test Suite', function () {
   let airdropContract;
   let tokenCreateContract;
   let erc20Contract;

--- a/test/system-contracts/hedera-token-service/hrc-904/AirdropContract.js
+++ b/test/system-contracts/hedera-token-service/hrc-904/AirdropContract.js
@@ -5,7 +5,7 @@ const { ethers } = require('hardhat');
 const utils = require('../utils');
 const Constants = require('../../../constants');
 
-describe('HIP904-Batch-1 AirdropContract Test Suite', function () {
+describe('HIP904Batch1 AirdropContract Test Suite', function () {
   let airdropContract;
   let tokenCreateContract;
   let erc20Contract;

--- a/test/system-contracts/hedera-token-service/hrc-904/CancelAirdropContract.js
+++ b/test/system-contracts/hedera-token-service/hrc-904/CancelAirdropContract.js
@@ -5,7 +5,7 @@ const { ethers } = require('hardhat');
 const utils = require('../utils');
 const Constants = require('../../../constants');
 
-describe('HIP904-Batch-2 CancelAirdropContract Test Suite', function () {
+describe('HIP904Batch2 CancelAirdropContract Test Suite', function () {
   let airdropContract;
   let cancelAirdropContract;
   let tokenCreateContract;

--- a/test/system-contracts/hedera-token-service/hrc-904/CancelAirdropContract.js
+++ b/test/system-contracts/hedera-token-service/hrc-904/CancelAirdropContract.js
@@ -5,7 +5,7 @@ const { ethers } = require('hardhat');
 const utils = require('../utils');
 const Constants = require('../../../constants');
 
-describe('HIP904 CancelAirdropContract Test Suite', function () {
+describe('HIP904-Batch-2 CancelAirdropContract Test Suite', function () {
   let airdropContract;
   let cancelAirdropContract;
   let tokenCreateContract;

--- a/test/system-contracts/hedera-token-service/hrc-904/ClaimAirdropContract.js
+++ b/test/system-contracts/hedera-token-service/hrc-904/ClaimAirdropContract.js
@@ -5,7 +5,7 @@ const { ethers } = require('hardhat');
 const utils = require('../utils');
 const Constants = require('../../../constants');
 
-describe('HIP904-Batch-3 ClaimAirdropContract Test Suite', function () {
+describe('HIP904Batch3 ClaimAirdropContract Test Suite', function () {
   let airdropContract;
   let claimAirdropContract;
   let tokenCreateContract;

--- a/test/system-contracts/hedera-token-service/hrc-904/ClaimAirdropContract.js
+++ b/test/system-contracts/hedera-token-service/hrc-904/ClaimAirdropContract.js
@@ -5,7 +5,7 @@ const { ethers } = require('hardhat');
 const utils = require('../utils');
 const Constants = require('../../../constants');
 
-describe('HIP904 ClaimAirdropContract Test Suite', function () {
+describe('HIP904-Batch-3 ClaimAirdropContract Test Suite', function () {
   let airdropContract;
   let claimAirdropContract;
   let tokenCreateContract;

--- a/test/system-contracts/hedera-token-service/hrc-904/IHRC904ProxyTests.js
+++ b/test/system-contracts/hedera-token-service/hrc-904/IHRC904ProxyTests.js
@@ -6,7 +6,7 @@ const utils = require('../utils');
 const Constants = require('../../../constants');
 const { Contract } = require('ethers');
 
-describe('HIP904-Batch-2 IHRC904Facade ContractTest Suite', function () {
+describe('HIP904Batch2 IHRC904Facade Contract Test Suite', function () {
   let airdropContract;
   let tokenAddress;
   let nftTokenAddress;

--- a/test/system-contracts/hedera-token-service/hrc-904/IHRC904ProxyTests.js
+++ b/test/system-contracts/hedera-token-service/hrc-904/IHRC904ProxyTests.js
@@ -6,7 +6,7 @@ const utils = require('../utils');
 const Constants = require('../../../constants');
 const { Contract } = require('ethers');
 
-describe('HIP904 IHRC904Facade ContractTest Suite', function () {
+describe('HIP904-Batch-2 IHRC904Facade ContractTest Suite', function () {
   let airdropContract;
   let tokenAddress;
   let nftTokenAddress;

--- a/test/system-contracts/hedera-token-service/hrc-904/TokenRejectContract.js
+++ b/test/system-contracts/hedera-token-service/hrc-904/TokenRejectContract.js
@@ -5,7 +5,7 @@ const { ethers } = require('hardhat');
 const utils = require('../utils');
 const Constants = require('../../../constants');
 
-describe('HIP904 TokenRejectContract Test Suite', function () {
+describe('HIP904-Batch-3 TokenRejectContract Test Suite', function () {
   let tokenRejectContract;
   let tokenCreateContract;
   let airdropContract;

--- a/test/system-contracts/hedera-token-service/hrc-904/TokenRejectContract.js
+++ b/test/system-contracts/hedera-token-service/hrc-904/TokenRejectContract.js
@@ -5,7 +5,7 @@ const { ethers } = require('hardhat');
 const utils = require('../utils');
 const Constants = require('../../../constants');
 
-describe('HIP904-Batch-3 TokenRejectContract Test Suite', function () {
+describe('HIP904Batch3 TokenRejectContract Test Suite', function () {
   let tokenRejectContract;
   let tokenCreateContract;
   let airdropContract;


### PR DESCRIPTION
**Description**:
This PR splits HIP-904 tests into 3 batches in order to prevent flakiness (local node instance crashing due to high load) and reduce duration of job

**Related issue(s)**:

Fixes #1309 

