### PR TITLE
chore: bump solo to 0.74.0 and remove consensus port-forward workaround

### DIFF
--- a/.github/falcon.yml
+++ b/.github/falcon.yml
@@ -2,16 +2,12 @@ network:
   --release-tag: "v0.72.0"
 setup:
   --release-tag: "v0.72.0"
-consensusNode:
-  --force-port-forward: true
 mirrorNode:
   --enable-ingress: true
   --pinger: true
   --mirror-node-version: "v0.151.0"
   --values-file: .github/mirror-node-values.yaml
-  --force-port-forward: true
 relayNode:
   --relay-release: "0.76.2"
   --node-aliases: "node1"
   --values-file: .github/relay-values.yaml
-  --force-port-forward: true

--- a/.github/workflows/erc-registry-test.yml
+++ b/.github/workflows/erc-registry-test.yml
@@ -60,10 +60,10 @@ jobs:
         id: solo_stack
         run: bash .github/workflows/support/scripts/setup-solo-stack.sh
         env:
-          SOLO_VERSION: "0.72.0"
+          SOLO_VERSION: "0.74.0"
         timeout-minutes: 15
 
-      - name: Solo kubectl port forwards (50211 / 8545)
+      - name: Forward mirror Web3 (8545) for indexer
         run: bash .github/workflows/support/scripts/solo-kubectl-port-forward.sh
         env:
           SOLO_NAMESPACE: ${{ steps.solo_stack.outputs.namespace }}
@@ -76,7 +76,7 @@ jobs:
       - name: One-shot Falcon destroy
         if: always()
         run: |
-          npx @hashgraph/solo@0.72.0 one-shot falcon destroy \
+          npx @hashgraph/solo@0.74.0 one-shot falcon destroy \
             --deployment "${{ steps.solo_stack.outputs.deployment_name }}" \
             --dev \
             --quiet-mode || true

--- a/.github/workflows/migration-testing.yml
+++ b/.github/workflows/migration-testing.yml
@@ -38,7 +38,7 @@ on:
       soloVersion:
         description: 'npm version for @hashgraph/solo (Falcon one-shot on Kind)'
         required: false
-        default: '0.72.0'
+        default: '0.74.0'
 
 jobs:
   check:
@@ -94,11 +94,6 @@ jobs:
           RELAY_TAG: ${{ inputs.initialRelayTag }}
           SOLO_VERSION: ${{ inputs.soloVersion }}
         timeout-minutes: 15
-
-      - name: Solo kubectl port forwards (50211 / 8545)
-        run: bash .github/workflows/support/scripts/solo-kubectl-port-forward.sh
-        env:
-          SOLO_NAMESPACE: ${{ steps.initial_solo.outputs.namespace }}
 
       - name: Run pre-migration tests
         run: npx hardhat test --grep ${{ inputs.preMigrationTestTags }}

--- a/.github/workflows/opcode-logger-testing.yml
+++ b/.github/workflows/opcode-logger-testing.yml
@@ -64,13 +64,8 @@ jobs:
         id: solo_stack
         run: bash .github/workflows/support/scripts/setup-solo-stack.sh
         env:
-          SOLO_VERSION: "0.72.0"
+          SOLO_VERSION: "0.74.0"
         timeout-minutes: 15
-
-      - name: Solo kubectl port forwards (50211 / 8545)
-        run: bash .github/workflows/support/scripts/solo-kubectl-port-forward.sh
-        env:
-          SOLO_NAMESPACE: ${{ steps.solo_stack.outputs.namespace }}
 
       - name: Run opcode tests against Hedera (Solo local network)
         run: npx hardhat test --grep @OpcodeLogger
@@ -78,7 +73,7 @@ jobs:
       - name: One-shot Falcon destroy
         if: always()
         run: |
-          npx @hashgraph/solo@0.72.0 one-shot falcon destroy \
+          npx @hashgraph/solo@0.74.0 one-shot falcon destroy \
             --deployment "${{ steps.solo_stack.outputs.deployment_name }}" \
             --dev \
             --quiet-mode || true

--- a/.github/workflows/support/scripts/setup-solo-stack.sh
+++ b/.github/workflows/support/scripts/setup-solo-stack.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 NETWORK_TAG="${NETWORK_TAG:-v0.72.0}"
 MIRROR_TAG="${MIRROR_TAG:-v0.151.0}"
 RELAY_TAG="${RELAY_TAG:-0.76.2}"
-SOLO_VERSION="${SOLO_VERSION:-0.72.0}"
+SOLO_VERSION="${SOLO_VERSION:-0.74.0}"
 
 mkdir -p .github
 
