### PR TITLE
feat: use `amountSentLD` in `.transferToken` on `_debit` function in LayerZero HTSConnector

### DIFF
--- a/lib/layer-zero/HTSConnector.sol
+++ b/lib/layer-zero/HTSConnector.sol
@@ -88,7 +88,7 @@ abstract contract HTSConnector is OFTCore, KeyHelper, HederaTokenService {
 
         (amountSentLD, amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);
 
-        int256 transferResponse = HederaTokenService.transferToken(htsTokenAddress, _from, address(this), int64(uint64(_amountLD)));
+        int256 transferResponse = HederaTokenService.transferToken(htsTokenAddress, _from, address(this), int64(uint64(amountSentLD)));
         require(transferResponse == HederaTokenService.SUCCESS_CODE, "HTS: Transfer failed");
 
         (int256 response,) = HederaTokenService.burnToken(htsTokenAddress, int64(uint64(amountSentLD)), new int64[](0));

--- a/lib/layer-zero/HTSConnectorExistingToken.sol
+++ b/lib/layer-zero/HTSConnectorExistingToken.sol
@@ -60,7 +60,7 @@ abstract contract HTSConnectorExistingToken is OFTCore, KeyHelper, HederaTokenSe
     ) internal virtual override returns (uint256 amountSentLD, uint256 amountReceivedLD) {
         (amountSentLD, amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);
 
-        int256 transferResponse = HederaTokenService.transferToken(htsTokenAddress, _from, address(this), int64(uint64(_amountLD)));
+        int256 transferResponse = HederaTokenService.transferToken(htsTokenAddress, _from, address(this), int64(uint64(amountSentLD)));
         require(transferResponse == HederaTokenService.SUCCESS_CODE, "HTS: Transfer failed");
 
         (int256 response,) = HederaTokenService.burnToken(htsTokenAddress, int64(uint64(amountSentLD)), new int64[](0));


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

In the debit function, there is a call to the debitView function, which returns an `amountSentLD`, but in the transfer function, `_amountLD` is used.

**Related issue(s)**:

Fixes #1478 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