@@ -17,19 +17,16 @@ network:
 setup:
   --release-tag: "${NETWORK_TAG}"
 consensusNode:
-  --force-port-forward: true
   --node-aliases: "node1"
 mirrorNode:
   --enable-ingress: true
   --pinger: true
   --mirror-node-version: "${MIRROR_TAG}"
   --values-file: .github/mirror-node-values.yaml
-  --force-port-forward: true
 relayNode:
   --relay-release: "${RELAY_TAG}"
   --values-file: .github/relay-values.yaml
   --node-aliases: "node1"
-  --force-port-forward: true
 EOF
 
 NS_BASE="sc-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-1}-${GITHUB_JOB:-solo}"

--- a/.github/workflows/support/scripts/solo-kubectl-port-forward.sh
+++ b/.github/workflows/support/scripts/solo-kubectl-port-forward.sh
@@ -1,17 +1,15 @@
 #!/usr/bin/env bash
-# Starts background kubectl port-forward processes so localhost matches @hashgraph/sdk
-# local-node expectations (127.0.0.1:50211 → consensus via HAProxy) and mirror Web3
-# (127.0.0.1:8545 → svc/mirror-1-web3), consistent with hiero-sdk-js solo-lib.js.
+# Forwards the mirror node Web3 service to localhost:8545 for the ERC-registry
+# indexer (its MIRROR_NODE_URL_WEB3). Consensus gRPC (35211), JSON-RPC relay (37546)
+# and mirror REST ingress (38081) are exposed automatically by Solo's one-shot
+# falcon deploy (@hashgraph/solo >= 0.74.0 forwards them to the host by default),
+# so no manual port-forward is needed for those.
 #
 # Required environment:
 #   SOLO_NAMESPACE — Kubernetes namespace from Solo deploy (e.g. steps.*.outputs.namespace).
 set -euo pipefail
 
 NS="${SOLO_NAMESPACE:?SOLO_NAMESPACE is required}"
-
-kubectl get svc haproxy-node1-svc -n "${NS}"
-kubectl port-forward -n "${NS}" svc/haproxy-node1-svc 50211:50211 &
-echo "Forwarding svc/haproxy-node1-svc → localhost:50211 (consensus gRPC for local-node)"
 
 if kubectl get svc mirror-1-web3 -n "${NS}" &>/dev/null; then
   kubectl port-forward -n "${NS}" svc/mirror-1-web3 8545:80 &

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -82,13 +82,8 @@ jobs:
           NETWORK_TAG: ${{ inputs.networkTag || 'v0.72.0' }}
           MIRROR_TAG: ${{ inputs.mirrorTag || 'v0.151.0' }}
           RELAY_TAG: ${{ inputs.relayTag || '0.76.2' }}
-          SOLO_VERSION: ${{ inputs.soloVersion || '0.72.0' }}
+          SOLO_VERSION: ${{ inputs.soloVersion || '0.74.0' }}
         timeout-minutes: 15
-
-      - name: Solo kubectl port forwards (50211 / 8545)
-        run: bash .github/workflows/support/scripts/solo-kubectl-port-forward.sh
-        env:
-          SOLO_NAMESPACE: ${{ steps.solo_stack.outputs.namespace }}
 
       - name: Run the test in ${{ inputs.testfilter }}
         run: npx hardhat test --grep ${{ inputs.testfilter }}
@@ -112,7 +107,7 @@ jobs:
       - name: One-shot Falcon destroy
         if: always()
         run: |
-          npx @hashgraph/solo@${{ inputs.soloVersion || '0.72.0' }} one-shot falcon destroy \
+          npx @hashgraph/solo@${{ inputs.soloVersion || '0.74.0' }} one-shot falcon destroy \
             --deployment "${{ steps.solo_stack.outputs.deployment_name }}" \
             --dev \
             --quiet-mode || true

--- a/.github/workflows_documentation.md
+++ b/.github/workflows_documentation.md
@@ -20,7 +20,7 @@ Available workflow inputs are:
 - **targetRelayTag** - Specify the target Relay image tag
 - **preMigrationTestTags** - Specify the pre-migration test tags. Default: @pre-migration. It could be every tag we want (e.g. **@OZERC20**)
 - **postMigrationTestTags** - Specify the post-migration test tags. Default: @post-migration. It could be every tag we want (e.g. **@OZERC20**)
-- **soloVersion** - `@hashgraph/solo` npm version for Falcon one-shot (default `0.72.0`).
+- **soloVersion** - `@hashgraph/solo` npm version for Falcon one-shot (default `0.74.0`).
 
 Examples:
 

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "forge:coverage:html": "forge coverage --report lcov && genhtml lcov.info --branch-coverage --output-dir coverage",
     "hh:compile": "hardhat compile",
     "hh:test": "hardhat test",
-    "solo:deploy": "npx @hashgraph/solo@0.72.0 one-shot falcon deploy --values-file .github/falcon.yml --dev --deploy-explorer=false --external-address 0.0.0.0",
-    "solo:destroy": "npx @hashgraph/solo@0.72.0 one-shot falcon destroy",
+    "solo:deploy": "npx @hashgraph/solo@0.74.0 one-shot falcon deploy --values-file .github/falcon.yml --dev --deploy-explorer=false --external-address 0.0.0.0",
+    "solo:destroy": "npx @hashgraph/solo@0.74.0 one-shot falcon destroy",
     "prepare": "husky install",
     "besu:start": "docker run -d -v ./utils/besu-configs:/var/lib/besu/ -p 8540:8545 -p 8541:8546 hyperledger/besu:24.6.0 --config-file=/var/lib/besu/customConfigFile.toml"
   },

--- a/tools/erc-repository-indexer/erc-contract-indexer/README.md
+++ b/tools/erc-repository-indexer/erc-contract-indexer/README.md
@@ -33,7 +33,7 @@ The ERC Contract Indexer is a tool designed to facilitate the indexing and manag
    npm install
    ```
 
-3. **Optional — Solo on Kubernetes (`HEDERA_NETWORK=local-node`):** Run `scripts/solo-port-forward.sh` to forward **50211** (consensus → matches `@hashgraph/sdk` `local-node`) and **8545** (mirror Web3), aligned with CI `.github/workflows/support/scripts/solo-kubectl-port-forward.sh`. Mirror REST / gRPC / relay may need separate forwards or Solo’s `--force-port-forward` ports — see the script header.
+3. **Optional — Solo on Kubernetes (`HEDERA_NETWORK=local-node`):** The indexer only talks to the mirror node (REST + Web3). Solo's one-shot falcon deploy (`@hashgraph/solo` >= 0.74.0) exposes consensus, the JSON-RPC relay and the mirror REST ingress on the host by default; the mirror **Web3** service still needs a manual forward to **8545** (`MIRROR_NODE_URL_WEB3`), the same one CI sets up in `.github/workflows/support/scripts/solo-kubectl-port-forward.sh`. Run `scripts/solo-port-forward.sh` to establish it:
 
    ```bash
    export SOLO_NAMESPACE=your-solo-namespace


### PR DESCRIPTION
## What & why

Solo's one-shot `falcon deploy` previously did not forward the consensus gRPC port to the host by default, so the Hiero JS SDK timed out. The repo worked around this with `--force-port-forward` flags plus a manual `kubectl port-forward` of `50211`. Solo **0.74.0** fixes the port-forward logic so consensus gRPC (`35211`), JSON-RPC relay (`37546`) and mirror REST ingress (`38081`) are forwarded to the host **by default**, making the workaround unnecessary.

Closes #1683 

## Verification

Deployed Solo 0.74.0 locally and confirmed, with **neither** the `--force-port-forward` flags **nor** the manual `kubectl port-forward`:

- Consensus gRPC reachable on host `35211` (SDK `AccountBalanceQuery` succeeded)
- JSON-RPC relay reachable on `37546` (chainId 298)

The exposed consensus host port is unchanged (`35211` → pod `50211`), so `utils/constants.js` and the manual `createSDKClient` remain correct and are intentionally left as-is.

## Changes

- Bump `@hashgraph/solo` `0.72.0` → `0.74.0` (`package.json`, `setup-solo-stack.sh`, the test / erc-registry / opcode-logger / migration workflows, and docs)
- Drop the redundant `--force-port-forward: true` flags from `falcon.yml` and `setup-solo-stack.sh`
- Trim `solo-kubectl-port-forward.sh` to only the mirror Web3 (`8545`) forward still needed by the ERC-registry indexer; remove the dead consensus `50211` forward
- Remove the now-redundant port-forward CI step from the `test`, `opcode-logger` and `migration` workflows; keep it (renamed) only in `erc-registry-test.yml` where `8545` is used
- Update the indexer README and workflows documentation accordingly

## Notes

- `solo-migration-inplace-upgrade.sh` keeps its `--force-port-forward` flags on purpose — those re-establish forwards after the mid-workflow pod restart, a different subcommand context not covered by the one-shot default behavior.
- The pre-existing prettier debt in `.github/*.yml` (double vs single quotes) was left untouched to avoid unrelated churn.